### PR TITLE
chore: release v2.12.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.12.10 (2026-06-06)
+
+## Fixed
+
+- COMP/CON **v3 mech weapon import** no longer throws when weapon slot data is missing (early return referenced undeclared `mod`/`modId`).
+- COMP/CON **v3 import** now reports partial failures (missing actors/items) with the same summary dialog as v2.
+
+## Changed
+
+- COMP/CON import cleanup: shared `unpackClock` and incomplete-import summary helpers; v2 reuses `clearPilotEmbeddedDocuments`, `hasCreatePermissions`, and `getActorItemByLid`; unified v3 bond import path.
+
 # 2.12.9 (2026-06-05)
 
 ## Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundryvtt-lancer",
-  "version": "2.12.9",
+  "version": "2.12.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundryvtt-lancer",
-      "version": "2.12.9",
+      "version": "2.12.10",
       "hasInstallScript": true,
       "dependencies": {
         "@massif/dustgrave-data": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.12.9",
+  "version": "2.12.10",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.12.9",
+  "version": "2.12.10",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.9/lancer-v2.12.9.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.10/lancer-v2.12.10.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares **v2.12.10** for release. This ships everything on `master` since the last tagged release (**v2.12.8**), including the v2.12.9 import hardening and the v2.12.10 simplify follow-up (#38).

## Version updates

- `package.json` → `2.12.10`
- `package-lock.json` → `2.12.10`
- `src/system.json` → `2.12.10` with download URL:
  `https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.10/lancer-v2.12.10.zip`

## Changelog

See CHANGELOG.md section **2.12.10 (2026-06-06)**.

## After merge — publish the release

The Release Creation workflow runs on tag push:

```bash
git checkout master
git pull origin master
git tag v2.12.10
git push origin v2.12.10
```

CI will build `dist/`, package `lancer-v2.12.10.zip` + `system.json`, and create the GitHub release.

## Note

`v2.12.9` was bumped in manifests but never tagged; this release consolidates that work under the 2.12.9 changelog section and ships it together with 2.12.10 fixes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4df3148-96a1-4638-84c4-777140faa4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4df3148-96a1-4638-84c4-777140faa4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

