### PR TITLE
chore: block pushes to Eranziel/foundryvtt-lancer upstream

### DIFF
--- a/.github/workflows/verify-git-remote.yml
+++ b/.github/workflows/verify-git-remote.yml
@@ -1,0 +1,25 @@
+name: Verify git remote (fork-only)
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  assert-safe-remote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Block Eranziel upstream remote URLs
+        run: REQUIRE_ALLOWED_ORIGIN=1 sh ./scripts/assert-safe-git-remote.sh
+
+      - name: Fail if workflow targets Eranziel for deploy
+        run: |
+          for f in .github/workflows/*.yml; do
+            case "$(basename "$f")" in verify-git-remote.yml) continue ;; esac
+            if grep -qE 'github\.com[:/]Eranziel/foundryvtt-lancer' "$f"; then
+              echo "Workflow must not target Eranziel/foundryvtt-lancer: $f"
+              exit 1
+            fi
+          done

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+sh "$(dirname "$0")/../scripts/assert-safe-git-remote.sh" "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,17 @@
 # AGENTS.md
 
+## Git / fork policy (required)
+
+This repository is **`VacantFanatic/foundryvtt-lancer`**. **Never push** to **`Eranziel/foundryvtt-lancer`** (any branch, including `master`).
+
+- **`origin`** must stay `https://github.com/VacantFanatic/foundryvtt-lancer` (or SSH equivalent).
+- Do **not** add an `upstream` remote pointing at Eranziel, and do not `git push` a URL under `github.com/Eranziel/foundryvtt-lancer`.
+- Cloud agents: use feature branches `cursor/<name>-f727` and open PRs against **`VacantFanatic`** `master` only.
+- **Pre-push hook** (`scripts/assert-safe-git-remote.sh`) and CI workflow **Verify git remote** block Eranziel remotes and accidental push targets.
+- Manual check: `REQUIRE_ALLOWED_ORIGIN=1 sh ./scripts/assert-safe-git-remote.sh`
+
+Reading Eranziel’s wiki or citing upstream authors in docs is fine; **git writes** stay on this fork only.
+
 ## Cursor Cloud specific instructions
 
 ### What this repo is

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "link": "./scripts/symlink.mjs",
     "postinstall": "./scripts/symlink.mjs",
     "prepare": "husky install",
+    "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "serve": "vite",
     "version": "./scripts/version.mjs && git add src/system.json",
     "watch": "vite build --watch"

--- a/scripts/assert-safe-git-remote.sh
+++ b/scripts/assert-safe-git-remote.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+# Blocks git remotes / push URLs that target the upstream Eranziel fork.
+# Used by .husky/pre-push and CI.
+
+set -eu
+
+FORBIDDEN_PATTERN='github\.com[:/]Eranziel/foundryvtt-lancer'
+ALLOWED_OWNER="${ALLOWED_GIT_OWNER:-VacantFanatic}"
+ALLOWED_REPO="${ALLOWED_GIT_REPO:-foundryvtt-lancer}"
+ALLOWED_PATTERN="github\\.com[:/]${ALLOWED_OWNER}/${ALLOWED_REPO}"
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+check_url() {
+  url="$1"
+  context="$2"
+  case "$url" in
+    ""|*"[REDACTED]"*) return 0 ;;
+  esac
+  if printf '%s' "$url" | grep -qiE "$FORBIDDEN_PATTERN"; then
+    fail "Refusing ${context}: ${url} points at Eranziel/foundryvtt-lancer. Push only to ${ALLOWED_OWNER}/${ALLOWED_REPO}."
+  fi
+}
+
+# Optional: require origin to match this fork when ORIGIN must be set (CI).
+if [ "${REQUIRE_ALLOWED_ORIGIN:-0}" = "1" ]; then
+  origin_url="$(git remote get-url origin 2>/dev/null || true)"
+  if [ -z "$origin_url" ]; then
+    fail "No git remote 'origin' configured."
+  fi
+  if ! printf '%s' "$origin_url" | grep -qiE "$ALLOWED_PATTERN"; then
+    fail "origin must be ${ALLOWED_OWNER}/${ALLOWED_REPO}, got: ${origin_url}"
+  fi
+fi
+
+for remote in $(git remote); do
+  url="$(git remote get-url "$remote" 2>/dev/null || true)"
+  check_url "$url" "remote ${remote}"
+  pushurl="$(git config --get "remote.${remote}.pushurl" 2>/dev/null || true)"
+  check_url "$pushurl" "remote.${remote}.pushurl"
+done
+
+# push.default URL if set
+default_push="$(git config --get remote.pushurl 2>/dev/null || true)"
+check_url "$default_push" "remote.pushurl"
+
+# pre-push hook passes: remote_name remote_url
+for arg in "$@"; do
+  check_url "$arg" "push target"
+done
+
+exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ensures all git activity stays on **VacantFanatic/foundryvtt-lancer** and never targets **Eranziel/foundryvtt-lancer** (including `master`).

### Changes
- **`scripts/assert-safe-git-remote.sh`** — rejects any remote or push URL containing `github.com/Eranziel/foundryvtt-lancer`; optional `REQUIRE_ALLOWED_ORIGIN=1` enforces `VacantFanatic/foundryvtt-lancer` as `origin`
- **`.husky/pre-push`** — runs the script on every push (including direct URL pushes via hook args)
- **`.github/workflows/verify-git-remote.yml`** — CI check on PRs/pushes
- **`AGENTS.md`** — fork-only policy for humans and cloud agents
- **`npm run verify:git-remote`** — manual check

### Current remote state
`origin` is already `VacantFanatic/foundryvtt-lancer` only; no Eranziel remote is configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

