### PR TITLE
fix: remove debug console noise (v2.12.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.12.7 (2026-06-05)
+
+## Fixed
+
+- Removed temporary agent debug instrumentation that spammed the browser console (`console.warn`, failed `127.0.0.1:7777` ingest requests) on every actor sheet render.
+- Removed stray debug `console.log` calls from the accuracy/diff HUD, action tracker, and actor sheet data prep.
+
 # 2.12.6 (2026-05-09)
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.12.6",
+  "version": "2.12.7",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -385,54 +385,6 @@ Hooks.once("setup", () => {
 /* ------------------------------------ */
 // Make an awaitable for when this shit is done
 Hooks.once("ready", async function () {
-  const debugCssLog = (hypothesisId: string, message: string, data: Record<string, unknown>) => {
-    // Paste-friendly single line when ingest (127.0.0.1) is unreachable from the Foundry browser host.
-    console.warn(`${lp} [04ebbd:${hypothesisId}] ${message} ${JSON.stringify(data)}`);
-    // #region agent log
-    fetch("http://127.0.0.1:7777/ingest/8de7fe5e-b66f-46b3-834a-869605e8207d", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "04ebbd" },
-      body: JSON.stringify({
-        sessionId: "04ebbd",
-        runId: "post-fix-1",
-        hypothesisId,
-        location: "src/lancer.ts:ready-hooks",
-        message,
-        data,
-        timestamp: Date.now(),
-      }),
-    }).catch(err => {
-      console.warn(`${lp} debug log send failed`, err);
-    });
-    // #endregion
-  };
-  // #region agent log
-  window.addEventListener("error", ev => {
-    const msg = String(ev.message ?? "");
-    if (!msg.includes("unrecognized expression")) return;
-    const h11Data = {
-      errorMessage: msg,
-      filename: ev.filename ?? null,
-      lineno: ev.lineno ?? null,
-      colno: ev.colno ?? null,
-      stack: (ev.error as { stack?: string } | undefined)?.stack ?? null,
-    };
-    console.warn(`${lp} [04ebbd:H11_selector-stack] Captured selector parse runtime error ${JSON.stringify(h11Data)}`);
-    fetch("http://127.0.0.1:7777/ingest/8de7fe5e-b66f-46b3-834a-869605e8207d", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "04ebbd" },
-      body: JSON.stringify({
-        sessionId: "04ebbd",
-        runId: "post-fix-1",
-        hypothesisId: "H11_selector-stack",
-        location: "src/lancer.ts:window-error",
-        message: "Captured selector parse runtime error",
-        data: h11Data,
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-  });
-  // #endregion
   // Register sheet application classes
   setupSheets();
 
@@ -455,88 +407,6 @@ Hooks.once("ready", async function () {
   await registerAutoAnimationsHooks();
   await applyLancerAutorecMenuIfConfigured();
 
-  Hooks.on("renderActorSheet", (app: unknown, html: HTMLElement) => {
-    const sheetRoot = html as HTMLElement;
-    const appAny = app as { actor?: { type?: string; uuid?: string }; constructor?: { name?: string } };
-    const windowContent = sheetRoot.querySelector(".window-content") as HTMLElement | null;
-    const lancerSheet = sheetRoot.querySelector("section.lancer-sheet") as HTMLElement | null;
-    const scrollBody = sheetRoot.querySelector(".sheet-body.scroll-body") as HTMLElement | null;
-    const firstControl = sheetRoot.querySelector("input, select, textarea") as HTMLElement | null;
-    const rootStyle = getComputedStyle(document.documentElement);
-    const bodyStyle = getComputedStyle(document.body);
-    const rootFontPx = Number.parseFloat(rootStyle.fontSize || "0");
-    const bodyFontPx = Number.parseFloat(bodyStyle.fontSize || "0");
-    const scrollStyle = scrollBody ? getComputedStyle(scrollBody) : null;
-    const controlStyle = firstControl ? getComputedStyle(firstControl) : null;
-    const scaleAncestor =
-      (sheetRoot.closest("[style*='transform']") as HTMLElement | null) ??
-      (sheetRoot.parentElement?.closest("[style*='transform']") as HTMLElement | null);
-
-    debugCssLog("H1_font-scale", "Actor sheet render baseline", {
-      actorType: appAny.actor?.type ?? null,
-      actorUuid: appAny.actor?.uuid ?? null,
-      appName: appAny.constructor?.name ?? null,
-      rootFontPx,
-      bodyFontPx,
-      viewport: { width: window.innerWidth, height: window.innerHeight, dpr: window.devicePixelRatio },
-      sheetRootClass: sheetRoot.className,
-    });
-
-    debugCssLog("H2_scroll-overflow", "Actor sheet scroll container metrics", {
-      hasWindowContent: Boolean(windowContent),
-      hasLancerSheet: Boolean(lancerSheet),
-      hasScrollBody: Boolean(scrollBody),
-      sheet: {
-        clientHeight: sheetRoot.clientHeight,
-        scrollHeight: sheetRoot.scrollHeight,
-        overflowY: getComputedStyle(sheetRoot).overflowY,
-      },
-      windowContent: windowContent
-        ? {
-            clientHeight: windowContent.clientHeight,
-            scrollHeight: windowContent.scrollHeight,
-            overflowY: getComputedStyle(windowContent).overflowY,
-            minHeight: getComputedStyle(windowContent).minHeight,
-          }
-        : null,
-      scrollBody: scrollBody
-        ? {
-            clientHeight: scrollBody.clientHeight,
-            scrollHeight: scrollBody.scrollHeight,
-            overflowY: scrollStyle?.overflowY ?? null,
-            scrollbarGutter: scrollStyle?.scrollbarGutter ?? null,
-            minHeight: scrollStyle?.minHeight ?? null,
-          }
-        : null,
-    });
-
-    debugCssLog("H3_control-size", "Actor sheet first control computed style", {
-      controlTag: firstControl?.tagName ?? null,
-      controlClass: firstControl?.className ?? null,
-      controlRect: firstControl?.getBoundingClientRect() ?? null,
-      controlFontSize: controlStyle?.fontSize ?? null,
-      controlLineHeight: controlStyle?.lineHeight ?? null,
-      controlPadding: controlStyle?.padding ?? null,
-      controlBoxSizing: controlStyle?.boxSizing ?? null,
-      transformAncestor: scaleAncestor
-        ? {
-            className: scaleAncestor.className,
-            transform: getComputedStyle(scaleAncestor).transform,
-          }
-        : null,
-    });
-
-    sheetRoot.addEventListener(
-      "click",
-      ev => {
-        const target = ev.target as HTMLElement | null;
-        const match = target?.closest(".roll-stat, .roll-attack, .roll-tech, .roll-damage, .lancer-flow-button");
-        if (!match) return;
-      },
-      { capture: true }
-    );
-  });
-
   Hooks.on("updateCompendium", async collection => {
     if (collection?.metadata?.id == get_pack_id(EntryType.STATUS)) {
       await LancerActiveEffect.updateIcons();
@@ -549,38 +419,6 @@ Hooks.once("ready", async function () {
   Hooks.on("createItem", _updateIcons);
   Hooks.on("deleteItem", _updateIcons);
   Hooks.on("updateItem", _updateIcons);
-  Hooks.on("createChatMessage", (msg: unknown) => {
-    void msg;
-  });
-
-  Hooks.on("renderApplication", (app: unknown, _html: unknown) => {
-    const ctor = (app as { constructor?: { name?: string } })?.constructor?.name ?? "";
-    if (!ctor.toLowerCase().includes("sheet")) return;
-    debugCssLog("H4_sheet-host", "Sheet host renderApplication fired", {
-      ctor,
-      appId: (app as { id?: string })?.id ?? null,
-    });
-  });
-
-  Hooks.on("renderActorDirectory", (_app: unknown, html: HTMLElement) => {
-    const root = html as HTMLElement;
-    const list = root.querySelector("ol.directory-list") as HTMLOListElement | null;
-    const firstItem = list?.querySelector("li") as HTMLLIElement | null;
-    const rootStyle = getComputedStyle(root);
-    const firstStyle = firstItem ? getComputedStyle(firstItem) : null;
-    debugCssLog("H12_sidebar-dimensions", "Actor directory metrics", {
-      rootRect: root.getBoundingClientRect(),
-      rootDisplay: rootStyle.display,
-      rootOverflow: rootStyle.overflow,
-      rootFontSize: rootStyle.fontSize,
-      listRect: list?.getBoundingClientRect() ?? null,
-      firstItemRect: firstItem?.getBoundingClientRect() ?? null,
-      firstItemDisplay: firstStyle?.display ?? null,
-      firstItemPosition: firstStyle?.position ?? null,
-      firstItemFontSize: firstStyle?.fontSize ?? null,
-      firstItemLineHeight: firstStyle?.lineHeight ?? null,
-    });
-  });
 
   window.addEventListener(
     "click",

--- a/src/module/action/action-manager.ts
+++ b/src/module/action/action-manager.ts
@@ -123,7 +123,6 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
    */
   private async resetActions() {
     if (this.target) {
-      console.log("Resetting " + this.target.name);
       await modAction(this.target, false);
       await this.update();
 
@@ -157,7 +156,7 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
       if (this.canMod()) {
         await this.resetActions();
       } else {
-        console.log(`${game.user?.name} :: Users currently not allowed to reset actions through action manager.`);
+        ui.notifications?.warn(`${game.user?.name} cannot reset actions via the action tracker.`, { localize: false });
       }
     });
 
@@ -172,7 +171,9 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
             await this.update();
           }
         } else {
-          console.log(`${game.user?.name} :: Users currently not allowed to toggle actions through action manager.`);
+          ui.notifications?.warn(`${game.user?.name} cannot toggle actions via the action tracker.`, {
+            localize: false,
+          });
         }
       })
     );
@@ -274,7 +275,6 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
             elmnt.style.top = yPos + "px";
             elmnt.style.left = xPos + "px";
           }
-          console.log(`Action Manager | CACHING: ${xPos} || ${yPos}.`);
           game.user?.update({ flags: { lancer: { "action-manager": { pos: { top: yPos, left: xPos } } } } });
           appPos.top = yPos;
           appPos.left = xPos;

--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -459,7 +459,6 @@ export class LancerActorSheet<T extends LancerActorType> extends HandlebarsAppli
     }
     if (!data) return;
     e.dataTransfer?.setData("text/plain", JSON.stringify(data));
-    console.log("Flow drag data:", data, e.dataTransfer?.getData("text/plain"));
   }
 
   async _activateActionGridListeners(html: JQuery) {
@@ -480,7 +479,7 @@ export class LancerActorSheet<T extends LancerActorType> extends HandlebarsAppli
           modAction(this.actor as LancerActor, spend, action);
         }
       } else {
-        console.log(`${game.user?.name} :: Users currently not allowed to toggle actions through action manager.`);
+        ui.notifications?.warn(`${game.user?.name} cannot toggle actions via the action tracker.`, { localize: false });
       }
     });
   }
@@ -753,7 +752,6 @@ export class LancerActorSheet<T extends LancerActorType> extends HandlebarsAppli
     }
     data.effect_categories = LancerActiveEffect.prepareActiveEffectCategories(this.actor);
     data.deployables = lookupOwnedDeployables(this.actor);
