### PR TITLE
Revert release to 2.12.0 and tidy CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-# 2.13.0 (2026-05-03)
+# 2.12.0 (2026-05-03)
 
 ## Changed
 
+- Migrated remaining App Framework V1 utility applications to ApplicationV2 patterns, including COMP/CON login, HTML editor, targeted edit forms, inventory dialog, action manager HUD, and shared Svelte host plumbing.
+- Updated legacy form/dialog templates to AppV2 form hosting expectations (outer form supplied by app, submit wiring through AppV2 handlers).
+- Added AppV2 migration guardrails and audit notes, including runtime warnings for any classes still extending V1 application bases during QA.
 - `npm run build` mirrors `dist/` into `**F:/FoundryVTT/Data/systems/lancer**` by default; set `SKIP_FOUNDRY_DIST_MIRROR=1` to skip, or `FOUNDRY_SYSTEM_DIR` / `MIRROR_DIST_TO_FOUNDRY_DATA=1` to use another destination (see README).
 - Migrated all Lancer actor and item document sheets to Foundry Application Framework V2 (`ActorSheetV2`, `ItemSheetV2` / `DocumentSheetV2` with `HandlebarsApplicationMixin`), including `static PARTS`, `static TABS`, `_prepareContext`, and form `handler` submission instead of V1 `getData` / `_updateObject`.
 - Sheet registration now unregisters core V2 default sheets (with optional cleanup of legacy V1 registrations when still present).
@@ -9,6 +12,7 @@
 
 ## Fixed
 
+- Improved rerender resilience for migrated app interactions by moving away from V1 `getData`/`_updateObject` lifecycles and onto AppV2 context and handler flows.
 - Actor and item sheet overflow sizing no longer depends on `:has(...)`; host + `section.lancer-sheet` flex rules now apply consistently in Foundry/Electron so vertical scrollbars appear when content exceeds window height.
 - Mech header name input is larger by default and now allows full-name display with wrap-safe sizing instead of forced ellipsis truncation.
 - Actor sheets (`section.lancer-sheet`) use a **column flex** layout so `section.sheet-body.scroll-body` gets a bounded height and shows a **vertical scrollbar** when tab content (e.g. pilot tactical talents) overflows the window.
@@ -24,18 +28,6 @@
 - Actor and item sheets call `**super.activateListeners(html)`** for Foundry core `data-action` handling, while Lancer-specific listeners (tabs, rolls, flows, editors, drag-drop) delegate from `**this.element`** so clicks still reach handlers under Application V2.
 - Actor sheet flex and scroll rules also apply when the sheet `**form` / `application` host is a direct child of `.window-content`** (typical Foundry 14 layout), so tab bodies scroll instead of clipping.
 - After each render, actor and item sheets call `**changeTab`** with the group’s configured **initial** tab when no `.tab.active` panel exists for that group, avoiding a blank tab body when tab state desyncs.
-
-# 2.12.0 (2026-05-03)
-
-## Changed
-
-- Migrated remaining App Framework V1 utility applications to ApplicationV2 patterns, including COMP/CON login, HTML editor, targeted edit forms, inventory dialog, action manager HUD, and shared Svelte host plumbing.
-- Updated legacy form/dialog templates to AppV2 form hosting expectations (outer form supplied by app, submit wiring through AppV2 handlers).
-- Added AppV2 migration guardrails and audit notes, including runtime warnings for any classes still extending V1 application bases during QA.
-
-## Fixed
-
-- Improved rerender resilience for migrated app interactions by moving away from V1 `getData`/`_updateObject` lifecycles and onto AppV2 context and handler flows.
 
 ## Action Needed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.13.0",
+  "version": "2.12.0",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.13.0",
+  "version": "2.12.0",
   "compatibility": {
     "minimum": 13,
     "verified": 14,


### PR DESCRIPTION
Set package and system versions back to 2.12.0 (package.json, src/system.json) and update CHANGELOG.md to match: change the top heading to 2.12.0, move the AppV2 migration notes into the main release section, and remove the duplicated 2.12.0 block. This consolidates release notes and keeps version metadata consistent.