### PR TITLE
chore: use VacantFanatic fork for all repo links and block Eranziel pushes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,4 +35,4 @@ Add any other context about the problem here.
 
 **Discord contact info**
 If you are willing to answer questions regarding this bug report on Discord, or if you want to be notified when it is fixed, please leave your Discord ID here.
-e.g. Eranziel#1234
+e.g. VacantFanatic#1234

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,4 +20,4 @@ Add any other context or screenshots about the feature request here.
 
 **Discord contact info**
 If you are willing to answer questions regarding this feature request on Discord, or if you want to be notified when it is fixed, please leave your Discord ID here.
-e.g. Eranziel#1234
+e.g. VacantFanatic#1234

--- a/.github/workflows/verify-git-remote.yml
+++ b/.github/workflows/verify-git-remote.yml
@@ -1,0 +1,25 @@
+name: Verify git remote (fork-only)
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  assert-safe-remote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Block Eranziel upstream remote URLs
+        run: REQUIRE_ALLOWED_ORIGIN=1 sh ./scripts/assert-safe-git-remote.sh
+
+      - name: Fail if workflow targets Eranziel for deploy
+        run: |
+          for f in .github/workflows/*.yml; do
+            case "$(basename "$f")" in verify-git-remote.yml) continue ;; esac
+            if grep -qE 'github\.com[:/]Eranziel/foundryvtt-lancer' "$f"; then
+              echo "Workflow must not target Eranziel/foundryvtt-lancer: $f"
+              exit 1
+            fi
+          done

--- a/.github/workflows/verify-git-remote.yml
+++ b/.github/workflows/verify-git-remote.yml
@@ -23,3 +23,10 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Fail if tracked sources link to Eranziel repo
+        run: |
+          if grep -rE 'github\.com/Eranziel/foundryvtt-lancer' README.md docs src public .github/ISSUE_TEMPLATE AGENTS.md 2>/dev/null; then
+            echo "Tracked docs and UI must use VacantFanatic/foundryvtt-lancer URLs."
+            exit 1
+          fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+sh "$(dirname "$0")/../scripts/assert-safe-git-remote.sh" "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This repository is **`VacantFanatic/foundryvtt-lancer`**. **Never push** to **`E
 - **Pre-push hook** (`scripts/assert-safe-git-remote.sh`) and CI workflow **Verify git remote** block Eranziel remotes and accidental push targets.
 - Manual check: `REQUIRE_ALLOWED_ORIGIN=1 sh ./scripts/assert-safe-git-remote.sh`
 
-Reading Eranziel’s wiki or citing upstream authors in docs is fine; **git writes** stay on this fork only.
+Docs, wiki links, and in-app URLs must use **`VacantFanatic/foundryvtt-lancer`**. Author credits in `system.json` (e.g. Eranziel) are attribution only, not repo links.
 
 ## Cursor Cloud specific instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Handled by the VM update script: `CI=1 npm ci` from repo root (skips `postinstal
 ### Build
 
 - **Production build (CI / headless):** `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build` — writes only to `dist/` (avoids mirroring to a Windows default path).
-- **Local with Foundry data dir:** set `FOUNDRY_SYSTEM_DIR` or `MIRROR_DIST_TO_FOUNDRY_DATA=1` with `fvttrc.yml` `dataPath`, or use `npm run link` after configuring `@foundryvtt/foundryvtt-cli` (see [Development Setup wiki](https://github.com/Eranziel/foundryvtt-lancer/wiki/Development-Setup)).
+- **Local with Foundry data dir:** set `FOUNDRY_SYSTEM_DIR` or `MIRROR_DIST_TO_FOUNDRY_DATA=1` with `fvttrc.yml` `dataPath`, or use `npm run link` after configuring `@foundryvtt/foundryvtt-cli` (see [Development Setup wiki](https://github.com/VacantFanatic/foundryvtt-lancer/wiki/Development-Setup)).
 - **Watch:** `npm run watch` or `npm run build:watch`.
 
 ### Lint / format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,17 @@
 # AGENTS.md
 
+## Git / fork policy (required)
+
+This repository is **`VacantFanatic/foundryvtt-lancer`**. **Never push** to **`Eranziel/foundryvtt-lancer`** (any branch, including `master`).
+
+- **`origin`** must stay `https://github.com/VacantFanatic/foundryvtt-lancer` (or SSH equivalent).
+- Do **not** add an `upstream` remote pointing at Eranziel, and do not `git push` a URL under `github.com/Eranziel/foundryvtt-lancer`.
+- Cloud agents: use feature branches `cursor/<name>-f727` and open PRs against **`VacantFanatic`** `master` only.
+- **Pre-push hook** (`scripts/assert-safe-git-remote.sh`) and CI workflow **Verify git remote** block Eranziel remotes and accidental push targets.
+- Manual check: `REQUIRE_ALLOWED_ORIGIN=1 sh ./scripts/assert-safe-git-remote.sh`
+
+Reading Eranziel’s wiki or citing upstream authors in docs is fine; **git writes** stay on this fork only.
+
 ## Cursor Cloud specific instructions
 
 ### What this repo is

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Additionally, a huge thank you and shout out to Animu36, Staubz, and Grygon for 
 
 ## Setup and FAQ
 
-Please see [our wiki](https://github.com/Eranziel/foundryvtt-lancer/wiki) for guides and commonly asked questions.
+Please see [our wiki](https://github.com/VacantFanatic/foundryvtt-lancer/wiki) for guides and commonly asked questions.
 
 ## System Installation
 
@@ -25,7 +25,7 @@ Simply search for Lancer in the Foundry system browser and install from there.
 
 ## Developer Resources
 
-[Setting up a development environment](https://github.com/Eranziel/foundryvtt-lancer/wiki/Development-Setup)
+[Setting up a development environment](https://github.com/VacantFanatic/foundryvtt-lancer/wiki/Development-Setup)
 
 How to use [Flows](docs/flow_api.md) to modify Lancer system automation.
 

--- a/docs/macro_guide.md
+++ b/docs/macro_guide.md
@@ -11,7 +11,7 @@ these steps.
 
 ### 1. Set up a development environment
 
-[Development Setup Wiki Page](https://github.com/Eranziel/foundryvtt-lancer/wiki/Development-Setup)
+[Development Setup Wiki Page](https://github.com/VacantFanatic/foundryvtt-lancer/wiki/Development-Setup)
 
 This is necessary to import and export the macro from the compendium.
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "link": "./scripts/symlink.mjs",
     "postinstall": "./scripts/symlink.mjs",
     "prepare": "husky install",
+    "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "serve": "vite",
     "version": "./scripts/version.mjs && git add src/system.json",
     "watch": "vite build --watch"

--- a/public/templates/window/lancerHelp.hbs
+++ b/public/templates/window/lancerHelp.hbs
@@ -25,15 +25,15 @@
   <ul>
     <li>
       <i class="fas fa-question"></i>
-      <a href="https://github.com/Eranziel/foundryvtt-lancer/wiki/FAQ">FAQ</a>
+      <a href="https://github.com/VacantFanatic/foundryvtt-lancer/wiki/FAQ">FAQ</a>
     </li>
     <li>
       <i class="fas fa-cube"></i>
-      <a href="https://github.com/Eranziel/foundryvtt-lancer/wiki/Recommended-Modules">Suggested Modules</a>
+      <a href="https://github.com/VacantFanatic/foundryvtt-lancer/wiki/Recommended-Modules">Suggested Modules</a>
     </li>
     <li>
       <i class="fas fa-bug"></i>
-      <a href="https://github.com/Eranziel/foundryvtt-lancer/issues">
+      <a href="https://github.com/VacantFanatic/foundryvtt-lancer/issues">
         Bug reports and enhancement suggestions</a>
     </li>
     <li>

--- a/scripts/assert-safe-git-remote.sh
+++ b/scripts/assert-safe-git-remote.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+# Blocks git remotes / push URLs that target the upstream Eranziel fork.
+# Used by .husky/pre-push and CI.
+
+set -eu
+
+FORBIDDEN_PATTERN='github\.com[:/]Eranziel/foundryvtt-lancer'
+ALLOWED_OWNER="${ALLOWED_GIT_OWNER:-VacantFanatic}"
+ALLOWED_REPO="${ALLOWED_GIT_REPO:-foundryvtt-lancer}"
+ALLOWED_PATTERN="github\\.com[:/]${ALLOWED_OWNER}/${ALLOWED_REPO}"
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+check_url() {
+  url="$1"
+  context="$2"
+  case "$url" in
+    ""|*"[REDACTED]"*) return 0 ;;
+  esac
+  if printf '%s' "$url" | grep -qiE "$FORBIDDEN_PATTERN"; then
+    fail "Refusing ${context}: ${url} points at Eranziel/foundryvtt-lancer. Push only to ${ALLOWED_OWNER}/${ALLOWED_REPO}."
+  fi
+}
+
+# Optional: require origin to match this fork when ORIGIN must be set (CI).
+if [ "${REQUIRE_ALLOWED_ORIGIN:-0}" = "1" ]; then
+  origin_url="$(git remote get-url origin 2>/dev/null || true)"
+  if [ -z "$origin_url" ]; then
+    fail "No git remote 'origin' configured."
+  fi
+  if ! printf '%s' "$origin_url" | grep -qiE "$ALLOWED_PATTERN"; then
+    fail "origin must be ${ALLOWED_OWNER}/${ALLOWED_REPO}, got: ${origin_url}"
+  fi
+fi
+
+for remote in $(git remote); do
+  url="$(git remote get-url "$remote" 2>/dev/null || true)"
+  check_url "$url" "remote ${remote}"
+  pushurl="$(git config --get "remote.${remote}.pushurl" 2>/dev/null || true)"
+  check_url "$pushurl" "remote.${remote}.pushurl"
+done
+
+# push.default URL if set
+default_push="$(git config --get remote.pushurl 2>/dev/null || true)"
+check_url "$default_push" "remote.pushurl"
+
+# pre-push hook passes: remote_name remote_url
+for arg in "$@"; do
+  check_url "$arg" "push target"
+done
+
+exit 0

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -20,11 +20,11 @@ export function WELCOME(): string {
     </a>
   </div>
 
-  <p><a href="https://github.com/Eranziel/foundryvtt-lancer/blob/master/CHANGELOG.md">CHANGELOG</a></p>
+  <p><a href="https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/CHANGELOG.md">CHANGELOG</a></p>
 
   <p>Check out the project wiki for
-  <a href="https://github.com/Eranziel/foundryvtt-lancer/wiki/FAQ">FAQ</a>,
-  <a href="https://github.com/Eranziel/foundryvtt-lancer/wiki/Resources">recommended modules</a>,
+  <a href="https://github.com/VacantFanatic/foundryvtt-lancer/wiki/FAQ">FAQ</a>,
+  <a href="https://github.com/VacantFanatic/foundryvtt-lancer/wiki/Resources">recommended modules</a>,
   and other information about how to use the system.</p>
 
   <p>@UUID[Compendium.lancer.lancer_info.JournalEntry.JDfVPzoWPOLyhCCa.JournalEntryPage.LVsmG9EfKH9VpVJX]{Legal & Acknowlegements}</p>

--- a/src/packs/lancer_info/LANCER_System_Information_JDfVPzoWPOLyhCCa.yml
+++ b/src/packs/lancer_info/LANCER_System_Information_JDfVPzoWPOLyhCCa.yml
@@ -38,7 +38,7 @@ pages:
 
         </p><p>For more information on what has changed recently, read the other
         pages in this journal and <a
-        href="https://github.com/Eranziel/foundryvtt-lancer/blob/master/CHANGELOG.md">check
+        href="https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/CHANGELOG.md">check
         the changelog</a>.</p>
 
         <h2>Migration Troubleshooting</h2>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Points all documentation, in-app help, and compendium links at **VacantFanatic/foundryvtt-lancer** instead of Eranziel/foundryvtt-lancer. Includes the git push safeguards from #32.

### URL updates
- `README.md`, `docs/macro_guide.md`, `AGENTS.md`
- `src/module/config.ts` (in-game help HTML)
- `public/templates/window/lancerHelp.hbs`
- `src/packs/lancer_info/LANCER_System_Information_JDfVPzoWPOLyhCCa.yml`
- Issue templates (Discord example username)

### Safeguards (merged from #32)
- Pre-push hook + `scripts/assert-safe-git-remote.sh`
- CI workflow blocks Eranziel remotes and Eranziel URLs in tracked docs/UI sources
- `npm run verify:git-remote`

### Unchanged (attribution only)
- `system.json` author list still credits Eranziel and other original maintainers
- `src/lancer.ts` file header author comment

Supersedes #32 — merge this PR instead to get both link fixes and push guards in one change.

After merge: run `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build` to refresh `dist/` with updated help links.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

