### PR TITLE
Bump version to 2.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.11.6 (2026-04-23)
+
+## Added
+
+- Pilot sheet: mouseover tooltips (`data-tooltip`) for header combat stats, license level, grit, and Hull/Agility/Systems/Engineering trigger stats (localized in English).
+
 # 2.11.5 (2026-04-21)
 
 ## Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundryvtt-lancer",
-  "version": "2.11.5",
+  "version": "2.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundryvtt-lancer",
-      "version": "2.11.5",
+      "version": "2.11.6",
       "hasInstallScript": true,
       "dependencies": {
         "@massif/dustgrave-data": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.11.5",
+  "version": "2.11.6",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -159,6 +159,22 @@
       "abilities": {
         "skills": "SKILL TRIGGERS",
         "talents": "TALENTS"
+      },
+      "stat-tooltip": {
+        "hp": "Hit Points — damage you can take before being downed out of your mech.",
+        "overshield": "Overshield — temporary HP from effects; lost first when you take damage.",
+        "armor": "Armor — reduces incoming pilot-scale damage by this amount.",
+        "evasion": "Evasion — difficulty to hit you with attacks that target Evasion.",
+        "edef": "Electronic Defense — difficulty to hit you with tech attacks and electronic effects.",
+        "speed": "Speed — how many spaces you move per move action on foot.",
+        "save": "Save — bonus to your pilot saves.",
+        "sensor_range": "Sensor Range — how far you can reliably detect and target with pilot-scale sensors.",
+        "license_level": "License Level — highest license rank used to unlock mech gear and frames.",
+        "grit": "Grit — resource spent to fuel grit-powered abilities and rolls.",
+        "hull": "Hull — trigger for bracing, melee, lifting, and physical endurance checks.",
+        "agi": "Agility — trigger for dodging, initiative, acrobatics, and finesse checks.",
+        "sys": "Systems — trigger for hacking, tech skill, and systems-focused checks.",
+        "eng": "Engineering — trigger for repairs, jury-rigging, and technical problem-solving checks."
       }
     },
     "chat-card": {

--- a/public/templates/actor/pilot.hbs
+++ b/public/templates/actor/pilot.hbs
@@ -24,14 +24,14 @@
     </div>
     {{{ ref-portrait-img actor.img "img" actor }}}
     <div class="header-details pilot-stats flexrow">
-      {{{compact-stat-edit "mdi mdi-heart-outline" "system.hp.value" "system.hp.max" }}}
-      {{{compact-stat-edit "mdi mdi-shield-star-outline" "system.overshield.value" "" }}}
-      {{{compact-stat-view "mdi mdi-shield-outline" "system.armor" }}}
-      {{{compact-stat-view "cci cci-evasion" "system.evasion" }}}
-      {{{compact-stat-view "cci cci-edef" "system.edef" }}}
-      {{{compact-stat-view "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed" }}}
-      {{{compact-stat-view "cci cci-save" "system.save" }}}
-      {{{compact-stat-view "cci cci-sensor" "system.sensor_range" }}}
+      {{{compact-stat-edit "mdi mdi-heart-outline" "system.hp.value" "system.hp.max" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.hp")}}}
+      {{{compact-stat-edit "mdi mdi-shield-star-outline" "system.overshield.value" "" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.overshield")}}}
+      {{{compact-stat-view "mdi mdi-shield-outline" "system.armor" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.armor")}}}
+      {{{compact-stat-view "cci cci-evasion" "system.evasion" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.evasion")}}}
+      {{{compact-stat-view "cci cci-edef" "system.edef" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.edef")}}}
+      {{{compact-stat-view "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.speed")}}}
+      {{{compact-stat-view "cci cci-save" "system.save" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.save")}}}
+      {{{compact-stat-view "cci cci-sensor" "system.sensor_range" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.sensor_range")}}}
     </div>
   </header>
 
@@ -107,8 +107,8 @@
     <div class="tab pilot flexcol" data-group="primary" data-tab="narrative">
       <div class="card clipped">
         <div class="flexrow">
-          {{{clicker-stat-card "LICENSE LEVEL" "mdi mdi-shield-outline" "system.level" false }}}
-          {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit" }}}
+          {{{clicker-stat-card "LICENSE LEVEL" "mdi mdi-shield-outline" "system.level" false tooltip=(localize "lancer.pilot-sheet.stat-tooltip.license_level")}}}
+          {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.grit")}}}
         </div>
       </div>
 
@@ -263,10 +263,10 @@
       </div>
 
       <div class="flexrow">
-        {{{clicker-stat-card "HUL" "" "system.hull" true }}}
-        {{{clicker-stat-card "AGI" "" "system.agi" true }}}
-        {{{clicker-stat-card "SYS" "" "system.sys" true }}}
-        {{{clicker-stat-card "ENG" "" "system.eng" true }}}
+        {{{clicker-stat-card "HUL" "" "system.hull" true tooltip=(localize "lancer.pilot-sheet.stat-tooltip.hull")}}}
+        {{{clicker-stat-card "AGI" "" "system.agi" true tooltip=(localize "lancer.pilot-sheet.stat-tooltip.agi")}}}
+        {{{clicker-stat-card "SYS" "" "system.sys" true tooltip=(localize "lancer.pilot-sheet.stat-tooltip.sys")}}}
+        {{{clicker-stat-card "ENG" "" "system.eng" true tooltip=(localize "lancer.pilot-sheet.stat-tooltip.eng")}}}
       </div>
 
       {{!-- Talents --}}

--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -1,4 +1,4 @@
-import type { HelperOptions } from "handlebars";
+import Handlebars, { type HelperOptions } from "handlebars";
 import type { ActionType } from "../action";
 import { actionIcon } from "../action/action-tracker";
 import type { LancerActor, LancerMECH, LancerNPC, LancerPILOT } from "../actor/lancer-actor";
@@ -10,6 +10,13 @@ import { ref_params, simple_ref_slot } from "./refs";
 
 // ---------------------------------------
 // Some simple stat editing thingies
+
+/** Optional `tooltip` hash from Handlebars for `data-tooltip` on wrappers. */
+function hashTooltipAttr(options: HelperOptions): string {
+  const raw = options.hash?.tooltip;
+  if (raw == null || raw === "") return "";
+  return ` data-tooltip="${Handlebars.escapeExpression(String(raw))}"`;
+}
 
 interface ButtonOverrides {
   icon?: string;
@@ -120,7 +127,7 @@ export function stat_view_card(
     }
   }
   return `
-    <div class="stat-card card clipped">
+    <div class="stat-card card clipped"${hashTooltipAttr(options)}>
       <div class="lancer-header lancer-primary ">
         ${inc_if(`<i class="${icon} i--4 i--light header-icon"> </i>`, icon)}
         <span class="major">${title}</span>
@@ -143,7 +150,7 @@ export function stat_rollable_card(title: string, icon: string, data_path: strin
 export function compact_stat_view(icon: string, data_path: string, options: HelperOptions): string {
   let data_val = resolveHelperDotpath(options, data_path);
   return `
-    <div class="compact-stat">
+    <div class="compact-stat"${hashTooltipAttr(options)}>
         <i class="${icon} i--4 i--dark"></i>
         <span class="lancer-stat minor">${data_val}</span>
     </div>
@@ -160,7 +167,7 @@ export function compact_stat_edit(icon: string, data_path: string, max_path: str
     <span class="lancer-stat minor">${max_val}</span>`;
   }
   return `
-        <div class="compact-stat">
+        <div class="compact-stat"${hashTooltipAttr(options)}>
           <i class="${icon} i--4 i--dark"></i>
           ${std_num_input(data_path, extendHelper(options, { classes: "lancer-stat minor" }))}
           ${max_html}
@@ -194,7 +201,7 @@ export function clicker_stat_card(
       attackButton = _basicFlowButton(uuid, "BasicAttack", { icon: "cci cci-weapon" });
     }
   }
-  return `<div class="card clipped stat-container">
+  return `<div class="card clipped stat-container"${hashTooltipAttr(options)}>
       <div class="lancer-header lancer-primary ">
         <i class="${icon} i--4 i--light header-icon"> </i>
         <span class="major">${title}</span>

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.11.5",
+  "version": "2.11.6",
   "compatibility": { "minimum": 13, "verified": 14, "maximum": 14 },
   "authors": [
     { "name": "Eranziel" },
@@ -76,7 +76,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.11.5/lancer-v2.11.5.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.11.6/lancer-v2.11.6.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
Add mouseover tooltips for header combat stats, license level, grit, and various trigger stats in the pilot sheet. Update CHANGELOG.md to reflect new features and adjust versioning in package.json, package-lock.json, and system.json.