-    console.log(`${lp} Rendering with following actor ctx: `, data);
     return data;
   }
 }

--- a/src/module/apps/acc_diff/AccDiffHUD.svelte
+++ b/src/module/apps/acc_diff/AccDiffHUD.svelte
@@ -141,9 +141,7 @@
 
   function isMelee() {
     if (!lancerItem || isTech()) return false;
-    const result = lancerItem.currentProfile().type === WeaponType.Melee;
-    console.log("isMelee?", result);
-    return result;
+    return lancerItem.currentProfile().type === WeaponType.Melee;
   }
 
   function gritLabel() {

--- a/src/module/helpers/refs.ts
+++ b/src/module/helpers/refs.ts
@@ -304,32 +304,7 @@ export function handleRefClickOpen(html: JQuery) {
   try {
     $root.find(".ref.set.click-open, .ref.set .click-open").on("click", click_evt_open_ref);
   } catch (err) {
-    // #region agent log
-    const h13Data = {
-      isJQuery: Boolean(maybe?.jquery),
-      ctor: maybe?.constructor?.name ?? null,
-      length: typeof maybe?.length === "number" ? maybe.length : null,
-      firstCtor: (maybe?.[0] as { constructor?: { name?: string } } | undefined)?.constructor?.name ?? null,
-      error: err instanceof Error ? err.message : String(err),
-      stack: err instanceof Error ? err.stack : null,
-    };
-    console.warn(
-      `${LANCER.log_prefix} [04ebbd:H13_ref-click-root-shape] handleRefClickOpen failed ${JSON.stringify(h13Data)}`
-    );
-    fetch("http://127.0.0.1:7777/ingest/8de7fe5e-b66f-46b3-834a-869605e8207d", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "04ebbd" },
-      body: JSON.stringify({
-        sessionId: "04ebbd",
-        runId: "post-fix-1",
-        hypothesisId: "H13_ref-click-root-shape",
-        location: "src/module/helpers/refs.ts:handleRefClickOpen",
-        message: "handleRefClickOpen failed to bind click-open refs",
-        data: h13Data,
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
+    console.error(`${LANCER.log_prefix} handleRefClickOpen failed`, err);
     throw err;
   }
 }

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.12.6",
+  "version": "2.12.7",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.6/lancer-v2.12.6.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.7/lancer-v2.12.7.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cleans up browser console spam from temporary agent debug instrumentation and a few stray `console.log` calls.

### Removed
- `debugCssLog` hooks on `renderActorSheet`, `renderApplication`, and `renderActorDirectory` (warned on every sheet open + failed `127.0.0.1:7777` ingest fetches)
- Global `error` listener and no-op `createChatMessage` hook left from the same debug session
- Empty per-sheet click listener that did nothing after a match
- Agent ingest logging in `handleRefClickOpen`
- `isMelee?` log in AccDiff HUD
- Action tracker drag-position cache log and per-render actor context dump

### Changed
- Action tracker permission denials use `ui.notifications.warn` instead of `console.log`

**Version:** 2.12.7

After merge, reload Foundry worlds (F5) so clients pick up the rebuilt system bundle.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

