### PR TITLE
fix(ci): verify-git-remote no longer fails on AGENTS.md fork policy

### DIFF
--- a/.github/workflows/verify-git-remote.yml
+++ b/.github/workflows/verify-git-remote.yml
@@ -25,8 +25,4 @@ jobs:
           done
 
       - name: Fail if tracked sources link to Eranziel repo
-        run: |
-          if grep -rE 'github\.com/Eranziel/foundryvtt-lancer' README.md docs src public .github/ISSUE_TEMPLATE AGENTS.md 2>/dev/null; then
-            echo "Tracked docs and UI must use VacantFanatic/foundryvtt-lancer URLs."
-            exit 1
-          fi
+        run: sh ./scripts/assert-no-eranziel-doc-links.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 This repository is **`VacantFanatic/foundryvtt-lancer`**. **Never push** to **`Eranziel/foundryvtt-lancer`** (any branch, including `master`).
 
 - **`origin`** must stay `https://github.com/VacantFanatic/foundryvtt-lancer` (or SSH equivalent).
-- Do **not** add an `upstream` remote pointing at Eranziel, and do not `git push` a URL under `github.com/Eranziel/foundryvtt-lancer`.
+- Do **not** add an `upstream` remote pointing at Eranziel, and do not `git push` to **`Eranziel/foundryvtt-lancer`** (use `scripts/assert-safe-git-remote.sh` to verify remotes).
 - Cloud agents: use feature branches `cursor/<name>-f727` and open PRs against **`VacantFanatic`** `master` only.
 - **Pre-push hook** (`scripts/assert-safe-git-remote.sh`) and CI workflow **Verify git remote** block Eranziel remotes and accidental push targets.
 - Manual check: `REQUIRE_ALLOWED_ORIGIN=1 sh ./scripts/assert-safe-git-remote.sh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Fixed
+
+- CI **Verify git remote** no longer fails on `AGENTS.md` fork-policy text; doc-link scanning moved to `scripts/assert-no-eranziel-doc-links.sh` (excludes agent docs that describe forbidden upstream targets).
+
 # 2.12.8 (2026-06-05)
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "postinstall": "./scripts/symlink.mjs",
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
+    "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
     "serve": "vite",
     "version": "./scripts/version.mjs && git add src/system.json",
     "watch": "vite build --watch"

--- a/scripts/assert-no-eranziel-doc-links.sh
+++ b/scripts/assert-no-eranziel-doc-links.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# Fails if user-facing docs or UI link to the upstream Eranziel repo.
+# AGENTS.md is excluded: it documents fork policy and may name forbidden targets in prose.
+
+set -eu
+
+FORBIDDEN_PATTERN='github\.com/Eranziel/foundryvtt-lancer'
+SCAN_PATHS="README.md docs src public .github/ISSUE_TEMPLATE"
+
+if grep -rE "$FORBIDDEN_PATTERN" $SCAN_PATHS 2>/dev/null; then
+  printf '%s\n' \
+    "Tracked docs and UI must use VacantFanatic/foundryvtt-lancer URLs." \
+    "Run: npm run verify:doc-links" >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

**Verify git remote (fork-only)** fails on every push/PR because the doc-link step greps for `github.com/Eranziel/foundryvtt-lancer` in `AGENTS.md`, which intentionally documents that URL as a forbidden push target.

## Fix

- Add `scripts/assert-no-eranziel-doc-links.sh` — scans `README.md`, `docs/`, `src/`, `public/`, and issue templates; **excludes** `AGENTS.md`
- Reword the fork-policy line in `AGENTS.md` to avoid embedding the blocked URL pattern
- Wire CI to the script; add `npm run verify:doc-links` for local checks

## Verification

```bash
REQUIRE_ALLOWED_ORIGIN=1 sh ./scripts/assert-safe-git-remote.sh
npm run verify:doc-links
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e7b1cc6-6bb8-440f-8eed-ad5ac032f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

