### PR TITLE
feat: port COMP/CON v3 pilot import from upstream (#934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Ported upstream COMP/CON **v3 pilot import** (Eranziel [#934](https://github.com/Eranziel/foundryvtt-lancer/pull/934)): `importCCv3` / `importCCv2` routing, updated packed types, v3/v2 share-code detection on the pilot sheet, and official `api.compcon.app` v3 share fetch (with share-proxy and legacy API fallback).
 
+## Fixed
+
+- V3 share codes and cloud pilot fetches expose `originId` on the top-level pilot object without a `data` wrapper; `importCC` now wraps that payload before calling `importCCv3` (fixes imports such as pilot **saziment Allara** from share code `I2RAI4F5MLPG`).
+
 # 2.12.7 (2026-06-05)
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.12.8 (2026-06-05)
+
+## Added
+
+- Ported upstream COMP/CON **v3 pilot import** (Eranziel [#934](https://github.com/Eranziel/foundryvtt-lancer/pull/934)): `importCCv3` / `importCCv2` routing, updated packed types, v3/v2 share-code detection on the pilot sheet, and official `api.compcon.app` v3 share fetch (with share-proxy and legacy API fallback).
+
 # 2.12.7 (2026-06-05)
 
 ## Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.12.7",
+  "version": "2.12.8",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/src/module/actor/import.ts
+++ b/src/module/actor/import.ts
@@ -1,6 +1,6 @@
 import { LANCER } from "../config";
 import { replaceDefaultResource } from "../config";
-import { EntryType, FittingSize, MountType } from "../enums";
+import { EntryType, EntryTypeLidPrefix, FittingSize, MountType } from "../enums";
 import {
   type LancerBOND,
   type LancerCORE_BONUS,
@@ -14,6 +14,7 @@ import {
   type LancerPILOT_WEAPON,
   type LancerSKILL,
   type LancerTALENT,
+  type LancerRESERVE,
   type LancerWEAPON_MOD,
 } from "../item/lancer-item";
 import type { PowerData } from "../models/bits/power";
@@ -21,18 +22,891 @@ import type { SourceData } from "../source-template";
 import { get_pack_id, insinuate } from "../util/doc";
 import { fromLid } from "../helpers/from-lid";
 import type {
-  PackedEquipmentData,
-  PackedMechWeaponSaveData,
-  PackedMountData,
+  PackedPilotWrapper,
   PackedPilotData,
+  PackedPilotEquipmentWrapper,
   PackedPilotEquipmentState,
+  PackedPilotArmorData,
+  PackedPilotGearData,
+  PackedPilotWeaponData,
+  PackedClockBurdenData,
+  PackedCoreBonusData,
+  PackedMechData,
+  PackedMechWeaponSaveWrapper,
+  PackedMechWeaponSaveData,
+  PackedMechEquipmentData,
+  PackedMountData,
 } from "../util/unpacking/packed-types";
 import { LancerActor, type LancerMECH, type LancerPILOT } from "./lancer-actor";
 import { frameToPath } from "./retrograde-map";
+import { unpackPilotArmor } from "../models/items/pilot_armor";
+import type { UnpackContext } from "../models/shared";
+import { unpackPilotWeapon } from "../models/items/pilot_weapon";
+import { unpackPilotGear } from "../models/items/pilot_gear";
+import { unpackCoreBonus } from "../models/items/core_bonus";
+import { unpackSkill } from "../models/items/skill";
+import { unpackTalent } from "../models/items/talent";
+import { unpackBond } from "../models/items/bond";
+import { unpackLicense } from "../models/items/license";
+import { unpackMechSystem } from "../models/items/mech_system";
+import { unpackMechWeapon } from "../models/items/mech_weapon";
+import { unpackWeaponMod } from "../models/items/weapon_mod";
+import { unpackReserve } from "../models/items/reserve";
+import { unpackFrame } from "../models/items/frame";
 const lp = LANCER.log_prefix;
 
+/**
+ * Updates the Pilot document, given COMP/CON data.
+ * @param pilot   - The pilot actor
+ * @param data    - `PackedPilotData`
+ * @param armor   - Array of pilot armor UUIDs
+ * @param gear    - Array of pilot gear UUIDs
+ * @param weapons - Array of pilot weapon UUIDs
+ */
+async function updatePilot(
+  pilot: LancerPILOT,
+  data: PackedPilotData,
+  armor?: string[],
+  gear?: string[],
+  weapons?: string[]
+) {
+  const portrait = data.cloud_portrait ?? data.img.cloud_portrait;
+  const unpackClock = (clock: PackedClockBurdenData) => {
+    return {
+      lid: clock.id,
+      name: clock.title,
+      min: 0,
+      max: clock.segments,
+      value: clock.progress,
+      default_value: 0,
+    };
+  };
+
+  await pilot.update({
+    name: data.name,
+    img: replaceDefaultResource(pilot.img, portrait),
+    system: {
+      hp: {
+        value: data.stats.current.hp,
+      },
+
+      // Pilot specific
+      background: data.background,
+      callsign: data.callsign,
+      cloud_id: data.cloudID,
+      history: data.history,
+      level: data.level,
+      loadout: {
+        armor: armor ?? [],
+        gear: gear ?? [],
+        weapons: weapons ?? [],
+      },
+      hull: data.mechSkills[0],
+      agi: data.mechSkills[1],
+      sys: data.mechSkills[2],
+      eng: data.mechSkills[3],
+      mounted: data.state?.mounted ?? true,
+      notes: data.notes,
+      player_name: data.player_name,
+      status: data.status,
+      text_appearance: data.text_appearance,
+      bond_state: data.bond
+        ? {
+            xp: {
+              value: data.xp ?? data.bond.xp,
+            },
+            stress: {
+              value: data.stress ?? data.bond.stress,
+            },
+            answers: data.bondAnswers ?? data.bond.bondAnswers,
+            minor_ideal: data.minorIdeal ?? data.bond.minorIdeal,
+            burdens: (data.burdens ?? data.bond.burdens).map(b => unpackClock(b)),
+            clocks: (data.clocks ?? data.bond.clocks).map(c => unpackClock(c)),
+          }
+        : undefined,
+    },
+    prototypeToken: {
+      name: data.name,
+      texture: {
+        src: replaceDefaultResource(pilot.prototypeToken?.texture?.src, portrait, pilot.img),
+      },
+    },
+  });
+}
+
+/**
+ * Updates the Pilot document, given COMP/CON data.
+ * @param mech              - The mech actor
+ * @param pilot             - The pilot actor
+ * @param data              - `PackedMechData`
+ * @param ownershipLevel    - The `CONST.DOCUMENT_OWNERSHIP_LEVELS` to set the mech document
+ * @param populatedMounts   - idk tbh lol
+ * @param populatedSystems  - Array of mech system UUIDs
+ * @param frame
+ */
+async function updateMech(
+  mech: LancerMECH,
+  pilot: LancerPILOT,
+  data: PackedMechData,
+  ownershipLevel: Record<string, CONST.DOCUMENT_OWNERSHIP_LEVELS>,
+  populatedMounts: SourceData.Mech["loadout"]["weapon_mounts"],
+  populatedSystems: string[],
+  frame?: LancerFRAME | null
+) {
+  await mech.update({
+    name: data.name,
+    folder: pilot.folder?.id || null,
+    img: replaceDefaultResource(mech.img, data.portrait, frame ? frameToPath(frame.name) : null),
+    ownershipLevel,
+    prototypeToken: {
+      name: pilot.system.callsign || data.name,
+      disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
+      texture: {
+        src: replaceDefaultResource(
+          mech.prototypeToken?.texture?.src,
+          data.img.cloud_portrait,
+          frame ? frameToPath(frame.name) : null
+        ),
+      },
+    },
+    system: {
+      // Universal stuff
+      lid: data.id,
+      hp: {
+        value: data.stats.current.hp,
+        max: data.stats.max.hp,
+      },
+      overshield: {
+        value: data.stats.current.overshield,
+        max: data.stats.max.overshield,
+      },
+      burn: data.stats.current.burn,
+      activations: data.stats.current.activations,
+      heat: {
+        value: data.stats.current.heat,
+        max: data.stats.max.heat,
+      },
+      stress: {
+        value: data.stats.current.stress,
+        max: data.stats.max.stress,
+      },
+      structure: {
+        value: data.stats.current.structure,
+        max: data.stats.max.structure,
+      },
+
+      // Mech stuff
+      overcharge: data.stats.current.overcharge,
+      repairs: {
+        value: data.stats.current.repairCapacity,
+        max: data.stats.max.repairCapacity,
+      },
+      core_active: data.coreActive,
+      core_energy: data.corePower,
+      notes: data.notes,
+      pilot: pilot.uuid,
+      loadout: {
+        frame: frame?.id ?? null,
+        weapon_mounts: populatedMounts,
+        systems: populatedSystems,
+      },
+    },
+  });
+}
+
+/**
+ * Clear all embedded documents related to the given pilot
+ * @param pilot - The pilot actor to delete embedded documents off of
+ */
+async function clearPilotEmbeddedDocuments(pilot: LancerPILOT) {
+  await pilot.deleteEmbeddedDocuments("Item", Array.from(pilot.items.keys()));
+  let existing_mechs = game.actors?.filter((a: LancerActor) => a.is_mech() && a.system.pilot?.value == pilot) ?? [];
+  for (let m of existing_mechs) {
+    await m.deleteEmbeddedDocuments("Item", Array.from(m.items.keys()));
+  }
+}
+
+/**
+ * Checks whether the calling client is able to create Actors
+ */
+function hasCreatePermissions() {
+  const canCreate = game.user?.can("ACTOR_CREATE");
+  const gmsOnline = game.users?.some(u => u.isGM && u.active);
+  if (!canCreate && !gmsOnline) {
+    new foundry.applications.api.DialogV2({
+      window: {
+        title: `Cannot Create Actors`,
+        icon: "fas fa-triangle-exclamation",
+      },
+      content: `
+        <p>You are not permitted to create actors and no GM's are online, so sync will not produce any new mechs or deployables.</p>
+        <p>Your GM can allow Players/Trusted Players to create actors in Settings->Configure Permissions.</p>
+      `,
+      buttons: [
+        {
+          action: "close",
+          icon: "fas fa-check",
+          label: "Close",
+          default: true,
+        },
+      ],
+    }).render(true);
+  }
+}
+
+/**
+ * Prompts a pilot loadout selector
+ * @param loadouts - Array of loadout string names
+ * @return The index of the choice made
+ */
+async function promptLoadoutSelection(loadouts: string[]) {
+  let contentChoices = "";
+  loadouts.map((l, i) => {
+    contentChoices += `<label><input type="radio" name="choice" value=${i} ${i == 0 ? "checked" : ""}>${l}</label>`;
+  });
+
+  // @ts-ignore Please stop yelling at me :sob:
+  return foundry.applications.api.DialogV2.prompt({
+    window: {
+      title: `Select Pilot Loadout`,
+      icon: "fas fa-triangle-exclamation",
+    },
+    content: `
+      <span>Multiple pilot loadouts found. Please select a single loadout to import and use:</span>
+      ${contentChoices}
+      <hr>
+    `,
+    ok: {
+      label: "Import Selected Loadout",
+      callback: (_event: Event, button: HTMLButtonElement, _dialog: any) =>
+        (button.form?.elements as unknown as { choice: RadioNodeList }).choice.value,
+    },
+  });
+}
+
+/**
+ * Gets an actor's Item by their LID and tries to insert the item into their Document.
+ * Searches from the item pool first before attempting to look up the Compendium entry.
+ * @param lid           - LID to lookup
+ * @param actor         - Actor to insert the embedded documents into
+ * @param itemPool      - Item pool to reference
+ * @param missingItems  - Array appending an object holding the `actor` and `lid` of any failed lookups
+ * @return The `LancerItem` if successful or `null`
+ */
+async function getActorItemByLid(
+  lid: string,
+  actor: LancerPILOT | LancerMECH,
+  itemPool: LancerItem[],
+  missingItems: { actor: string; lid: string }[]
+): Promise<LancerItem | null> {
+  let existingItem = itemPool.findSplice(i => (i as any).system.lid == lid);
+  if (existingItem) return existingItem;
+  let fromCompendium = (await fromLid(lid)) as LancerItem | null;
+  if (!fromCompendium) {
+    missingItems.push({ actor: actor.name, lid });
+    return null;
+  }
+  return (await insinuate([fromCompendium], actor))[0] ?? null;
+}
+
+/**
+ * Wrapper function to determine which importer to use
+ */
+export async function importCC(
+  pilot: LancerPILOT,
+  importedData: PackedPilotData | PackedPilotWrapper,
+  clearFirst = true
+) {
+  // CCv3 JSON exports have a wrapper that is missing in sharecode/cloud fetching
+  // `originId` is some arbitrary V3 exclusive data; it can be anything else.
+  // `EXPORT_TYPE` is exclusive to V3 and only in JSON exports.
+  if ("originId" in importedData || "EXPORT_TYPE" in importedData) {
+    await importCCv3(pilot, importedData, clearFirst);
+  } else if ("data" in importedData && importedData.data && !("callsign" in importedData)) {
+    await importCCv3(pilot, { EXPORT_TYPE: "pilot", data: importedData.data }, clearFirst);
+  } else {
+    await importCCv2(pilot, importedData as PackedPilotData, clearFirst);
+  }
+}
+
+/**
+ * Imports packed pilot data from CCv3.
+ * Minimum import version: CCv3.0.4
+ */
+export async function importCCv3(pilot: LancerPILOT, importedData: PackedPilotWrapper, clearFirst = true) {
+  console.log(`${lp} Importing v3 Pilot`, pilot, importedData);
+  if (!pilot.is_pilot()) console.error(`${lp} Actor was not a pilot type`, pilot);
+  if (!importedData) console.error(`${lp} Imported data is missing`, importedData);
+  const data = importedData.data;
+  if (!data) {
+    console.error(`${lp} Tried using CCv3 importer on CCv2 data`, importedData);
+  }
+
+  if (clearFirst) {
+    await clearPilotEmbeddedDocuments(pilot);
+  }
+
+  hasCreatePermissions();
+
+  // Extract data
+  try {
+    // Immediately fix the name, so deployables get named properly
+    await pilot.update({
+      name: data.name,
+      system: {
+        callsign: data.callsign,
+      },
+    });
+    const _context: UnpackContext = { createdDeployables: [] };
+
+    // Keep track of which actors and items could not be found/created
+    const _missingActors: { name: string; lid: string }[] = [];
+    const _missingItems: { actor: string; lid: string }[] = [];
+
+    // --- Pilot ---
+    const pilotItemUpdates: any = [];
+    const pilotItemPool = [...pilot.items.contents];
+    let selectedLoadout = 0;
+
+    // Get the object by LIDs first if able as a natural guard against incomplete data
+    // and then overwrite with values in the importing data
+    const gears: string[] = [];
+    const armors: string[] = [];
+    const weapons: string[] = [];
+    if (data.loadouts) {
+      try {
+        if (data.loadouts.length > 1)
+          selectedLoadout = Number(await promptLoadoutSelection(data.loadouts.map(l => l.name)));
+      } catch {
+        console.log(`${lp} User cancelled pilot import`);
+        return;
+      }
+
+      let flatData: ((PackedPilotEquipmentState & PackedPilotEquipmentWrapper) | null)[];
+
+      // Gear
+      flatData = (data.loadouts[selectedLoadout].gear ?? []).filter(a => a);
+      for (const item of flatData) {
+        if (!item) continue;
+        const compendiumItem = (await getActorItemByLid(
+          item.id,
+          pilot,
+          pilotItemPool,
+          _missingItems
+        )) as LancerPILOT_GEAR | null;
+        const id =
+          compendiumItem?.id ??
+          (
+            await pilot.createEmbeddedDocuments("Item", [
+              {
+                type: EntryType.PILOT_GEAR,
+                name: item.data.name,
+              },
+            ])
+          )[0].id;
+
+        gears.push(id);
+
+        const ccData = unpackPilotGear(item.data as PackedPilotGearData, _context);
+        pilotItemUpdates.push({
+          ...ccData,
+          _id: id,
+        });
+      }
+
+      // Armor
+      flatData = (data.loadouts[selectedLoadout].armor ?? []).filter(a => a);
+      for (const item of flatData) {
+        if (!item) continue;
+        const compendiumItem = (await getActorItemByLid(
+          item.id,
+          pilot,
+          pilotItemPool,
+          _missingItems
+        )) as LancerPILOT_GEAR | null;
+        const id =
+          compendiumItem?.id ??
+          (
+            await pilot.createEmbeddedDocuments("Item", [
+              {
+                type: EntryType.PILOT_ARMOR,
+                name: item.data.name,
+              },
+            ])
+          )[0].id;
+
+        armors.push(id);
+
+        const ccData = unpackPilotArmor(item.data as PackedPilotArmorData, _context);
+        pilotItemUpdates.push({
+          ...ccData,
+          _id: id,
+        });
+      }
+
+      // Weapons
+      flatData = (data.loadouts[selectedLoadout].weapons ?? []).filter(a => a);
+      for (const item of flatData) {
+        if (!item) continue;
+        const compendiumItem = (await getActorItemByLid(
+          item.id,
+          pilot,
+          pilotItemPool,
+          _missingItems
+        )) as LancerPILOT_GEAR | null;
+        const id =
+          compendiumItem?.id ??
+          (
+            await pilot.createEmbeddedDocuments("Item", [
+              {
+                type: EntryType.PILOT_WEAPON,
+                name: item.data.name,
+              },
+            ])
+          )[0].id;
+
+        weapons.push(id);
+
+        const ccData = unpackPilotWeapon(item.data as PackedPilotWeaponData, _context);
+        pilotItemUpdates.push({
+          ...ccData,
+          _id: id,
+        });
+      }
+    }
+
+    // Core Bonuses
+    for (const item of data.core_bonuses as PackedCoreBonusData[]) {
+      const compendiumItem = (await getActorItemByLid(
+        item.id,
+        pilot,
+        pilotItemPool,
+        _missingItems
+      )) as LancerCORE_BONUS | null;
+      const id =
+        compendiumItem?.id ??
+        (
+          await pilot.createEmbeddedDocuments("Item", [
+            {
+              type: EntryType.CORE_BONUS,
+              name: item.name,
+            },
+          ])
+        )[0].id;
+
+      const ccData = unpackCoreBonus(item, _context);
+      pilotItemUpdates.push({
+        ...ccData,
+        _id: id,
+      });
+    }
+
+    // Skills
+    for (const item of data.skills) {
+      if ("custom" in item && item.custom) {
+        pilot.createEmbeddedDocuments("Item", [
+          {
+            type: EntryType.SKILL,
+            name: item.id ?? "Custom Skill",
+            system: <any>{
+              rank: item.rank,
+              description: item.custom_desc || item.custom_detail || "",
+            },
+          },
+        ]);
+      } else if ("data" in item) {
+        const compendiumItem = (await getActorItemByLid(
+          item.id,
+          pilot,
+          pilotItemPool,
+          _missingItems
+        )) as LancerSKILL | null;
+        const id =
+          compendiumItem?.id ??
+          (
+            await pilot.createEmbeddedDocuments("Item", [
+              {
+                type: EntryType.SKILL,
+                name: item.data.name,
+              },
+            ])
+          )[0].id;
+
+        const ccData = unpackSkill(item.data, _context);
+        pilotItemUpdates.push({
+          ...ccData,
+          _id: id,
+        });
+      }
+    }
+
+    // Talents
+    for (const item of data.talents) {
+      const compendiumItem = (await getActorItemByLid(
+        item.id,
+        pilot,
+        pilotItemPool,
+        _missingItems
+      )) as LancerTALENT | null;
+      const id =
+        compendiumItem?.id ??
+        (
+          await pilot.createEmbeddedDocuments("Item", [
+            {
+              type: EntryType.TALENT,
+              name: item.data.name,
+            },
+          ])
+        )[0].id;
+
+      const ccData = unpackTalent(item.data, _context);
+      pilotItemUpdates.push({
+        ...ccData,
+        _id: id,
+        system: {
+          ...ccData.system,
+          curr_rank: item.rank,
+        },
+      });
+    }
+
+    // Bonds
+    if (data.bond) {
+      const item = data.bond;
+      const bond = (await getActorItemByLid(item.bondId, pilot, pilotItemPool, _missingItems)) as LancerBOND | null;
+      const id =
+        bond?.id ??
+        (
+          await pilot.createEmbeddedDocuments("Item", [
+            {
+              type: EntryType.BOND,
+              name: item.data.name,
+            },
+          ])
+        )[0].id;
+
+      const ccData = unpackBond(item.data);
+      pilotItemUpdates.push({
+        ...ccData,
+        _id: id,
+      });
+    }
+
+    // Licenses
+    for (const item of data.licenses) {
+      const lid = EntryTypeLidPrefix(EntryType.LICENSE) + item.id;
+      const compendiumItem = (await getActorItemByLid(
+        lid,
+        pilot,
+        pilotItemPool,
+        _missingItems
+      )) as LancerLICENSE | null;
+      const id =
+        compendiumItem?.id ??
+        (
+          await pilot.createEmbeddedDocuments("Item", [
+            {
+              type: EntryType.LICENSE,
+              name: item.stub.name,
+            },
+          ])
+        )[0].id;
+
+      const ccData = unpackLicense(item.stub.name, lid, item.stub.source, _context);
+      pilotItemUpdates.push({
+        ...ccData,
+        _id: id,
+      });
+    }
+
+    // Reserves
+    for (const item of data.reserves) {
+      const compendiumItem = (await getActorItemByLid(
+        item.id,
+        pilot,
+        pilotItemPool,
+        _missingItems
+      )) as LancerRESERVE | null;
+      const id =
+        compendiumItem?.id ??
+        (
+          await pilot.createEmbeddedDocuments("Item", [
+            {
+              type: EntryType.RESERVE,
+              name: item.name,
+            },
+          ])
+        )[0].id;
+
+      const ccData = unpackReserve(item, _context);
+      pilotItemUpdates.push({
+        ...ccData,
+        _id: id,
+      });
+    }
+
+    // Update all items
+    await pilot.updateEmbeddedDocuments("Item", pilotItemUpdates);
+
+    // Delete all old items of certain types when done
+    const remove = pilotItemPool.filter(x =>
+      [EntryType.TALENT, EntryType.SKILL, EntryType.CORE_BONUS].includes(x.type! as EntryType)
+    );
+    await pilot._safeDeleteDescendant("Item", remove);
+
+    // Perform base pilot update
+    await updatePilot(pilot, data, armors, gears, weapons);
+
+    // --- Mechs ---
+    let activeMechUuid: string | null = null;
+    const ownershipLevel = foundry.utils.deepClone(pilot.ownership);
+    const createNewMech = async (importData: PackedMechData) => {
+      if (!game.user?.can("ACTOR_CREATE")) {
+        ui.notifications!.warn(
+          `Could not import mech '${importData.name}' as you lack the permission to create new actors. Please ask your GM for assistance (either they import for you, or give you permissions)`,
+          { permanent: true }
+        );
+        _missingActors.push({ name: importData.name, lid: importData.frameData.id });
+      } else {
+        return (await LancerActor.create({
+          name: importData.name,
+          type: EntryType.MECH,
+          folder: pilot.folder?.id,
+          ownership: ownershipLevel,
+          system: {
+            pilot: pilot.uuid,
+          },
+        })) as LancerMECH;
+      }
+    };
+
+    for (const importedMech of data.mechs) {
+      // Find the existing mech, or create one as necessary
+      let mech = game.actors!.find((m: LancerActor) => m.is_mech() && m.system.lid == importedMech.id) as LancerMECH;
+      if (!mech) {
+        const newMech = await createNewMech(importedMech);
+        if (newMech) mech = newMech;
+      }
+      if (!mech.canUserModify(game.user!, "update")) {
+        ui.notifications!.warn(
+          `Could not import mech '${importedMech.name}' as you lack the permission to update the actor. Please ask your GM for assistance.`,
+          { permanent: true }
+        );
+        _missingActors.push({ name: importedMech.name, lid: importedMech.frameData.id });
+        continue;
+      }
+
+      const mechItemPool = [...mech.items.contents];
+      const mechItemUpdates: any = [];
+      const loadout = importedMech.loadouts[importedMech.active_loadout_index];
+      const populatedMounts: SourceData.Mech["loadout"]["weapon_mounts"] = [];
+      const populatedSystems: string[] = [];
+
+      // Mech Frame
+      const compendiumFrame = (await getActorItemByLid(
+        importedMech.frame,
+        mech,
+        mechItemPool,
+        _missingItems
+      )) as LancerFRAME | null;
+      const frameId =
+        compendiumFrame?.id ??
+        (
+          await mech.createEmbeddedDocuments("Item", [
+            {
+              type: EntryType.FRAME,
+              name: importedMech.frameData.name,
+            },
+          ])
+        )[0].id;
+
+      const ccData = unpackFrame(importedMech.frameData, _context);
+      mechItemUpdates.push({
+        ...ccData,
+        _id: frameId,
+      });
+
+      // Mech Systems
+      const flatSystems = [...loadout.integratedSystems, ...loadout.systems];
+      // const assocSystemData = new Map<string, PackedMechEquipmentData>();
+      for (const item of flatSystems) {
+        const compendiumItem = (await getActorItemByLid(
+          item.data.id,
+          mech,
+          mechItemPool,
+          _missingItems
+        )) as LancerMECH_SYSTEM | null;
+        const id =
+          compendiumItem?.id ??
+          (
+            await mech.createEmbeddedDocuments("Item", [
+              {
+                type: EntryType.MECH_SYSTEM,
+                name: item.data.name,
+              },
+            ])
+          )[0].id;
+
+        populatedSystems.push(id);
+        // assocSystemData.set(id, item);
+
+        const ccData = unpackMechSystem(item.data, _context);
+        mechItemUpdates.push({
+          ...ccData,
+          _id: id,
+          system: {
+            ...ccData.system,
+            uses: {
+              value: Math.max(0, (item.maxUses ?? 0) - (item.currentUses ?? 0)),
+              max: item.maxUses,
+            } as const,
+          },
+        });
+      }
+
+      // Mounts
+      const flatMounts: PackedMountData[] = [
+        loadout.integratedWeapon,
+        loadout.improved_armament,
+        loadout.superheavy_mounting,
+        ...loadout.integratedMounts.map(im => ({
+          mount_type: MountType.Integrated,
+          slots: [
+            {
+              weapon: im.weapon,
+              mod: null,
+              size: FittingSize.Integrated,
+            },
+          ],
+          extra: [],
+          bonus_effects: [],
+        })),
+        ...loadout.mounts,
+      ].filter(m => m?.slots.some(x => x.weapon));
+      // const assocWeaponData = new Map<string, PackedMechWeaponSaveData>();
+
+      for (const mount of flatMounts) {
+        const populatedSlots: (typeof populatedMounts)[0]["slots"] = [];
+        // Helper that creates a weapon and maybe its mod and attaches it to the mech
+        const processMechWeapon = async (weaponSlot: PackedMechWeaponSaveData & PackedMechWeaponSaveWrapper) => {
+          const weapon = (await getActorItemByLid(
+            weaponSlot.id,
+            mech,
+            mechItemPool,
+            _missingItems
+          )) as LancerMECH_WEAPON | null;
+          const weaponId =
+            weapon?.id ??
+            (
+              await mech.createEmbeddedDocuments("Item", [
+                {
+                  type: EntryType.MECH_WEAPON,
+                  name: weaponSlot.data.name,
+                },
+              ])
+            )[0].id;
+
+          const ccData = unpackMechWeapon(weaponSlot.data, _context);
+          mechItemUpdates.push({
+            ...ccData,
+            _id: weaponId,
+            system: {
+              ...ccData.system,
+              uses: {
+                value: Math.max(0, (weaponSlot.maxUses ?? 0) - (weaponSlot.currentUses ?? 0)),
+                max: weaponSlot.maxUses,
+              } as const,
+            },
+          });
+
+          let mod: LancerWEAPON_MOD | null = null;
+          let modId: string | null = null;
+          if (weaponSlot.mod) {
+            mod = (await getActorItemByLid(weaponSlot.mod.id, mech, mechItemPool, _missingItems)) as LancerWEAPON_MOD;
+            modId =
+              mod?.id ??
+              (
+                await mech.createEmbeddedDocuments("Item", [
+                  {
+                    type: EntryType.WEAPON_MOD,
+                    name: weaponSlot.mod.data.name,
+                  },
+                ])
+              )[0].id;
+
+            const ccData = unpackWeaponMod(weaponSlot.mod.data, _context);
+            mechItemUpdates.push({
+              ...ccData,
+              _id: modId,
+              system: {
+                ...ccData.system,
+                uses: {
+                  value: Math.max(0, (weaponSlot.mod.maxUses ?? 0) - (weaponSlot.mod.currentUses ?? 0)),
+                  max: weaponSlot.mod.maxUses,
+                } as const,
+              },
+            });
+          }
+
+          return { weapon, weaponId, mod, modId };
+        };
+
+        for (const slot of mount.slots) {
+          if (!slot.weapon) continue;
+          const { weapon, weaponId, mod, modId } = await processMechWeapon(slot.weapon);
+          // assocWeaponData.set(weaponId, slot.weapon);
+          // if (slot.weapon.mod) assocSystemData.set(weaponId, slot.weapon.mod);
+          populatedSlots.push({
+            mod: mod ? modId : null,
+            weapon: weapon ? weaponId : null,
+            size: slot.size,
+          });
+        }
+
+        for (const extraSlot of mount.extra) {
+          if (!extraSlot.weapon) continue;
+          const { weapon, weaponId, mod, modId } = await processMechWeapon(extraSlot.weapon);
+          populatedSlots.push({ mod: mod ? modId : null, weapon: weapon ? weaponId : null, size: extraSlot.size });
+        }
+
+        populatedMounts.push({
+          bracing: mount.lock ?? false,
+          type: mount.mount_type as MountType,
+          slots: populatedSlots,
+        });
+      }
+
+      // Update all items
+      await mech.updateEmbeddedDocuments("Item", mechItemUpdates);
+
+      // Perform base mech update
+      await updateMech(mech, pilot, importedMech, ownershipLevel, populatedMounts, populatedSystems, compendiumFrame);
+
+      // Try to use CC's starred mech otherwise set the first one as active.
+      if (!activeMechUuid) activeMechUuid = mech.uuid;
+      else if (data.favorite_mech === mech.system.lid) activeMechUuid = mech.uuid;
+    }
+
+    // Update active mech and last imported timestamp
+    await pilot.update({
+      system: {
+        active_mech: activeMechUuid,
+        last_cloud_update: new Date().toISOString(),
+      },
+    });
+
+    pilot.effectHelper.propagateEffects(true);
+    // Reset current data and render all
+    pilot.render();
+    ui.notifications!.info("Successfully loaded pilot new state.");
+  } catch (e) {
+    console.warn(e);
+    ui.notifications!.warn(`Failed to update pilot: ${e instanceof Error ? e.message : e}`, { permanent: true });
+  }
+}
+
 // Imports packed pilot data, from either a vault id or gist id
-export async function importCC(pilot: LancerPILOT, data: PackedPilotData, clearFirst = true) {
+export async function importCCv2(pilot: LancerPILOT, data: PackedPilotData, clearFirst = true) {
   const coreVersion = game.settings.get(game.system.id, LANCER.setting_core_data);
   if (!coreVersion) {
     ui.notifications!.warn(
@@ -41,7 +915,7 @@ export async function importCC(pilot: LancerPILOT, data: PackedPilotData, clearF
     );
     return;
   }
-  console.log(`${lp} Importing Pilot`, pilot, data);
+  console.log(`${lp} Importing v2 Pilot`, pilot, data);
   if (!pilot.is_pilot() || !data) return;
   if (clearFirst) {
     await pilot.deleteEmbeddedDocuments("Item", Array.from(pilot.items.keys()));
@@ -232,6 +1106,11 @@ export async function importCC(pilot: LancerPILOT, data: PackedPilotData, clearF
         }
       }
 
+      // Do reserves
+      for (let reserve of data.reserves) {
+        let _r = (await getActorItemByLid(reserve.id, pilot, pilotItemPool, missingItems)) as LancerRESERVE | null;
+      }
+
       // Update all items
       await pilot.updateEmbeddedDocuments("Item", itemUpdates);
 
@@ -359,7 +1238,7 @@ export async function importCC(pilot: LancerPILOT, data: PackedPilotData, clearF
       // Populate our systems
       let flatSystems = [...loadout.integratedSystems, ...loadout.systems];
       let populatedSystems: string[] = [];
-      let assocSystemData = new Map<string, PackedEquipmentData>();
+      let assocSystemData = new Map<string, PackedMechEquipmentData>();
       for (let sys of flatSystems) {
         let realSys = (await getMechItemByLid(sys.id)) as LancerMECH_SYSTEM | null;
         if (realSys) {

--- a/src/module/actor/import.ts
+++ b/src/module/actor/import.ts
@@ -317,11 +317,11 @@ export async function importCC(
   importedData: PackedPilotData | PackedPilotWrapper,
   clearFirst = true
 ) {
-  // CCv3 JSON exports have a wrapper that is missing in sharecode/cloud fetching
-  // `originId` is some arbitrary V3 exclusive data; it can be anything else.
-  // `EXPORT_TYPE` is exclusive to V3 and only in JSON exports.
-  if ("originId" in importedData || "EXPORT_TYPE" in importedData) {
-    await importCCv3(pilot, importedData, clearFirst);
+  // CCv3 JSON exports use a wrapper; share codes and cloud fetches return pilot fields at the top level.
+  if ("EXPORT_TYPE" in importedData && "data" in importedData && importedData.data) {
+    await importCCv3(pilot, importedData as PackedPilotWrapper, clearFirst);
+  } else if (("originId" in importedData || "EXPORT_TYPE" in importedData) && "callsign" in importedData) {
+    await importCCv3(pilot, { EXPORT_TYPE: "pilot", data: importedData as PackedPilotData }, clearFirst);
   } else if ("data" in importedData && importedData.data && !("callsign" in importedData)) {
     await importCCv3(pilot, { EXPORT_TYPE: "pilot", data: importedData.data }, clearFirst);
   } else {

--- a/src/module/actor/pilot-sheet.ts
+++ b/src/module/actor/pilot-sheet.ts
@@ -7,7 +7,7 @@ import { buildCounterHeader, buildCounterHTML } from "../helpers/item";
 import { ref_params, resolve_ref_element } from "../helpers/refs";
 import { inc_if, resolveDotpath } from "../helpers/commons";
 import { LancerActor, type LancerMECH, type LancerPILOT } from "./lancer-actor";
-import { fetchPilotViaCache, fetchPilotViaShareCode, pilotCache } from "../util/compcon";
+import { fetchPilotViaCache, fetchV2PilotViaShareCode, fetchV3PilotViaShareCode, pilotCache } from "../util/compcon";
 import type { LancerFRAME } from "../item/lancer-item";
 import { clicker_num_input } from "../helpers/actor";
 import type { ResolvedDropData } from "../helpers/dragdrop";
@@ -15,6 +15,8 @@ import { EntryType } from "../enums";
 import type { PackedPilotData } from "../util/unpacking/packed-types";
 import { importCC } from "./import";
 
+const shareCodeMatcherV2 = /^[A-Z0-9\d]{6}$/;
+const shareCodeMatcherV3 = /^[A-Z0-9]{12}$/;
 const COUNTER_MAX = 8;
 
 /**
@@ -63,7 +65,7 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
       download.on("click", async ev => {
         ev.stopPropagation();
 
-        let raw_pilot_data = null;
+        let raw_pilot_data: PackedPilotData | null = null;
         const cloudId = pilot.system.cloud_id?.trim();
         if (!cloudId) {
           ui.notifications!.error(
@@ -72,27 +74,42 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
           return;
         }
 
-        const cachedPilot = pilotCache().find(p => p.cloudID == cloudId);
-        if (cachedPilot != undefined) {
-          ui.notifications!.info("Importing character from COMP/CON account...");
+        if (shareCodeMatcherV3.test(cloudId)) {
+          ui.notifications!.info("Importing character from V3 share code...");
           try {
-            raw_pilot_data = await fetchPilotViaCache(cachedPilot);
+            raw_pilot_data = await fetchV3PilotViaShareCode(cloudId);
           } catch (error) {
-            ui.notifications!.error(
-              "Failed to import from COMP/CON account. Try refreshing the page to reload pilot list."
-            );
-            console.error(`Failed to import vaultID ${cloudId} via pilot list, error:`, error);
+            ui.notifications!.error("Error importing from V3 share code.");
+            console.error(`Failed import with V3 share code ${cloudId}, error:`, error);
+            return;
+          }
+        } else if (shareCodeMatcherV2.test(cloudId)) {
+          ui.notifications!.info("Importing character from V2 share code...");
+          try {
+            raw_pilot_data = await fetchV2PilotViaShareCode(cloudId);
+          } catch (error) {
+            ui.notifications!.error("Error importing from V2 share code. Share code may need to be refreshed.");
+            console.error(`Failed import with V2 share code ${cloudId}, error:`, error);
             return;
           }
         } else {
-          ui.notifications!.info("Importing character from share code...");
-          console.log(`Attempting import with share code: ${cloudId}`);
-          try {
-            raw_pilot_data = await fetchPilotViaShareCode(cloudId);
-          } catch (error) {
-            const errMessage = error instanceof Error ? error.message : String(error);
-            ui.notifications!.error(`Error importing from share code. ${errMessage}`);
-            console.error(`Failed import with share code ${cloudId}, error:`, error);
+          const cachedPilot = pilotCache().find(p => p.cloudID == cloudId);
+          if (cachedPilot != undefined) {
+            ui.notifications!.info("Importing character from COMP/CON account...");
+            try {
+              raw_pilot_data = await fetchPilotViaCache(cachedPilot);
+            } catch (error) {
+              ui.notifications!.error(
+                "Failed to import from COMP/CON account. Try refreshing the page to reload pilot list."
+              );
+              console.error(`Failed to import vaultID ${cloudId} via pilot list, error:`, error);
+              return;
+            }
+          } else {
+            ui.notifications!.error(
+              "Failed to import from COMP/CON account. Try refreshing the page to reload pilot list."
+            );
+            console.error(`Failed to find pilot in cache, vaultID: ${cloudId}`);
             return;
           }
         }
@@ -134,17 +151,16 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
 
   async _onPilotJsonParsed(fileData: string | null) {
     if (!fileData) return;
-    const pilotData = JSON.parse(fileData) as PackedPilotData;
-    console.log(`${lp} Pilot Data of selected JSON:`, pilotData);
+    const parsed = JSON.parse(fileData) as PackedPilotData & { data?: PackedPilotData };
+    console.log(`${lp} Pilot Data of selected JSON:`, parsed);
 
-    if (!pilotData) return;
-    ui.notifications!.info(`Starting import of ${pilotData.name}, Callsign ${pilotData.callsign}. Please wait.`);
-    console.log(`${lp} Starting import of ${pilotData.name}, Callsign ${pilotData.callsign}.`);
-    console.log(`${lp} Parsed Pilot Data pack:`, pilotData);
+    if (!parsed) return;
+    const displayName = parsed.name ?? parsed.data?.name ?? "Pilot";
+    const displayCallsign = parsed.callsign ?? parsed.data?.callsign ?? "";
+    ui.notifications!.info(`Starting import of ${displayName}, Callsign ${displayCallsign}. Please wait.`);
 
-    await importCC(this.actor as LancerPILOT, pilotData);
-    ui.notifications!.info(`Import of ${pilotData.name}, Callsign ${pilotData.callsign} complete.`);
-    console.log(`${lp} Import of ${pilotData.name}, Callsign ${pilotData.callsign} complete.`);
+    await importCC(this.actor as LancerPILOT, parsed as PackedPilotData);
+    ui.notifications!.info(`Import of ${displayName}, Callsign ${displayCallsign} complete.`);
     this.render();
   }
 

--- a/src/module/effects/converter.ts
+++ b/src/module/effects/converter.ts
@@ -1,5 +1,5 @@
 import { LancerActor, type LancerNPC } from "../actor/lancer-actor";
-import { EntryType } from "../enums";
+import { EntryType, getMountType, MountType } from "../enums";
 import {
   type LancerFRAME,
   LancerItem,
@@ -702,6 +702,16 @@ export function convertBonus(item: LancerItem, name: string, bonus: BonusData) {
         priority,
         key: "system.loadout.limited_bonus",
       });
+      break;
+    case "add_mount": // New in CCv3
+      const mountType = value && typeof value === "number" ? getMountType(value) : -1;
+      // TODO: Indicate whether a mount was appended by a trait/talent/whatever
+      break;
+    case "no_mods": // New in CCv3
+      // TODO: Disallows/disables weapon mod on the a slot
+      break;
+    case "engineering": // New in CCv3
+      // TODO: Exposed Reactor: -1 accuracy on ENG checks and saves
       break;
     case "pilot_hp":
       target_type = EntryType.PILOT;

--- a/src/module/enums.ts
+++ b/src/module/enums.ts
@@ -1,9 +1,7 @@
-// TODO: Just use machine mind, where possible
-
-export enum PilotEquipType {
-  PilotArmor = "armor",
-  PilotWeapon = "weapon",
-  PilotGear = "gear",
+export enum PilotItemType {
+  Armor = "Armor",
+  Weapon = "Weapon",
+  Gear = "Gear",
 }
 
 export enum EffectType {
@@ -288,12 +286,32 @@ export enum SystemType {
 
 export type SystemTypeChecklist = { [key in SystemType]: boolean };
 
+// New in CCv3:
+// https://github.com/massif-press/lancer-data/wiki/active-effects#duration
+// If the effect does not expire or lasts the entire encounter, this field should be omitted.
+// Round durations should be string matched
 export enum Duration {
-  Free = "Free",
-  Turn = "Turn",
-  NextTurn = "NextTurn",
-  Scene = "Scene",
-  Mission = "Mission",
+  NextTurnStartSelf = "next_turn_start_self",
+  NextTurnEndSelf = "next_turn_end_self",
+  NextTurnStartTarget = "next_turn_start_target",
+  NextTurnEndTarget = "next_turn_end_target",
+  // RoundStart = "round_start_",
+  // RoundEnd = "round_end_"
+}
+
+export enum Target {
+  Self = "self",
+  Ally = "ally",
+  Enemy = "enemy",
+}
+
+export enum Frequency {
+  Unlimited = "unlimited",
+  Round = "1/round",
+  Turn = "1/turn",
+  Scene = "1/scene",
+  Encounter = "1/encounter", // Alias of 1/scene
+  Mission = "1/mission",
 }
 
 export enum FrameEffectUse { // Handles cores and traits usage duration thingies
@@ -334,23 +352,32 @@ export enum RangeType {
 export type RangeTypeChecklist = { [key in RangeType]: boolean };
 
 export enum DamageType {
-  Kinetic = "Kinetic",
-  Energy = "Energy",
-  Explosive = "Explosive",
-  Heat = "Heat",
-  Burn = "Burn",
-  Variable = "Variable",
+  Kinetic = "kinetic",
+  Energy = "energy",
+  Explosive = "explosive",
+  Heat = "heat",
+  Burn = "burn",
+  Variable = "variable", // Only in CCv2(?)
+  Aoe = "aoe",
+  All = "all",
 }
 
 export type DamageTypeChecklist = { [key in DamageType]: boolean };
 
 export enum AttackType {
-  Melee = "Melee",
-  Ranged = "Ranged",
-  Tech = "Tech",
+  Melee = "melee",
+  Ranged = "ranged",
+  Tech = "tech",
 }
 
 export type AttackTypeChecklist = { [key in AttackType]: boolean };
+
+export enum OtherEffectType {
+  Overshield = "overshield",
+  Hp = "hp",
+  Repair = "repair",
+  cover = "cover",
+}
 
 export enum MechType {
   Balanced = "Balanced",
@@ -387,12 +414,6 @@ export enum OrgType {
   Industrial = "Industrial",
   Entertainment = "Entertainment",
   Political = "Political",
-}
-
-export enum EncounterSide {
-  Enemy = "Enemy",
-  Ally = "Ally",
-  Neutral = "Neutral",
 }
 
 export type SynergyLocation =
@@ -436,7 +457,8 @@ export type SynergyLocation =
   | "engineering"
   | "brace"
   | "cascade"
-  | "pilot_weapon";
+  | "pilot_weapon"
+  | "mount";
 export const AllSynergyLocations = [
   "any", // Acts as a wildcard
   "active_effects",
@@ -479,6 +501,7 @@ export const AllSynergyLocations = [
   "brace",
   "cascade",
   "pilot_weapon",
+  "mount",
 ];
 
 export enum DeployableType {

--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -327,7 +327,7 @@ export function bondPower(bond_path: string, power_index: number, options: Helpe
   let bond = resolveHelperDotpath<LancerBOND>(options, bond_path);
   let power = bond?.system.powers[power_index];
   if (!bond || !power) return "";
-  let body = `<span class="desc-text">${power.description}</span>`;
+  let body = `<span class="desc-text">${power.description ?? ""}</span>`;
   return `
     <div class="card clipped bond-power" data-uuid="${bond.uuid}" data-power-index="${power_index}">
       <div class="lancer-header lancer-primary medium clipped-top">
@@ -887,7 +887,7 @@ export function manufacturer_ref(source_path: string, options: HelperOptions): s
 // This if for display purposes and does not provide editable fields
 export function licenseRefView(item_path: string, options: HelperOptions): string {
   let license = resolveHelperDotpath(options, item_path) as LancerLICENSE;
-  const mfr = manufacturerStyle(license.system.manufacturer);
+  const mfr = license.system.manufacturer ? manufacturerStyle(license.system.manufacturer) : "gms";
   return `
     <li class="card clipped ref set" ${ref_params(license)}>
       <div class="lancer-header ${mfr} medium clipped-top" style="grid-area: 1/1/2/3">

--- a/src/module/helpers/pilot.ts
+++ b/src/module/helpers/pilot.ts
@@ -26,7 +26,7 @@ export function talent_view(talent_path: string, options: HelperOptions) {
   for (var i = 0; i < talent.system.curr_rank; i++) {
     let talent_actions = "";
 
-    if (talent.system.ranks[i].actions) {
+    if (talent.system.ranks[i]?.actions) {
       talent_actions = buildActionArrayHTML(talent, `system.ranks.${i}.actions`);
     }
 

--- a/src/module/models/bits/bonus.ts
+++ b/src/module/models/bits/bonus.ts
@@ -65,7 +65,7 @@ export function generateBonus(
 export function unpackBonus(data: PackedBonusData): BonusData {
   return {
     lid: data.id,
-    val: data.val.toString(),
+    val: data.val?.toString() ?? "",
     damage_types: data.damage_types ? Damage.MakeChecklist(data.damage_types) : null,
     range_types: data.range_types ? Range.MakeChecklist(data.range_types) : null,
     weapon_sizes: data.weapon_sizes ? makeWeaponSizeChecklist(data.weapon_sizes) : null,

--- a/src/module/models/items/pilot_armor.ts
+++ b/src/module/models/items/pilot_armor.ts
@@ -48,7 +48,7 @@ export function unpackPilotArmor(
       synergies: data.synergies?.map(unpackSynergy),
       counters: undefined,
       deployables: deployables ?? [],
-      description: data.description,
+      description: data.description ?? "",
       effect: data.effect,
       lid: data.id,
       tags: tags ?? [],

--- a/src/module/models/items/pilot_gear.ts
+++ b/src/module/models/items/pilot_gear.ts
@@ -48,7 +48,7 @@ export function unpackPilotGear(
       synergies: data.synergies?.map(unpackSynergy),
       counters: undefined,
       deployables: deployables ?? [],
-      description: data.description,
+      description: data.description ?? "",
       effect: data.effect,
       lid: data.id,
       tags: tags ?? [],

--- a/src/module/models/items/pilot_weapon.ts
+++ b/src/module/models/items/pilot_weapon.ts
@@ -59,9 +59,9 @@ export function unpackPilotWeapon(
       counters: undefined,
       deployables: deployables ?? [],
 
-      description: data.description,
-      range: data.range.map(unpackRange),
-      damage: data.damage.map(unpackDamage),
+      description: data.description ?? "",
+      range: data.range?.map(unpackRange) ?? [],
+      damage: data.damage?.map(unpackDamage) ?? [],
       effect: data.effect,
       loaded: undefined,
 

--- a/src/module/util/compcon.ts
+++ b/src/module/util/compcon.ts
@@ -8,10 +8,13 @@ import type { PackedPilotData } from "./unpacking/packed-types";
 // (they could also re-login, we initiate a cache refresh there)
 
 let _cache: CachedCloudPilot[] = [];
-const CC_V2_SHARE_ENDPOINT = "https://api.compcon.app/share";
-const CC_V3_API_ENDPOINT = "https://idu55qr85i.execute-api.us-east-1.amazonaws.com/prod";
-const CC_V3_CLOUDFRONT_BASE = "https://ds69h3g1zxwgy.cloudfront.net";
-const CC_V3_API_KEY = "Y5DnZ4miJi30iazqn9VV73A253Db7HRxamHEQeMr";
+const CC_API_KEY = "fcFvjjrnQy2hypelJQi4X9dRI55r5KuI4bC07Maf";
+const CC_API_URI = "https://api.compcon.app";
+const CC_BUCKET_URI = "https://ds69h3g1zxwgy.cloudfront.net";
+
+/** Alternate v3 code API used before official compcon.app v3 routes were wired in Foundry. */
+const CC_V3_LEGACY_API_ENDPOINT = "https://idu55qr85i.execute-api.us-east-1.amazonaws.com/prod";
+const CC_V3_LEGACY_API_KEY = "Y5DnZ4miJi30iazqn9VV73A253Db7HRxamHEQeMr";
 
 type ProxyRequestPayload = {
   url: string;
@@ -89,34 +92,75 @@ export function pilotCache(): CachedCloudPilot[] {
   return _cache;
 }
 
-async function fetchPilotViaLegacyShareCode(sharecode: string): Promise<PackedPilotData> {
+export async function fetchV2PilotViaShareCode(sharecode: string): Promise<PackedPilotData> {
   const shareCodeResponse = await fetchWithOptionalShareProxy(
-    `${CC_V2_SHARE_ENDPOINT}?code=${encodeURIComponent(sharecode)}`,
+    `${CC_API_URI}/share?code=${encodeURIComponent(sharecode)}`,
     {
       headers: {
-        "x-api-key": "fcFvjjrnQy2hypelJQi4X9dRI55r5KuI4bC07Maf",
+        "x-api-key": CC_API_KEY,
       },
     }
   );
 
   if (!shareCodeResponse.ok) {
-    throw new Error(`Legacy share endpoint returned HTTP ${shareCodeResponse.status}`);
+    throw new Error(`V2 share endpoint returned HTTP ${shareCodeResponse.status}`);
   }
 
   const shareObj = await shareCodeResponse.json();
   if (!shareObj?.presigned) {
-    throw new Error("Legacy share endpoint did not return a presigned URL");
+    throw new Error("V2 share endpoint did not return a presigned URL");
   }
 
   const pilotResponse = await fetchWithOptionalShareProxy(shareObj["presigned"]);
   if (!pilotResponse.ok) {
-    throw new Error(`Legacy presigned pilot fetch returned HTTP ${pilotResponse.status}`);
+    throw new Error(`V2 presigned pilot fetch returned HTTP ${pilotResponse.status}`);
   }
   return await pilotResponse.json();
 }
 
-async function fetchPilotViaV3ShareCode(sharecode: string): Promise<PackedPilotData> {
-  const query = new URL(`${CC_V3_API_ENDPOINT}/code`);
+/**
+ * Fetches multiple pilot share codes from CCv3 at once (official compcon.app API).
+ */
+export async function fetchV3PilotViaShareCodes(sharecodes: string[]): Promise<PackedPilotData[]> {
+  const shareCodeResponse = await fetchWithOptionalShareProxy(
+    `${CC_API_URI}/v3/code?codes=${encodeURIComponent(JSON.stringify(sharecodes))}&scope=items`,
+    {
+      headers: {
+        "x-api-key": CC_API_KEY,
+      },
+    }
+  );
+
+  if (!shareCodeResponse.ok) {
+    throw new Error(`V3 share endpoint returned HTTP ${shareCodeResponse.status}`);
+  }
+
+  const sourceObjs: { uri: string }[] = await shareCodeResponse.json();
+  const sources = sourceObjs.map(o => o.uri);
+
+  return Promise.all(
+    sources.map(source =>
+      fetchWithOptionalShareProxy(`${CC_BUCKET_URI}/${source}`, { cache: "no-cache" }).then(res => {
+        if (!res.ok) throw new Error(`V3 pilot fetch returned HTTP ${res.status}`);
+        return res.json();
+      })
+    )
+  );
+}
+
+/**
+ * Wrapper for `fetchV3PilotViaShareCodes`
+ */
+export async function fetchV3PilotViaShareCode(sharecode: string): Promise<PackedPilotData> {
+  try {
+    return (await fetchV3PilotViaShareCodes([sharecode]))[0];
+  } catch (officialErr) {
+    return await fetchPilotViaLegacyV3ShareCode(sharecode, officialErr);
+  }
+}
+
+async function fetchPilotViaLegacyV3ShareCode(sharecode: string, officialErr: unknown): Promise<PackedPilotData> {
+  const query = new URL(`${CC_V3_LEGACY_API_ENDPOINT}/code`);
   query.searchParams.append("scope", "download");
   query.searchParams.append("codes", JSON.stringify([sharecode]));
 
@@ -124,41 +168,44 @@ async function fetchPilotViaV3ShareCode(sharecode: string): Promise<PackedPilotD
     method: "GET",
     headers: {
       "Content-Type": "application/json",
-      "x-api-key": CC_V3_API_KEY,
+      "x-api-key": CC_V3_LEGACY_API_KEY,
     },
   });
 
   if (!codeLookupResponse.ok) {
-    throw new Error(`V3 share endpoint returned HTTP ${codeLookupResponse.status}`);
+    const legacyMsg = officialErr instanceof Error ? officialErr.message : String(officialErr);
+    throw new Error(
+      `V3 share import failed (official API and legacy API). Official: ${legacyMsg}; legacy HTTP ${codeLookupResponse.status}`
+    );
   }
 
   const codeLookupJson = await codeLookupResponse.json();
   if (!codeLookupJson?.uri) {
-    throw new Error("V3 share endpoint did not return a downloadable URI");
+    throw new Error("V3 legacy share endpoint did not return a downloadable URI");
   }
 
-  const pilotResponse = await fetchWithOptionalShareProxy(`${CC_V3_CLOUDFRONT_BASE}/${codeLookupJson.uri}`, {
+  const pilotResponse = await fetchWithOptionalShareProxy(`${CC_BUCKET_URI}/${codeLookupJson.uri}`, {
     cache: "no-cache",
   });
   if (!pilotResponse.ok) {
-    throw new Error(`V3 cloudfront pilot fetch returned HTTP ${pilotResponse.status}`);
+    throw new Error(`V3 legacy cloudfront pilot fetch returned HTTP ${pilotResponse.status}`);
   }
 
-  const pilotData = (await pilotResponse.json()) as PackedPilotData;
-  return pilotData;
+  return (await pilotResponse.json()) as PackedPilotData;
 }
 
+/** Tries v3 then v2 share endpoints when code format is unknown. */
 export async function fetchPilotViaShareCode(sharecode: string): Promise<PackedPilotData> {
   const trimmedCode = sharecode.trim();
   let v3Error: unknown = null;
   try {
-    return await fetchPilotViaV3ShareCode(trimmedCode);
+    return await fetchV3PilotViaShareCode(trimmedCode);
   } catch (err) {
     v3Error = err;
   }
 
   try {
-    return await fetchPilotViaLegacyShareCode(trimmedCode);
+    return await fetchV2PilotViaShareCode(trimmedCode);
   } catch (legacyErr) {
     const v3Message = v3Error instanceof Error ? v3Error.message : String(v3Error);
     const legacyMessage = legacyErr instanceof Error ? legacyErr.message : String(legacyErr);
@@ -168,7 +215,7 @@ export async function fetchPilotViaShareCode(sharecode: string): Promise<PackedP
         "All share-code import paths failed with browser fetch errors. This is usually CORS blocking for localhost origins. Use JSON import, or set a COMP/CON Share Import Proxy URL in System Settings."
       );
     }
-    throw new Error(`All share-code import paths failed. v3: ${v3Message}; legacy: ${legacyMessage}`);
+    throw new Error(`All share-code import paths failed. v3: ${v3Message}; v2: ${legacyMessage}`);
   }
 }
 

--- a/src/module/util/requests.ts
+++ b/src/module/util/requests.ts
@@ -54,8 +54,8 @@ export function deployableName(baseName: string, owner: LancerActor | null): str
   let ownerName = owner.name;
   if (owner.is_pilot()) {
     ownerName = owner.system.callsign || owner.name;
-  } else if (owner.is_mech() && owner.system.pilot?.status == "resolved") {
-    ownerName = owner.system.pilot.value.system.callsign || owner.system.pilot.value.name;
+  } else if (owner.is_mech()) {
+    ownerName = owner.name;
   }
 
   return `${baseName} [${ownerName}]`;

--- a/src/module/util/unpacking/packed-types.ts
+++ b/src/module/util/unpacking/packed-types.ts
@@ -11,10 +11,24 @@ import {
   SystemType,
   WeaponSize,
   WeaponType,
+  HASE,
+  Target,
+  StatusConditionType,
+  OtherEffectType,
+  AttackType,
+  PilotItemType,
 } from "../../enums";
 
+export interface PackedBrewData {
+  LcpId: string;
+  LcpName: string;
+  LcpVersion: string;
+  Website: string;
+  Status: string;
+}
+
 export interface PackedActionData {
-  name?: string;
+  name?: string; // Required in CCv3
   activation: ActivationType;
   cost?: number;
   frequency?: string;
@@ -35,6 +49,17 @@ export interface PackedActionData {
   id?: string;
   damage?: PackedDamageData[];
   range?: PackedRangeData[];
+
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/actions
+  bonus_damage?: string; // XdY+Z; where X is the number of dice, dY is the dice type, and Z is a flat bonus. Z and X are optional
+  active_effects?: PackedActiveEffectData[];
+  add_status?: PackedStatusEffectData[];
+  add_resist?: PackedResistanceData[];
+  add_special?: PackedSpecialData[];
+  remove_special?: string[];
+  add_other?: PackedOtherEffectData[];
+  save?: HASE | PackedSaveData;
 }
 
 export interface PackedSkillData {
@@ -44,20 +69,105 @@ export interface PackedSkillData {
   detail: string; // v-html
   family: any; // These exist in lancer-data, but we will purposefully ignore them
   rank?: number;
+}
+
+export interface PackedSkillWrapper {
+  data: PackedSkillData;
+}
+
+export interface PackedCustomSkillData {
   custom?: true;
   custom_desc?: string;
   custom_detail?: string;
 }
 
+// New in CCv3:
+// https://github.com/massif-press/lancer-data/wiki/active-effects
+export interface PackedActiveEffectData {
+  name: string;
+  detail: string;
+  condition?: string;
+  frequency?: string;
+  duration?: string;
+  bonus_damage?: string; // XdY+Z; where X is the number of dice, dY is the dice type, and Z is a flat bonus. Z and X are optional
+  damage: PackedDamageData;
+  range: PackedRangeData;
+  add_status?: PackedStatusData[];
+  add_resist?: PackedResistanceData[];
+  add_special?: PackedSpecialData[];
+  remove_special?: string[];
+  add_other?: PackedOtherEffectData;
+  save?: HASE | PackedSaveData;
+  attack?: AttackType;
+  pilot?: boolean;
+  mech?: boolean;
+}
+
+// New in CCv3:
+// https://github.com/massif-press/lancer-data/wiki/active-effects#add_status
+export interface PackedStatusEffectData {
+  id: string;
+  duration?: string;
+  save?: HASE;
+  aoe?: string | boolean;
+  target?: Target;
+}
+
+// New in CCv3:
+// https://github.com/massif-press/lancer-data/wiki/active-effects#add_resist
+export interface PackedResistanceData {
+  immunity?: DamageType | StatusConditionType;
+  resistance?: DamageType;
+  vulnerability?: DamageType;
+  target?: Target;
+}
+
+// New in CCv3:
+// https://github.com/massif-press/lancer-data/wiki/active-effects#add_special
+export interface PackedSpecialData {
+  attribute: string;
+  detail?: string;
+  target?: Target;
+  duration?: string;
+}
+
+// New in CCv3:
+// https://github.com/massif-press/lancer-data/wiki/active-effects#add_other
+export interface PackedOtherEffectData {
+  type: OtherEffectType;
+  val: any;
+  target?: Target;
+  aoe: string | boolean;
+}
+
+// New in CCv3:
+// https://github.com/massif-press/lancer-data/wiki/active-effects#save
+export interface PackedSaveData {
+  stat: HASE;
+  aoe?: string | boolean;
+}
+
 export interface PackedDamageData {
-  type?: DamageType;
-  val?: string | number;
+  type?: DamageType; // Required in CCv3
+  val?: string | number; // Required in CCv3
   override?: boolean; // If player can set the damage of this, I guess????
+
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/damage#IDamageData
+  aoe?: boolean | string;
+  save?: HASE | PackedSaveData;
+  save_half?: string;
+  ap?: boolean;
+  target?: Target;
 }
 
 export interface PackedRangeData {
-  type?: RangeType;
-  val?: string | number;
+  type?: RangeType; // Required in CCv3
+  val?: string | number; // Required in CCv3
+
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/range
+  min?: number;
 }
 
 export interface PackedBonusData {
@@ -71,6 +181,10 @@ export interface PackedBonusData {
   // ugh
   overwrite?: boolean;
   replace?: boolean;
+
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/bonuses
+  accuracy?: number;
 }
 
 export interface PackedSynergyData {
@@ -144,9 +258,6 @@ export interface PackedCounterSaveData {
 export interface PackedRankedData {
   id: string;
   rank: number;
-  custom?: boolean;
-  custom_desc?: string;
-  custom_detail?: string;
 }
 
 export interface PackedAmmoData {
@@ -188,8 +299,33 @@ export interface PackedOrganizationData {
   lid: string;
 }
 
+// Starting in CCv3, pilot export data is nested inside of `data`
+export interface PackedPilotWrapper {
+  EXPORT_TYPE: string;
+  data: PackedPilotData;
+}
+
+// In CCv2 bond progression is baked into the pilot data directly
+export interface PackedBondProgressData {
+  bondId: string;
+  xp: number;
+  stress: number;
+  maxStress: number;
+  burdens: PackedClockBurdenData[];
+  clocks: PackedClockBurdenData[];
+  bondPowers: PackedBondPowerData[];
+  powerSelections: number;
+  bondAnswers: string[];
+  minorIdeal: string;
+}
+
+export interface PackedPortraitData {
+  portrait: string;
+  cloud_portrait: string;
+}
+
 // The compcon export format. This stuff just gets converted into owned items.
-export interface PackedPilotData {
+export interface PackedPilotData extends PackedBondProgressData {
   campaign: string;
   group: string;
   sort_index: number;
@@ -204,28 +340,26 @@ export interface PackedPilotData {
   text_appearance: string;
   notes: string;
   history: string;
+
   portrait: string;
   cloud_portrait: string;
+  img: PackedPortraitData; // New in CCv3; replaces cloud_portrait
+
   background: string;
   mechSkills: [number, number, number, number];
   cc_ver: string;
 
   id: string;
-  licenses: PackedRankedData[];
-  skills: Array<PackedRankedData | (PackedSkillData & { custom: true })>;
-  talents: PackedRankedData[];
+  licenses: (PackedRankedData & PackedLicenseData & PackedLicenseWrapper)[];
+  skills: (PackedRankedData & (PackedSkillWrapper | PackedCustomSkillData))[];
+  talents: (PackedRankedData & PackedTalentWrapper)[];
   reserves: PackedReserveData[];
   orgs: PackedOrganizationData[];
-  bondId: string;
-  xp: number;
-  stress: number;
-  maxStress: number;
-  burdens: PackedClockBurdenData[];
-  clocks: PackedClockBurdenData[];
-  bondPowers: PackedBondPowerData[];
-  powerSelections: number;
-  bondAnswers: string[];
-  minorIdeal: string;
+
+  stats: PackedCurrentStatsData;
+  bond?: PackedBondWrapper & PackedBondProgressData;
+
+  favorite_mech?: string; // New in CCv3; default selection for CC's 'Active Mode' & used as the default active mech in import
   mechs: PackedMechData[];
   state?: IMechState;
   counter_data: PackedCounterSaveData[];
@@ -255,7 +389,7 @@ export interface PackedPilotData {
   loadout?: PackedPilotLoadoutData;
   loadouts?: PackedPilotLoadoutData[];
   brews: string[];
-  core_bonuses: string[];
+  core_bonuses: string[] | PackedCoreBonusData[]; // in CCv3 it may be an array of PackedCoreBonusData
   factionID: string;
   quirk: string;
   current_hp: number;
@@ -265,11 +399,15 @@ export interface PackedPilotData {
 export interface PackedPilotLoadoutData {
   id: string;
   name: string;
-  armor: (PackedPilotEquipmentState | null)[]; // Accounts for gaps in the inventory slots.... Were it my call this wouldn't be how it was, but it ain't my way
-  weapons: (PackedPilotEquipmentState | null)[];
-  gear: (PackedPilotEquipmentState | null)[];
-  extendedWeapons: (PackedPilotEquipmentState | null)[];
-  extendedGear: (PackedPilotEquipmentState | null)[];
+  armor: ((PackedPilotEquipmentState & PackedPilotEquipmentWrapper) | null)[]; // Accounts for gaps in the inventory slots.... Were it my call this wouldn't be how it was, but it ain't my way
+  weapons: ((PackedPilotEquipmentState & PackedPilotEquipmentWrapper) | null)[];
+  gear: ((PackedPilotEquipmentState & PackedPilotEquipmentWrapper) | null)[];
+  extendedWeapons: ((PackedPilotEquipmentState & PackedPilotEquipmentWrapper) | null)[];
+  extendedGear: ((PackedPilotEquipmentState & PackedPilotEquipmentWrapper) | null)[];
+}
+
+export interface PackedPilotEquipmentWrapper {
+  data: PackedPilotEquipmentData;
 }
 
 export interface PackedPilotEquipmentState {
@@ -312,12 +450,14 @@ export interface PackedMechData {
   gm_note: string;
   portrait: string;
   cloud_portrait: string;
+  img: PackedPortraitData; // New in CCv3; replaces cloud_portrait
   overshield: number;
   burn: number;
   ejected: boolean;
   meltdown_imminent: boolean; // TODO: Make this active effect
   cc_ver: string;
   core_active: boolean;
+  coreActive: boolean; // New in CCv3; replaces core_active
 
   id: string;
   active: boolean;
@@ -327,8 +467,11 @@ export interface PackedMechData {
   current_heat: number;
   current_repairs: number;
   current_core_energy: number;
+  corePower: number; // New in CCv3
   current_overcharge: number;
+  stats: PackedCurrentStatsData; // New in CCv3
   frame: string;
+  frameData: PackedFrameData; // New in CCv3
   statuses: string[];
   conditions: string[];
   resistances: string[];
@@ -343,27 +486,74 @@ export interface PackedMechData {
   defeat: string;
 }
 
+export interface PackedCurrentStatsData {
+  max: PackedStatsData;
+  current: PackedStatsData;
+  stat_version: number;
+}
+
+export interface PackedStatsData {
+  activations: number;
+  size: number;
+  sizes: number[];
+  structure: number;
+  hull: number;
+  agi: number;
+  sys: number;
+  eng: number;
+  hp: number;
+  armor: number;
+  stress: number;
+  heat: number;
+  speed: number;
+  evasion: number;
+  edef: number;
+  sensorRange: number;
+  saveTarget: number;
+  overshield: number;
+  overcharge: number;
+  burn: number;
+  grit: number;
+  limitedBonus: number;
+  heatcap?: number;
+  repairCapacity?: number;
+  techAttack?: number;
+  grapple?: number;
+  ram?: number;
+  attack?: number;
+  sp?: number;
+}
+
 export interface PackedMechLoadoutData {
   id: string;
   name: string;
-  systems: PackedEquipmentData[];
-  integratedSystems: PackedEquipmentData[];
+  systems: (PackedMechEquipmentData & PackedMechEquipmentWrapper)[];
+  integratedSystems: (PackedMechEquipmentData & PackedMechEquipmentWrapper)[];
   mounts: PackedMountData[];
-  integratedMounts: { weapon: PackedMechWeaponSaveData }[];
+  integratedMounts: { weapon: PackedMechWeaponSaveData & PackedMechWeaponSaveWrapper }[];
   improved_armament: PackedMountData;
   integratedWeapon: PackedMountData;
   superheavy_mounting: PackedMountData;
 }
 
-export interface PackedEquipmentData {
+export interface PackedMechEquipmentData {
   id: string;
   destroyed: boolean;
   cascading: boolean;
   note: string;
+
   uses?: number;
   flavorName?: string;
   flavorDescription?: string;
   customDamageType?: string;
+
+  // New in CCv3
+  currentUses?: number;
+  maxUses?: number;
+}
+
+export interface PackedMechEquipmentWrapper {
+  data: PackedMechSystemData;
 }
 
 export interface PackedMountData {
@@ -371,19 +561,27 @@ export interface PackedMountData {
   lock?: boolean; // Superheavy bracing
   slots: PackedWeaponSlotData[];
   extra: PackedWeaponSlotData[];
-  bonus_effects: string[]; // "cb_mount_retrofitting", "cb_auto_stabilizing_hardpoints"
+  bonus_effects: string[];
 }
 
 export interface PackedWeaponSlotData {
   size: FittingSize; // Superheavy? look into that
-  weapon: PackedMechWeaponSaveData | null;
+  weapon: (PackedMechWeaponSaveData & PackedMechWeaponSaveWrapper) | null;
 }
 
-export interface PackedMechWeaponSaveData extends PackedEquipmentData {
+export interface PackedMechWeaponSaveData extends PackedMechEquipmentData {
   loaded: boolean;
-  mod?: PackedEquipmentData;
+  mod?: PackedMechEquipmentData & PackedWeaponModSaveWrapper;
   customDamageType?: string;
   maxUseOverride?: number;
+}
+
+export interface PackedMechWeaponSaveWrapper {
+  data: PackedMechWeaponData;
+}
+
+export interface PackedWeaponModSaveWrapper {
+  data: PackedWeaponModData;
 }
 
 export interface IContentPackManifest {
@@ -400,7 +598,7 @@ export interface IContentPackData {
   factions?: PackedFactionData[];
   coreBonuses?: PackedCoreBonusData[];
   frames?: PackedFrameData[];
-  weapons?: PackedMechWeaponData[];
+  weapons?: PackedMechWeaponData;
   systems?: PackedMechSystemData[];
   mods?: PackedWeaponModData[];
   pilotGear?: PackedPilotEquipmentData[];
@@ -448,37 +646,68 @@ interface PackedFactionData {
 }
 
 export interface PackedCoreBonusData {
+  id: string;
   name: string;
+  source: string; // must be the same as the Manufacturer ID to sort correctly
   effect: string; // v-html
   description: string; // v-html
+
   mounted_effect?: string;
   synergies?: PackedSynergyData[];
-  id: string;
   bonuses?: PackedBonusData[];
   deployables?: PackedDeployableData[];
   counters?: PackedCounterData[];
   integrated?: string[];
-  source: string; // must be the same as the Manufacturer ID to sort correctly
   actions?: PackedActionData[];
+
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/core-bonuses
+  active_effects?: PackedActiveEffectData[];
+  special_equipment?: string[];
+}
+
+export interface PackedLicenseWrapper {
+  stub: PackedLicenseData;
+}
+
+export interface PackedLicenseData {
+  id: string;
+  name: string;
+  source: string;
+  frameName: string;
+  brew: PackedBrewData;
 }
 
 export interface PackedFrameData {
-  license_id?: string;
-  license_level: number; // set to zero for this item to be available to a LL0 character
+  id: string;
   name: string;
+  source: string;
+  license_id?: string; // Required in CCv3 if `variant` is `true`
+  license_level: number; // set to zero for this item to be available to a LL0 character
   mechtype: string[]; // can be customized
-  y_pos: number; // used for vertical alignment of the mech in banner views (like in the new mech selector)
   description: string; // v-html
   mounts: MountType[];
   stats: IFrameStats;
-  image_url?: string;
-  other_art?: IArtLocation[];
-  id: string;
   traits: PackedFrameTraitData[];
   core_system: PackedCoreSystemData;
-  source: string;
+
+  image_url?: string;
+  other_art?: IArtLocation[]; // Does not exist in CCv3
+  y_pos: number; // used for vertical alignment of the mech in banner views (like in the new mech selector)
   variant?: string; // If an alt frame, this is the primary license name
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/frames
+  speciality?: PackedPrerequisiteData;
 }
+
+// For frameless licenses
+// https://github.com/massif-press/lancer-data/wiki/frames#specialty
+export interface PackedPrerequisiteData {
+  source: string;
+  min_rank: number;
+  cumulative?: boolean;
+}
+
 export interface IFrameStats {
   size: number;
   structure: number;
@@ -500,28 +729,29 @@ export interface PackedCoreSystemData {
   name: string;
   description: string; // v-html
   activation: ActivationType;
+  active_name: string;
+  active_effect: string; // v-html
+
   deactivation?: ActivationType;
   use?: FrameEffectUse;
 
-  //
-  active_name: string;
-  active_effect: string; // v-html
-  active_synergies: PackedSynergyData[];
+  active_effects?: PackedActiveEffectData[]; // New in CCv3
+  active_actions?: PackedActionData[];
+  active_bonuses?: PackedBonusData[];
+  active_synergies?: PackedSynergyData[]; // Optional in CCv3
 
-  // Basically the same but passives
   passive_name?: string;
   passive_effect?: string; // v-html,
+  passive_actions?: PackedActionData[];
+  passive_bonuses?: PackedBonusData[];
   passive_synergies?: PackedSynergyData[];
 
   // And all the rest
   deployables?: PackedDeployableData[];
   counters?: PackedCounterData[];
   integrated?: string[];
+  special_equipment?: string[]; // New in CCv3
   tags: PackedTagInstanceData[];
-  active_bonuses?: PackedBonusData[];
-  passive_bonuses?: PackedBonusData[];
-  active_actions?: PackedActionData[];
-  passive_actions?: PackedActionData[];
 }
 
 export interface PackedTagInstanceData {
@@ -538,6 +768,7 @@ export interface IArtLocation {
 export interface PackedFrameTraitData {
   name: string;
   description: string; // v-html
+
   use?: FrameEffectUse;
   synergies?: PackedSynergyData[];
   integrated?: string[];
@@ -545,6 +776,11 @@ export interface PackedFrameTraitData {
   deployables?: PackedDeployableData[];
   bonuses?: PackedBonusData[];
   actions?: PackedActionData[];
+
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/frame-traits
+  special_equipment?: string[];
+  active_effects?: PackedActiveEffectData[];
 }
 
 export interface PackedMechWeaponData {
@@ -582,31 +818,45 @@ export interface PackedMechWeaponData {
   no_mods?: boolean;
   no_core_bonus?: boolean;
   license_id?: string;
+
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/weapons
+  special_equipment?: string[];
+  active_effects?: PackedActiveEffectData[];
+  ammo?: PackedAmmoData[];
 }
 export type PackedMechWeaponProfile = Partial<
   Omit<PackedMechWeaponData, "id" | "profiles" | "source" | "license" | "license_level" | "mount" | "sp">
 >;
 
 export interface PackedMechSystemData {
+  id: string;
   name: string;
   license: string; // reference to the Frame name of the associated license
   license_level: number; // set to zero for this item to be available to a LL0 character
-  type?: SystemType;
-  sp: number;
-  description: string; // v-html
-  effect: string; // v-html
-  synergies?: PackedSynergyData[];
 
-  id: string;
+  source: string; // must be the same as the Manufacturer ID to sort correctly; not required if the item is included in a license collection
+  license_id?: string; // Not required if the item is included in a license collection
+
+  type?: SystemType;
+  effect?: string; // v-html; Optional in CCv3
+  description?: string; // v-html; Optional in CCv3
+  sp?: number; // Optional in CCv3
+  synergies?: PackedSynergyData[];
   deployables?: PackedDeployableData[];
   integrated?: string[];
   counters?: PackedCounterData[];
-  bonuses?: PackedBonusData[];
-  actions?: PackedActionData[];
-  ammo?: PackedAmmoData[];
   tags?: PackedTagInstanceData[];
-  source: string; // must be the same as the Manufacturer ID to sort correctly
-  license_id?: string;
+  actions?: PackedActionData[];
+  bonuses?: PackedBonusData[];
+  ammo?: PackedAmmoData[];
+
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/systems
+  no_bonus?: boolean;
+  no_synergy?: boolean;
+  special_equipment?: string[];
+  active_effects?: PackedActiveEffectData[];
 }
 
 export interface PackedWeaponModData {
@@ -638,31 +888,43 @@ export interface PackedWeaponModData {
 
 export type PackedPilotEquipmentData = PackedPilotWeaponData | PackedPilotArmorData | PackedPilotGearData;
 
-interface AllPilotStuffPackedData {
+// Common specs in CCv3 for pilot items:
+// https://github.com/massif-press/lancer-data/wiki/pilot-gear
+export interface PackedPilotItemData {
   id: string;
-  name: string; // v-html
-  description: string;
+  name: string;
+  type: PilotItemType;
+}
+
+// Collated optional specs from CCv3 for pilot items:
+// https://github.com/massif-press/lancer-data/wiki/pilot-gear
+export interface PackedPilotItemOptionalData {
+  description?: string; // v-html; Optional in CCv3
+  tags?: PackedTagInstanceData[];
+  deployables?: PackedDeployableData[];
   actions?: PackedActionData[]; // these are only available to UNMOUNTED pilots
   bonuses?: PackedBonusData[]; // these bonuses are applied to the pilot, not parent system
   synergies?: PackedSynergyData[];
-  deployables?: PackedDeployableData[];
-  tags?: PackedTagInstanceData[];
-}
-
-export interface PackedPilotWeaponData extends AllPilotStuffPackedData {
-  type: "Weapon";
-  damage: PackedDamageData[];
-  range: PackedRangeData[];
+  counters?: PackedCounterData[];
   effect?: string;
-}
-export interface PackedPilotGearData extends AllPilotStuffPackedData {
-  type: "Gear";
-  effect: string;
+
+  // New in CCv3
+  active_effects?: PackedActiveEffectData[];
 }
 
-export interface PackedPilotArmorData extends AllPilotStuffPackedData {
-  type: "Armor";
-  effect: string;
+export interface PackedPilotWeaponData extends PackedPilotItemData, PackedPilotItemOptionalData {
+  type: PilotItemType.Weapon;
+
+  damage?: PackedDamageData[];
+  range?: PackedRangeData[];
+}
+
+export interface PackedPilotGearData extends PackedPilotItemData, PackedPilotItemOptionalData {
+  type: PilotItemType.Gear;
+}
+
+export interface PackedPilotArmorData extends PackedPilotItemData, PackedPilotItemOptionalData {
+  type: PilotItemType.Armor;
 }
 
 export interface PackedTalentData {
@@ -672,18 +934,30 @@ export interface PackedTalentData {
   terse: string; // terse text used in short descriptions. The fewer characters the better
   description: string; // v-html
   ranks: PackedTalentRank[];
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/talents
+  icon_svg: string; // Strongly preferred
+  icon_url: string;
+}
+
+export interface PackedTalentWrapper {
+  data: PackedTalentData;
 }
 
 export interface PackedTalentRank {
   name: string;
   description: string; // v-html
-  exclusive: boolean; // see below
+  exclusive?: boolean;
   actions?: PackedActionData[];
   bonuses?: PackedBonusData[];
   synergies?: PackedSynergyData[];
   deployables?: PackedDeployableData[];
   counters?: PackedCounterData[];
   integrated?: string[];
+}
+
+export interface PackedBondWrapper {
+  data: PackedBondData;
 }
 
 export interface PackedBondData {
@@ -829,10 +1103,15 @@ export interface PackedNpcTemplateData {
 export interface PackedStatusData {
   name: string;
   icon: string;
+  type: "Status" | "Condition";
+  effects: string | string[];
   id?: string;
   terse?: string;
-  effects: string | string[];
-  type: "Status" | "Condition";
+  // New in CCv3:
+  // https://github.com/massif-press/lancer-data/wiki/statuses-&-conditions
+  icon_svg?: string; // inline SVG string
+  icon_url?: string;
+  exclusive?: "Mech" | "Pilot";
 }
 
 export interface PackedEnvironmentData {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.12.7",
+  "version": "2.12.8",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.7/lancer-v2.12.7.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.8/lancer-v2.12.8.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports COMP/CON **v3 pilot import** (upstream Eranziel #934) and verifies end-to-end import with share code **`I2RAI4F5MLPG`** (pilot **saziment Allara** / callsign **Stingray**).

## Changes

- `importCCv3` / `importCCv2` routing, packed types, pilot-sheet v3/v2 share-code matchers
- Official `api.compcon.app` v3 share fetch (+ share-proxy + legacy API fallback)
- **Fix:** v3 share codes return `originId` on the top-level pilot object without a `data` wrapper — `importCC` now wraps before calling `importCCv3`

## Verification

- API: `GET /v3/code` returns 200 for `I2RAI4F5MLPG`
- Foundry (Docker, `dist` mount): RM-4://SYNC tab → enter code → re-open sheet → Download → pilot updates to **saziment Allara** / **Stingray**
- Minor non-blocking warning during import: `Cannot read properties of undefined (reading 'name')` (tracked for follow-up)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

