### PR TITLE
Add UX Roadmap 2026 GitHub Project bootstrap

### DIFF
--- a/.github/workflows/ux-roadmap-bootstrap.yml
+++ b/.github/workflows/ux-roadmap-bootstrap.yml
@@ -1,0 +1,40 @@
+# Create or refresh the UX Roadmap 2026 GitHub Project, milestones, labels, and issues.
+# Manual only — requires a PAT or GITHUB_TOKEN with project + issues write on VacantFanatic account.
+name: UX Roadmap bootstrap
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Bootstrap mode
+        required: true
+        default: full
+        type: choice
+        options:
+          - full
+          - issues-only
+          - project-only
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Bootstrap UX roadmap
+        env:
+          GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          MODE="${{ github.event.inputs.mode }}"
+          FLAGS=""
+          if [ "$MODE" = "issues-only" ]; then FLAGS="--issues-only"; fi
+          if [ "$MODE" = "project-only" ]; then FLAGS="--project-only"; fi
+          node scripts/ux-roadmap/bootstrap.mjs $FLAGS

--- a/.github/workflows/ux-roadmap-bootstrap.yml
+++ b/.github/workflows/ux-roadmap-bootstrap.yml
@@ -1,5 +1,9 @@
 # Create or refresh the UX Roadmap 2026 GitHub Project, milestones, labels, and issues.
-# Manual only — requires a PAT or GITHUB_TOKEN with project + issues write on VacantFanatic account.
+#
+# Setup (passkey-friendly, no local gh CLI):
+#   1. Create a fine-grained PAT with Issues + Account Projects (read/write) on this repo.
+#   2. Add repo secret UX_ROADMAP_GH_TOKEN (see scripts/ux-roadmap/MANUAL-SETUP.md).
+#   3. Run workflow manually. GITHUB_TOKEN alone cannot create user-owned Projects.
 name: UX Roadmap bootstrap
 
 on:
@@ -29,9 +33,16 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Require project token
+        if: ${{ !secrets.UX_ROADMAP_GH_TOKEN }}
+        run: |
+          echo "::error::Add repository secret UX_ROADMAP_GH_TOKEN (fine-grained PAT with Projects + Issues)."
+          echo "See scripts/ux-roadmap/MANUAL-SETUP.md — no local gh credentials required."
+          exit 1
+
       - name: Bootstrap UX roadmap
         env:
-          GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN }}
         run: |
           MODE="${{ github.event.inputs.mode }}"
           FLAGS=""

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ foundry.js
 
 # foundryvtt-cli
 fvttrc.yml
+
+# UX roadmap bootstrap local state
+scripts/ux-roadmap/bootstrap-state.json

--- a/scripts/ux-roadmap/MANUAL-SETUP.md
+++ b/scripts/ux-roadmap/MANUAL-SETUP.md
@@ -1,0 +1,147 @@
+# UX Roadmap — setup without local GitHub credentials
+
+Use this guide if you sign in with a **passkey** and do not use `gh` or stored tokens on your dev machine / cloud VM.
+
+**Tracking issues already exist:** epic [#43](https://github.com/VacantFanatic/foundryvtt-lancer/issues/43), releases [#44–#53](https://github.com/VacantFanatic/foundryvtt-lancer/issues/44), PRs [#54–#85](https://github.com/VacantFanatic/foundryvtt-lancer/issues/54).
+
+Pick **Option A** (recommended, ~5 minutes once) or **Option B** (pure browser, no tokens).
+
+---
+
+## Option A — GitHub Actions + one-time fine-grained PAT (recommended)
+
+You only use the browser (passkey) once to create a token and paste it into repo secrets. No CLI on any machine.
+
+### 1. Merge the bootstrap PR
+
+Merge [PR #86](https://github.com/VacantFanatic/foundryvtt-lancer/pull/86) so the workflow and scripts are on `master`.
+
+### 2. Create a fine-grained personal access token
+
+1. Open [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new) (passkey sign-in).
+2. **Token name:** `foundryvtt-lancer-ux-roadmap`
+3. **Expiration:** 90 days (or custom; renew when you refresh the project).
+4. **Resource owner:** your account (`VacantFanatic`).
+5. **Repository access:** Only select repositories → `foundryvtt-lancer`.
+6. **Repository permissions:**
+   - **Issues** — Read and write
+   - **Metadata** — Read-only (required)
+   - **Contents** — Read-only (workflow checkout)
+7. **Account permissions:**
+   - **Projects** — Read and write
+8. Generate token and **copy it** (shown once).
+
+### 3. Add the token as a repository secret
+
+1. [Repo → Settings → Secrets and variables → Actions](https://github.com/VacantFanatic/foundryvtt-lancer/settings/secrets/actions)
+2. **New repository secret**
+3. Name: `UX_ROADMAP_GH_TOKEN`
+4. Value: paste the token → Save
+
+### 4. Run the workflow
+
+1. [Actions → UX Roadmap bootstrap](https://github.com/VacantFanatic/foundryvtt-lancer/actions/workflows/ux-roadmap-bootstrap.yml)
+2. **Run workflow** → branch `master` → mode **`full`** → Run.
+
+This creates labels, milestones, the **UX Roadmap 2026** project, custom fields, and adds issues #43–#85.
+
+If issues already exist, use mode **`project-only`** to skip re-creating them.
+
+### 5. Configure project views (browser, ~2 min)
+
+Open the new project under your profile **Projects** tab, then:
+
+| View name | Layout | Group by | Sort |
+|-----------|--------|----------|------|
+| Roadmap | Roadmap | Release | PR # |
+| Board | Board | Status | Priority |
+| Table | Table | — | Release, then PR # |
+
+### 6. Revoke the token (optional)
+
+After a successful run you can delete the secret and revoke the PAT at [github.com/settings/tokens](https://github.com/settings/tokens). Re-create it only if you run bootstrap again.
+
+---
+
+## Option B — Pure GitHub UI (no PAT, no Actions)
+
+### 1. Create the project
+
+1. [foundryvtt-lancer → Projects](https://github.com/VacantFanatic/foundryvtt-lancer/projects) → **New project**.
+2. Template: **Roadmap** (or Board).
+3. Title: **UX Roadmap 2026**.
+4. Link repository: `foundryvtt-lancer`.
+
+### 2. Add custom fields
+
+In the project → **…** → **Settings** / field menu → **New field**:
+
+| Field | Type | Options |
+|-------|------|---------|
+| Type | Single select | Epic, Release, PR |
+| Release | Single select | v2.12.11, v2.13.0, v2.14.0, v2.15.0, v2.16.0, v2.17.0, v2.18.0, v2.19.0, v2.20.0, v3.0.0 |
+| Sprint | Single select | A, B, C, D, E, F, G |
+| Priority | Single select | P0, P1, P2 |
+| PR # | Number | — |
+
+**Status** is built in (Todo / In progress / Done).
+
+### 3. Add existing issues
+
+Click **+ Add item** → search `repo:VacantFanatic/foundryvtt-lancer [UX` → add all matches (#43–#85).
+
+Or paste issue numbers in bulk if your UI supports multi-add.
+
+### 4. Set field values (filter helpers)
+
+| Filter title | Type | Release | Sprint | Priority |
+|--------------|------|---------|--------|----------|
+| `[UX Epic]` | Epic | — | A | P0 |
+| `[UX Release v2.12.11]` | Release | v2.12.11 | A | P0 |
+| `[UX Release v2.13.0]` | Release | v2.13.0 | B | P0 |
+| `[UX Release v2.14.0]` | Release | v2.14.0 | C | P0 |
+| `[UX Release v2.15.0]` | Release | v2.15.0 | D | P1 |
+| `[UX Release v2.16.0]` | Release | v2.16.0 | E | P1 |
+| `[UX Release v2.17.0]` | Release | v2.17.0 | F | P1 |
+| `[UX Release v2.18.0]` | Release | v2.18.0 | F | P2 |
+| `[UX Release v2.19.0]` | Release | v2.19.0 | F | P1 |
+| `[UX Release v2.20.0]` | Release | v2.20.0 | G | P2 |
+| `[UX Release v3.0.0]` | Release | v3.0.0 | G | P2 |
+| `[UX PR1]` … `[UX PR5]` | PR | v2.12.11 | A | P0 | PR # 1–5 |
+| `[UX PR6]` … `[UX PR9]` | PR | v2.13.0 | B | P0/P1 | PR # 6–9 |
+| `[UX PR10]` … `[UX PR12]` | PR | v2.14.0 | C | P0 | PR # 10–12 |
+| `[UX PR13]` … `[UX PR15]` | PR | v2.15.0 | D | P1 | PR # 13–15 |
+| `[UX PR16]` … `[UX PR21]` | PR | v2.16.0 | E | P1/P2 | PR # 16–21 |
+| `[UX PR22]` … `[UX PR24]` | PR | v2.17.0 | F | P1/P2 | PR # 22–24 |
+| `[UX PR25]` … `[UX PR26]` | PR | v2.18.0 | F | P2 | PR # 25–26 |
+| `[UX PR27]` … `[UX PR29]` | PR | v2.19.0 | F | P1 | PR # 27–29 |
+| `[UX PR30]` … `[UX PR31]` | PR | v2.20.0 | G | P2 | PR # 30–31 |
+| `[UX PR32]` | PR | v3.0.0 | G | P2 | PR # 32 |
+
+Use **Table** view → multi-select rows → edit fields in bulk where possible.
+
+### 5. Milestones & labels (optional)
+
+**Issues → Milestones → New milestone** for each release title in `roadmap.json` (e.g. `v2.12.11 — Trust & polish`).
+
+**Issues → Labels → New label** for `ux-roadmap`, `ux/epic`, `ux/pr`, `priority/p0`, etc.
+
+Assign via issue sidebar or milestone filter — not required for the project board to work.
+
+### 6. Create views
+
+Same as Option A step 5.
+
+---
+
+## Cleanup
+
+Close stray test issues if still open: [#40](https://github.com/VacantFanatic/foundryvtt-lancer/issues/40), [#41](https://github.com/VacantFanatic/foundryvtt-lancer/issues/41), [#42](https://github.com/VacantFanatic/foundryvtt-lancer/issues/42). Canonical epic is **#43**.
+
+---
+
+## Day-to-day (no credentials needed)
+
+- Cloud agents open PRs with `Closes #54` (etc.) — issues close automatically on merge.
+- You triage in the **Project** board in the browser (passkey login).
+- Edits to scope go in `scripts/ux-roadmap/roadmap.json`; re-run Option A workflow `project-only` only if you add new tracking issues via bootstrap.

--- a/scripts/ux-roadmap/README.md
+++ b/scripts/ux-roadmap/README.md
@@ -1,0 +1,64 @@
+# UX Roadmap 2026 — GitHub Project bootstrap
+
+This folder defines the **UX Roadmap 2026** release plan and a script to create:
+
+- GitHub **labels** and **milestones**
+- **Tracking issues** (1 epic, 10 release epics, 32 PR issues)
+- A linked **GitHub Project** with custom fields for Roadmap / Board views
+
+## Quick start (repo owner)
+
+```bash
+# Authenticate with project scope
+gh auth refresh -s project,read:org
+
+# Full bootstrap (issues + project)
+node scripts/ux-roadmap/bootstrap.mjs
+
+# Or step by step:
+node scripts/ux-roadmap/bootstrap.mjs --issues-only   # issues only (works with limited tokens)
+node scripts/ux-roadmap/bootstrap.mjs --project-only  # project + fields after issues exist
+```
+
+Progress is saved to `bootstrap-state.json` (gitignored) so re-runs skip existing issues.
+
+## GitHub Project views (manual, one-time)
+
+After bootstrap, open the project URL printed by the script and add:
+
+| View | Layout | Group by | Sort |
+|------|--------|----------|------|
+| **Roadmap** | Roadmap | Release | PR # |
+| **Board** | Board | Status | Priority |
+| **Release table** | Table | — | Release, PR # |
+
+Enable **Status** field (built-in) for Todo / In Progress / Done.
+
+## Data
+
+- `roadmap.json` — releases, PRs, branches, acceptance criteria (source of truth)
+- `bootstrap.mjs` — creates GitHub artifacts from JSON
+
+## Issue index (generated)
+
+| Kind | Issue |
+|------|-------|
+| **Epic** | [#43](https://github.com/VacantFanatic/foundryvtt-lancer/issues/43) |
+| Release v2.12.11 | [#44](https://github.com/VacantFanatic/foundryvtt-lancer/issues/44) |
+| Release v2.13.0 | [#45](https://github.com/VacantFanatic/foundryvtt-lancer/issues/45) |
+| Release v2.14.0 | [#46](https://github.com/VacantFanatic/foundryvtt-lancer/issues/46) |
+| Release v2.15.0 | [#47](https://github.com/VacantFanatic/foundryvtt-lancer/issues/47) |
+| Release v2.16.0 | [#48](https://github.com/VacantFanatic/foundryvtt-lancer/issues/48) |
+| Release v2.17.0 | [#49](https://github.com/VacantFanatic/foundryvtt-lancer/issues/49) |
+| Release v2.18.0 | [#50](https://github.com/VacantFanatic/foundryvtt-lancer/issues/50) |
+| Release v2.19.0 | [#51](https://github.com/VacantFanatic/foundryvtt-lancer/issues/51) |
+| Release v2.20.0 | [#52](https://github.com/VacantFanatic/foundryvtt-lancer/issues/52) |
+| Release v3.0.0 | [#53](https://github.com/VacantFanatic/foundryvtt-lancer/issues/53) |
+| PR1–PR32 | [#54](https://github.com/VacantFanatic/foundryvtt-lancer/issues/54)–[#85](https://github.com/VacantFanatic/foundryvtt-lancer/issues/85) |
+
+Re-run `bootstrap.mjs` as repo owner to create labels, milestones, the GitHub Project, and refresh epic/release bodies with cross-links.
+
+## Cursor cloud agents
+
+Implementation branches: `cursor/ux-<slug>-4b38`  
+Link PRs to issues: `Closes #<issue>` in PR description (PR *n* → issue *53+n* for PR1=#54).

--- a/scripts/ux-roadmap/README.md
+++ b/scripts/ux-roadmap/README.md
@@ -6,18 +6,22 @@ This folder defines the **UX Roadmap 2026** release plan and a script to create:
 - **Tracking issues** (1 epic, 10 release epics, 32 PR issues)
 - A linked **GitHub Project** with custom fields for Roadmap / Board views
 
-## Quick start (repo owner)
+## Quick start
+
+### Passkey / no local credentials?
+
+**You do not need `gh` on your machine or the cloud VM.** See **[MANUAL-SETUP.md](./MANUAL-SETUP.md)**:
+
+- **Option A (recommended):** one fine-grained PAT in repo secrets → run the **UX Roadmap bootstrap** GitHub Action (passkey only in the browser).
+- **Option B:** create the Project entirely in the GitHub web UI and add issues #43–#85.
+
+### Local CLI (optional)
 
 ```bash
-# Authenticate with project scope
 gh auth refresh -s project,read:org
-
-# Full bootstrap (issues + project)
-node scripts/ux-roadmap/bootstrap.mjs
-
-# Or step by step:
-node scripts/ux-roadmap/bootstrap.mjs --issues-only   # issues only (works with limited tokens)
-node scripts/ux-roadmap/bootstrap.mjs --project-only  # project + fields after issues exist
+node scripts/ux-roadmap/bootstrap.mjs              # full
+node scripts/ux-roadmap/bootstrap.mjs --issues-only
+node scripts/ux-roadmap/bootstrap.mjs --project-only
 ```
 
 Progress is saved to `bootstrap-state.json` (gitignored) so re-runs skip existing issues.

--- a/scripts/ux-roadmap/bootstrap.mjs
+++ b/scripts/ux-roadmap/bootstrap.mjs
@@ -1,0 +1,547 @@
+#!/usr/bin/env node
+/**
+ * Bootstrap the UX Roadmap 2026 GitHub Project, milestones, labels, and tracking issues.
+ *
+ * Usage:
+ *   node scripts/ux-roadmap/bootstrap.mjs              # full bootstrap (needs project scope + owner perms)
+ *   node scripts/ux-roadmap/bootstrap.mjs --issues-only
+ *   node scripts/ux-roadmap/bootstrap.mjs --project-only   # add existing issues to project
+ *   node scripts/ux-roadmap/bootstrap.mjs --dry-run
+ *
+ * Requires: gh CLI authenticated with repo + project scopes.
+ * Run as VacantFanatic (or a user with permission to create Projects on the owner account).
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const roadmapPath = path.join(__dirname, "roadmap.json");
+const statePath = path.join(__dirname, "bootstrap-state.json");
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const issuesOnly = args.has("--issues-only");
+const projectOnly = args.has("--project-only");
+
+const roadmap = JSON.parse(fs.readFileSync(roadmapPath, "utf8"));
+const { project, labels, milestones, releases, prs } = roadmap;
+const REPO = `${project.owner}/${project.repo}`;
+
+function log(...parts) {
+  console.log("[ux-roadmap]", ...parts);
+}
+
+function gh(args, opts = {}) {
+  const cmd = ["gh", ...args];
+  if (dryRun) {
+    log("DRY", cmd.join(" "));
+    return opts.default ?? "";
+  }
+  try {
+    return execFileSync("gh", args, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch (e) {
+    const stderr = e.stderr?.toString() ?? e.message;
+    throw new Error(`gh ${args.join(" ")} failed: ${stderr}`);
+  }
+}
+
+function graphql(query, variables = {}) {
+  const varArgs = Object.entries(variables).flatMap(([k, v]) => ["-f", `${k}=${typeof v === "object" ? JSON.stringify(v) : v}`]);
+  if (dryRun) {
+    log("DRY graphql", query.slice(0, 80).replace(/\s+/g, " "));
+    return {};
+  }
+  const out = gh(["api", "graphql", "-f", `query=${query}`, ...varArgs]);
+  const parsed = JSON.parse(out);
+  if (parsed.errors?.length) {
+    throw new Error(parsed.errors.map(e => e.message).join("; "));
+  }
+  return parsed.data;
+}
+
+function loadState() {
+  if (fs.existsSync(statePath)) {
+    return JSON.parse(fs.readFileSync(statePath, "utf8"));
+  }
+  return { issues: {}, project: null, fields: {} };
+}
+
+function saveState(state) {
+  if (!dryRun) {
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n");
+  }
+}
+
+function releaseMilestoneTitle(releaseId) {
+  const m = milestones.find(ms => ms.title.startsWith(`v${releaseId}`));
+  return m?.title ?? `v${releaseId}`;
+}
+
+function createLabels() {
+  log("Creating labels...");
+  for (const label of labels) {
+    try {
+      gh([
+        "api",
+        `repos/${REPO}/labels`,
+        "-f",
+        `name=${label.name}`,
+        "-f",
+        `color=${label.color}`,
+        "-f",
+        `description=${label.description}`,
+      ]);
+      log("  label", label.name);
+    } catch (e) {
+      if (String(e).includes("already_exists")) {
+        log("  label exists", label.name);
+      } else {
+        log("  label skip", label.name, "-", e.message.split("\n")[0]);
+      }
+    }
+  }
+}
+
+function createMilestones(state) {
+  log("Creating milestones...");
+  state.milestones = state.milestones ?? {};
+  for (const ms of milestones) {
+    if (state.milestones[ms.title]) continue;
+    try {
+      const res = JSON.parse(
+        gh([
+          "api",
+          `repos/${REPO}/milestones`,
+          "-f",
+          `title=${ms.title}`,
+          "-f",
+          `description=${ms.description}`,
+        ])
+      );
+      state.milestones[ms.title] = res.number;
+      log("  milestone", ms.title, "#" + res.number);
+    } catch (e) {
+      log("  milestone skip", ms.title, "-", e.message.split("\n")[0]);
+    }
+  }
+}
+
+function issueLabels(kind, priority) {
+  const p = priority?.toLowerCase() ?? "p1";
+  return ["ux-roadmap", kind === "epic" ? "ux/epic" : "ux/pr", `priority/${p}`];
+}
+
+function createIssue(title, body, { milestone, labels: labelNames = [] }) {
+  const minimal = ["issue", "create", "-R", REPO, "--title", title, "--body", body];
+  const withMilestone = milestone ? [...minimal, "-m", milestone] : minimal;
+  const withLabels = [...withMilestone];
+  for (const l of labelNames) {
+    withLabels.push("-l", l);
+  }
+
+  const attempts = [
+    labelNames.length ? withLabels : withMilestone,
+    withMilestone,
+    minimal,
+  ];
+  const seen = new Set();
+  let lastError;
+  for (const args of attempts) {
+    const key = args.join("\0");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    try {
+      const url = gh(args);
+      const num = parseInt(url.split("/").pop(), 10);
+      log("  issue", `#${num}`, title);
+      return num;
+    } catch (e) {
+      lastError = e;
+    }
+  }
+  throw lastError;
+}
+
+function prBody(pr, state) {
+  const release = releases.find(r => r.id === pr.release);
+  const deps = pr.dependsOn
+    .map(id => {
+      const n = state.issues.pr?.[id];
+      return n ? `#${n}` : `PR${id}`;
+    })
+    .join(", ");
+  const releaseIssue = state.issues.release?.[pr.release];
+
+  return `## UX Roadmap — PR ${pr.id}
+
+| Field | Value |
+|-------|-------|
+| **Release** | v${pr.release} (${release?.semver ?? "minor"}) |
+| **Branch** | \`${pr.branch}\` |
+| **Priority** | ${pr.priority} |
+| **Sprint** | ${release?.sprint ?? "—"} |
+| **Parallel** | ${pr.parallel ? "Yes" : "No — merge in order"} |
+| **Depends on** | ${deps || "None"} |
+| **Release epic** | ${releaseIssue ? `#${releaseIssue}` : `v${pr.release}`} |
+
+### Summary
+${pr.title}
+
+### Files (expected)
+${pr.files.map(f => `- \`${f}\``).join("\n")}
+
+### Acceptance criteria
+${pr.acceptance.map(a => `- [ ] ${a}`).join("\n")}
+
+### Test plan
+- [ ] \`npm run test\`
+- [ ] \`SKIP_FOUNDRY_DIST_MIRROR=1 npm run build\`
+- [ ] Foundry smoke: relevant actor sheet / combat flow
+
+### Changelog
+Add entries under the **v${pr.release}** section in \`CHANGELOG.md\` when implementing.
+
+---
+_Tracking issue for [UX Roadmap 2026](https://github.com/${REPO}/issues/${state.issues.epic}). Do not implement in this issue — open \`${pr.branch}\` instead._
+`;
+}
+
+function releaseBody(rel, state) {
+  const prIds = prs.filter(p => p.release === rel.id).map(p => state.issues.pr?.[p.id]).filter(Boolean);
+  return `## UX Roadmap — Release v${rel.id}
+
+| Field | Value |
+|-------|-------|
+| **Semver bump** | ${rel.semver} |
+| **Sprint** | ${rel.sprint} |
+| **Priority** | ${rel.priority} |
+
+### Summary
+${rel.summary}
+
+### PR issues in this release
+${prIds.map(n => `- [ ] #${n}`).join("\n")}
+
+### Release checklist
+- [ ] All PR issues closed
+- [ ] \`CHANGELOG.md\` section for v${rel.id}
+- [ ] \`npm version ${rel.semver === "patch" ? "patch" : rel.semver === "major" ? "major" : "minor"}\`
+- [ ] Foundry Docker smoke test (AGENTS.md)
+- [ ] GitHub release tag \`v${rel.id}\`
+
+---
+Epic: #${state.issues.epic}
+`;
+}
+
+function epicBody() {
+  return `## UX Roadmap 2026
+
+Master tracker for the Foundry VTT Lancer UX pass (baseline **v2.12.10**).
+
+### GitHub Project
+Run \`node scripts/ux-roadmap/bootstrap.mjs\` (as repo owner with \`project\` scope) to create or refresh the [**UX Roadmap 2026**](https://github.com/users/${project.owner}/projects) board with Roadmap, Table, and Board views.
+
+### Releases
+${releases.map(r => `- **v${r.id}** (${r.semver}) — ${r.title}`).join("\n")}
+
+### Execution order
+| Sprint | Releases |
+|--------|----------|
+| A | v2.12.11 (all PRs parallel) |
+| B | v2.13.0 |
+| C | v2.14.0 |
+| D | v2.15.0 |
+| E | v2.16.0 |
+| F | v2.17.0 – v2.19.0 |
+| G | v2.20.0 (+ optional v3.0.0) |
+
+### Source of truth
+- Data: \`scripts/ux-roadmap/roadmap.json\`
+- Bootstrap: \`scripts/ux-roadmap/bootstrap.mjs\`
+
+### Notes
+- Cloud agent branches use suffix \`-4b38\`
+- PRs target \`VacantFanatic/foundryvtt-lancer\` → \`master\`
+`;
+}
+
+function createIssues(state) {
+  log("Creating tracking issues...");
+
+  if (!state.issues.epic) {
+    state.issues.epic = createIssue(
+      "[UX Epic] UX Roadmap 2026",
+      epicBody(),
+      { labels: issueLabels("epic", "P0") },
+    );
+  }
+
+  state.issues.release = state.issues.release ?? {};
+  for (const rel of releases) {
+    if (state.issues.release[rel.id]) continue;
+    state.issues.release[rel.id] = createIssue(
+      `[UX Release v${rel.id}] ${rel.title.replace(/^v[\d.]+ — /, "")}`,
+      releaseBody(rel, state),
+      {
+        milestone: releaseMilestoneTitle(rel.id),
+        labels: issueLabels("epic", rel.priority),
+      },
+    );
+  }
+
+  state.issues.pr = state.issues.pr ?? {};
+  for (const pr of prs) {
+    if (state.issues.pr[pr.id]) continue;
+    state.issues.pr[pr.id] = createIssue(
+      `[UX PR${pr.id}] ${pr.title}`,
+      prBody(pr, state),
+      {
+        milestone: releaseMilestoneTitle(pr.release),
+        labels: issueLabels("pr", pr.priority),
+      },
+    );
+  }
+
+  // Refresh epic body with issue links
+  if (!dryRun && state.issues.epic) {
+    const epicNum = state.issues.epic;
+    const updated = epicBody() + "\n### Release issues\n" +
+      releases.map(r => `- v${r.id}: #${state.issues.release[r.id]}`).join("\n");
+    try {
+      gh(["issue", "edit", String(epicNum), "-R", REPO, "--body", updated]);
+    } catch {
+      log("Could not update epic body (permission); issues still created.");
+    }
+  }
+}
+
+function getOwnerId() {
+  const q = `query($login:String!){ user(login:$login){ id } }`;
+  const data = graphql(q, { login: project.owner });
+  return data.user?.id;
+}
+
+function createProject(state) {
+  log("Creating GitHub Project...");
+  const ownerId = getOwnerId();
+  if (!ownerId) throw new Error(`Could not resolve owner ${project.owner}`);
+
+  const createQ = `
+    mutation($input: CreateProjectV2Input!) {
+      createProjectV2(input: $input) {
+        projectV2 { id number title url }
+      }
+    }`;
+  const created = graphql(createQ, {
+    input: { ownerId, title: project.title },
+  });
+  const proj = created.createProjectV2.projectV2;
+  state.project = { id: proj.id, number: proj.number, url: proj.url };
+  log("  project", proj.url);
+
+  const linkQ = `
+    mutation($projectId:ID!, $repoId:ID!) {
+      linkProjectV2ToRepository(input: {projectId: $projectId, repositoryId: $repoId}) {
+        repository { name }
+      }
+    }`;
+  const repoNode = JSON.parse(gh(["api", `repos/${REPO}`, "--jq", ".node_id"]));
+  graphql(linkQ, { projectId: proj.id, repoId: repoNode });
+
+  const fields = [
+    { name: "Type", dataType: "SINGLE_SELECT", options: ["Epic", "Release", "PR"] },
+    { name: "Release", dataType: "SINGLE_SELECT", options: releases.map(r => `v${r.id}`) },
+    { name: "Sprint", dataType: "SINGLE_SELECT", options: ["A", "B", "C", "D", "E", "F", "G"] },
+    { name: "Priority", dataType: "SINGLE_SELECT", options: ["P0", "P1", "P2"] },
+    { name: "PR #", dataType: "NUMBER" },
+  ];
+
+  state.fields = {};
+  for (const field of fields) {
+    const fieldQ = `
+      mutation($input: CreateProjectV2FieldInput!) {
+        createProjectV2Field(input: $input) {
+          projectV2Field { ... on ProjectV2FieldCommon { id name } }
+        }
+      }`;
+    const input = {
+      projectId: proj.id,
+      name: field.name,
+      dataType: field.dataType,
+    };
+    if (field.dataType === "SINGLE_SELECT") {
+      input.singleSelectOptions = field.options.map(name => ({ name, color: "GRAY", description: "" }));
+    }
+    const res = graphql(fieldQ, { input: JSON.stringify(input) });
+    const f = res.createProjectV2Field.projectV2Field;
+    state.fields[field.name] = f.id;
+    log("  field", field.name);
+  }
+
+  return proj;
+}
+
+function getFieldOptionIds(projectId, fieldId) {
+  const q = `
+    query($projectId: ID!, $fieldId: ID!) {
+      node(id: $projectId) {
+        ... on ProjectV2 {
+          field(name: "") { id }
+        }
+      }
+    }`;
+  // fetch all fields with options
+  const fq = `
+    query($id: ID!) {
+      node(id: $id) {
+        ... on ProjectV2 {
+          fields(first: 20) {
+            nodes {
+              ... on ProjectV2SingleSelectField {
+                id name
+                options { id name }
+              }
+            }
+          }
+        }
+      }
+    }`;
+  const data = graphql(fq, { id: projectId });
+  const map = {};
+  for (const node of data.node.fields.nodes) {
+    if (node.options) {
+      map[node.name] = { id: node.id, options: Object.fromEntries(node.options.map(o => [o.name, o.id])) };
+    } else if (node.id) {
+      map[node.name] = { id: node.id };
+    }
+  }
+  return map;
+}
+
+function addIssueToProject(projectId, issueNodeId, fieldMap, itemMeta, state) {
+  const addQ = `
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item { id }
+      }
+    }`;
+  const added = graphql(addQ, { projectId, contentId: issueNodeId });
+  const itemId = added.addProjectV2ItemById.item.id;
+
+  const setField = (fieldName, optionName) => {
+    const field = fieldMap[fieldName];
+    if (!field?.options?.[optionName]) return;
+    const mut = `
+      mutation($input: UpdateProjectV2ItemFieldValueInput!) {
+        updateProjectV2ItemFieldValue(input: $input) { projectV2Item { id } }
+      }`;
+    graphql(mut, {
+      input: JSON.stringify({
+        projectId,
+        itemId,
+        fieldId: field.id,
+        value: { singleSelectOptionId: field.options[optionName] },
+      }),
+    });
+  };
+
+  const setNumber = (fieldName, num) => {
+    const field = fieldMap[fieldName];
+    if (!field?.id) return;
+    const mut = `
+      mutation($input: UpdateProjectV2ItemFieldValueInput!) {
+        updateProjectV2ItemFieldValue(input: $input) { projectV2Item { id } }
+      }`;
+    graphql(mut, {
+      input: JSON.stringify({
+        projectId,
+        itemId,
+        fieldId: field.id,
+        value: { number: num },
+      }),
+    });
+  };
+
+  setField("Type", itemMeta.type);
+  if (itemMeta.release) setField("Release", `v${itemMeta.release}`);
+  if (itemMeta.sprint) setField("Sprint", itemMeta.sprint);
+  if (itemMeta.priority) setField("Priority", itemMeta.priority);
+  if (itemMeta.prNumber != null) setNumber("PR #", itemMeta.prNumber);
+}
+
+function populateProject(state) {
+  if (!state.project?.id) {
+    createProject(state);
+  }
+  const projectId = state.project.id;
+  log("Populating project items...");
+
+  const fieldMap = getFieldOptionIds(projectId);
+
+  const addByNumber = (num, meta) => {
+    const nodeId = gh(["api", `repos/${REPO}/issues/${num}`, "--jq", ".node_id"]);
+    addIssueToProject(projectId, nodeId, fieldMap, meta, state);
+    log("  added", `#${num}`, meta.type);
+  };
+
+  addByNumber(state.issues.epic, { type: "Epic", priority: "P0", sprint: "A" });
+
+  for (const rel of releases) {
+    const num = state.issues.release[rel.id];
+    addByNumber(num, { type: "Release", release: rel.id, sprint: rel.sprint, priority: rel.priority });
+  }
+
+  for (const pr of prs) {
+    const num = state.issues.pr[pr.id];
+    const rel = releases.find(r => r.id === pr.release);
+    addByNumber(num, {
+      type: "PR",
+      release: pr.release,
+      sprint: rel?.sprint,
+      priority: pr.priority,
+      prNumber: pr.id,
+    });
+  }
+
+  log("Project ready:", state.project.url);
+  log("Configure a Roadmap view in the UI: Layout → Roadmap, group by Release, sort by PR #.");
+}
+
+async function main() {
+  log("Repo:", REPO);
+  const state = loadState();
+  state.issues = state.issues ?? {};
+
+  if (!projectOnly) {
+    createLabels();
+    createMilestones(state);
+    createIssues(state);
+    saveState(state);
+  }
+
+  if (!issuesOnly) {
+    try {
+      populateProject(state);
+      saveState(state);
+    } catch (e) {
+      console.error("\n[ux-roadmap] Project creation failed (issues may still have been created):");
+      console.error(e.message);
+      console.error("\nRun as VacantFanatic with: gh auth refresh -s project,read:org");
+      console.error("Then: node scripts/ux-roadmap/bootstrap.mjs --project-only");
+      process.exitCode = 1;
+    }
+  }
+
+  log("Done. State:", statePath);
+  if (state.issues.epic) {
+    log("Epic:", `https://github.com/${REPO}/issues/${state.issues.epic}`);
+  }
+}
+
+main();

--- a/scripts/ux-roadmap/roadmap.json
+++ b/scripts/ux-roadmap/roadmap.json
@@ -1,0 +1,493 @@
+{
+  "project": {
+    "title": "UX Roadmap 2026",
+    "owner": "VacantFanatic",
+    "repo": "foundryvtt-lancer",
+    "description": "Foundry VTT Lancer system UX improvements from the 2026 UX pass. Tracks releases v2.12.11 through v2.20.0 (optional v3.0.0)."
+  },
+  "labels": [
+    { "name": "ux-roadmap", "color": "1D76DB", "description": "UX roadmap tracking" },
+    { "name": "ux/epic", "color": "5319E7", "description": "Roadmap epic or release milestone issue" },
+    { "name": "ux/pr", "color": "0E8A16", "description": "Roadmap implementation PR issue" },
+    { "name": "priority/p0", "color": "B60205", "description": "High impact UX work" },
+    { "name": "priority/p1", "color": "D93F0B", "description": "Moderate impact UX work" },
+    { "name": "priority/p2", "color": "FBCA04", "description": "Polish and long-term UX work" }
+  ],
+  "milestones": [
+    { "title": "v2.12.11 — Trust & polish", "description": "Quick wins: import errors, WIP cleanup, cloud spinner, chat layout, HUD drag fix." },
+    { "title": "v2.13.0 — Combat loop", "description": "Auto-damage prompt, Acc/Diff disclosure, combat tour, chat rerolls." },
+    { "title": "v2.14.0 — Import & equip", "description": "Pilot cloud wizard, empty slot picker, unified import dialog." },
+    { "title": "v2.15.0 — Sheet IA", "description": "Pilot defaults, mech stat sections, NPC tabs." },
+    { "title": "v2.16.0 — A11y & dialogs", "description": "Collapse a11y, action manager labels, DialogV2, HUD focus trap, i18n." },
+    { "title": "v2.17.0 — Help & tours", "description": "Contextual help, what's new, tour maintenance." },
+    { "title": "v2.18.0 — Visual consistency", "description": "SCSS migration, remove legacy LCP HBS." },
+    { "title": "v2.19.0 — Finish stubs", "description": "Async loading, mount reset, combat tracker targets." },
+    { "title": "v2.20.0 — Interactive sheets", "description": "Svelte cloud island, experimental loadout editor." },
+    { "title": "v3.0.0 — Loadout editor GA", "description": "Optional major: promote loadout editor, remove legacy markup." }
+  ],
+  "releases": [
+    {
+      "id": "2.12.11",
+      "title": "v2.12.11 — Trust & polish",
+      "semver": "patch",
+      "sprint": "A",
+      "priority": "P0",
+      "summary": "Five low-risk PRs: actionable errors, hide WIP UI, cloud download spinner, attack card layout, HUD pointer-events during drag."
+    },
+    {
+      "id": "2.13.0",
+      "title": "v2.13.0 — Combat loop",
+      "semver": "minor",
+      "sprint": "B",
+      "priority": "P0",
+      "summary": "Optional auto-prompt damage, Acc/Diff progressive disclosure, combat tour update, chat reroll buttons."
+    },
+    {
+      "id": "2.14.0",
+      "title": "v2.14.0 — Import & equip",
+      "semver": "minor",
+      "sprint": "C",
+      "priority": "P0",
+      "summary": "Pilot cloud wizard, empty slot affordances with compendium picker, unified import result dialog."
+    },
+    {
+      "id": "2.15.0",
+      "title": "v2.15.0 — Sheet information architecture",
+      "semver": "minor",
+      "sprint": "D",
+      "priority": "P1",
+      "summary": "Pilot tab defaults, mech stats collapsible sections, NPC sheet tabs."
+    },
+    {
+      "id": "2.16.0",
+      "title": "v2.16.0 — Accessibility & dialogs",
+      "semver": "minor",
+      "sprint": "E",
+      "priority": "P1",
+      "summary": "Collapse a11y, action manager labels, DialogV2 migration, HUD focus trap, Svelte HUD i18n, sheet aria audit."
+    },
+    {
+      "id": "2.17.0",
+      "title": "v2.17.0 — Help & discoverability",
+      "semver": "minor",
+      "sprint": "F",
+      "priority": "P1",
+      "summary": "Contextual help links, what's new in help dialog, guided tour maintenance."
+    },
+    {
+      "id": "2.18.0",
+      "title": "v2.18.0 — Visual consistency",
+      "semver": "minor",
+      "sprint": "F",
+      "priority": "P2",
+      "summary": "Inline styles to SCSS utilities; remove legacy Handlebars LCP manager."
+    },
+    {
+      "id": "2.19.0",
+      "title": "v2.19.0 — Finish stubs",
+      "semver": "minor",
+      "sprint": "F",
+      "priority": "P1",
+      "summary": "Shared async loading pattern, mount reset implementation, combat tracker target controls."
+    },
+    {
+      "id": "2.20.0",
+      "title": "v2.20.0 — Interactive sheets (phase 1)",
+      "semver": "minor",
+      "sprint": "G",
+      "priority": "P2",
+      "summary": "Svelte cloud import island; experimental visual loadout editor."
+    },
+    {
+      "id": "3.0.0",
+      "title": "v3.0.0 — Loadout editor GA (optional)",
+      "semver": "major",
+      "sprint": "G",
+      "priority": "P2",
+      "summary": "Promote loadout editor; remove legacy Handlebars loadout if no fallback."
+    }
+  ],
+  "prs": [
+    {
+      "id": 1,
+      "release": "2.12.11",
+      "branch": "cursor/ux-import-errors-4b38",
+      "title": "Actionable import & migration errors",
+      "priority": "P0",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/actor/import.ts", "src/lancer.ts", "src/module/world_migration.ts", "src/module/apps/lcp-manager/lcp-manager.ts", "lang/en.json"],
+      "acceptance": [
+        "Failed COMP/CON import shows reason and next step",
+        "Missing-core errors include Open LCP Manager action",
+        "GM migration warnings stay permanent; player errors are timed"
+      ]
+    },
+    {
+      "id": 2,
+      "release": "2.12.11",
+      "branch": "cursor/ux-hide-wip-4b38",
+      "title": "Remove live WIP surfaces",
+      "priority": "P0",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["public/templates/actor/pilot.hbs", "src/module/actor/mech-sheet.ts", "src/module/actor/lancer-actor-sheet.ts"],
+      "acceptance": [
+        "No user-visible TODO toasts",
+        "Pilot upload WIP card hidden until implemented"
+      ]
+    },
+    {
+      "id": 3,
+      "release": "2.12.11",
+      "branch": "cursor/ux-cloud-download-spinner-4b38",
+      "title": "Pilot cloud download loading state",
+      "priority": "P0",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/actor/pilot-sheet.ts", "public/templates/actor/pilot.hbs", "src/styles/applications/_actor-sheet.scss"],
+      "acceptance": [
+        "Download button disabled with spinner during sync",
+        "Double-click cannot fire duplicate downloads"
+      ]
+    },
+    {
+      "id": 4,
+      "release": "2.12.11",
+      "branch": "cursor/ux-attack-card-layout-4b38",
+      "title": "Attack chat card layout polish",
+      "priority": "P0",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["public/templates/chat/attack-card.hbs", "public/templates/chat/tech-attack-card.hbs", "src/module/helpers/chat.ts"],
+      "acceptance": [
+        "Hit summary visible at top of card",
+        "Roll Damage CTA pinned above collapsible sections"
+      ]
+    },
+    {
+      "id": 5,
+      "release": "2.12.11",
+      "branch": "cursor/ux-hud-drag-pointer-events-4b38",
+      "title": "HUD non-interactive during canvas drag",
+      "priority": "P0",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/apps/slidinghud/SlidingHUDZone.svelte"],
+      "acceptance": ["Cannot click HUD controls while dragging a token on canvas"]
+    },
+    {
+      "id": 6,
+      "release": "2.13.0",
+      "branch": "cursor/ux-auto-damage-prompt-4b38",
+      "title": "Optional auto-prompt damage after attack",
+      "priority": "P0",
+      "parallel": false,
+      "dependsOn": [4],
+      "files": ["src/module/flows/attack.ts", "src/module/apps/automation-settings.ts", "public/templates/settings/automation-config.hbs", "lang/en.json"],
+      "acceptance": [
+        "World setting defaults to off",
+        "When on and hits exist, Damage HUD opens after attack card",
+        "Cancel aborts without applying damage"
+      ]
+    },
+    {
+      "id": 7,
+      "release": "2.13.0",
+      "branch": "cursor/ux-accdiff-disclosure-4b38",
+      "title": "Acc/Diff HUD progressive disclosure",
+      "priority": "P0",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/apps/acc_diff/AccDiffHUD.svelte", "src/lancer.ts", "lang/en.json"],
+      "acceptance": [
+        "Default view shows targets, totals, cover only",
+        "Advanced section for plugins and template tools",
+        "Client setting remembers per-weapon toggles"
+      ]
+    },
+    {
+      "id": 8,
+      "release": "2.13.0",
+      "branch": "cursor/ux-combat-tour-damage-loop-4b38",
+      "title": "Combat tour: attack → damage → apply",
+      "priority": "P1",
+      "parallel": false,
+      "dependsOn": [6],
+      "files": ["public/tours/combat.json", "src/module/tours/register-tours.ts"],
+      "acceptance": ["Tour documents manual and auto-damage paths"]
+    },
+    {
+      "id": 9,
+      "release": "2.13.0",
+      "branch": "cursor/ux-chat-reroll-4b38",
+      "title": "Restore chat reroll buttons",
+      "priority": "P1",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["public/templates/chat/*.hbs", "src/lancer.ts"],
+      "acceptance": ["Reroll available to owner/GM; hidden for others"]
+    },
+    {
+      "id": 10,
+      "release": "2.14.0",
+      "branch": "cursor/ux-pilot-cloud-wizard-4b38",
+      "title": "Pilot Cloud import wizard",
+      "priority": "P0",
+      "parallel": true,
+      "dependsOn": [3],
+      "files": ["public/templates/actor/pilot.hbs", "src/styles/applications/_actor-sheet.scss", "src/module/actor/pilot-sheet.ts"],
+      "acceptance": [
+        "Stepped layout: Login → Select → Download/JSON",
+        "Unsynced pilots default to Cloud tab",
+        "Link to pilot-import tour"
+      ]
+    },
+    {
+      "id": 11,
+      "release": "2.14.0",
+      "branch": "cursor/ux-empty-slot-picker-4b38",
+      "title": "Empty slot affordances & compendium picker",
+      "priority": "P0",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/helpers/refs.ts", "src/module/helpers/dragdrop.ts", "src/module/actor/lancer-actor-sheet.ts", "lang/en.json"],
+      "acceptance": [
+        "Empty slots show drag hint",
+        "Click opens filtered compendium picker",
+        "Invalid drop explains accepted types"
+      ]
+    },
+    {
+      "id": 12,
+      "release": "2.14.0",
+      "branch": "cursor/ux-import-result-dialog-4b38",
+      "title": "Unified import result dialog",
+      "priority": "P0",
+      "parallel": false,
+      "dependsOn": [1],
+      "files": ["src/module/actor/import.ts", "public/templates/window/import-result.hbs", "lang/en.json"],
+      "acceptance": ["Single DialogV2 for v2/v3/JSON success, partial, and failure"]
+    },
+    {
+      "id": 13,
+      "release": "2.15.0",
+      "branch": "cursor/ux-pilot-tab-defaults-4b38",
+      "title": "Pilot sheet IA defaults",
+      "priority": "P1",
+      "parallel": false,
+      "dependsOn": [10],
+      "files": ["src/module/actor/pilot-sheet.ts", "public/templates/actor/pilot.hbs"],
+      "acceptance": ["Cloud tab default for unsynced pilots; dismissible Tactical banner"]
+    },
+    {
+      "id": 14,
+      "release": "2.15.0",
+      "branch": "cursor/ux-mech-stats-sections-4b38",
+      "title": "Mech stats collapsible sections",
+      "priority": "P1",
+      "parallel": false,
+      "dependsOn": [13],
+      "files": ["public/templates/actor/mech.hbs", "src/styles/applications/_actor-sheet.scss"],
+      "acceptance": ["Combat vs Systems collapsible groups with sticky headers"]
+    },
+    {
+      "id": 15,
+      "release": "2.15.0",
+      "branch": "cursor/ux-npc-sheet-tabs-4b38",
+      "title": "NPC sheet tabs",
+      "priority": "P1",
+      "parallel": false,
+      "dependsOn": [14],
+      "files": ["public/templates/actor/npc.hbs", "src/module/actor/npc-sheet.ts", "public/tours/npc.json"],
+      "acceptance": ["Stats | Features | Effects tabs; feature drag-sort preserved"]
+    },
+    {
+      "id": 16,
+      "release": "2.16.0",
+      "branch": "cursor/ux-collapse-a11y-4b38",
+      "title": "Collapse accessibility",
+      "priority": "P1",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/helpers/collapse.ts", "public/templates/chat/*.hbs"],
+      "acceptance": ["aria-expanded, keyboard Enter/Space on collapse triggers"]
+    },
+    {
+      "id": 17,
+      "release": "2.16.0",
+      "branch": "cursor/ux-action-manager-a11y-4b38",
+      "title": "Action manager accessibility",
+      "priority": "P1",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["public/templates/window/action_manager.hbs", "src/module/action/action-manager.ts", "lang/en.json"],
+      "acceptance": ["aria-label on all actions; optional text labels via client setting"]
+    },
+    {
+      "id": 18,
+      "release": "2.16.0",
+      "branch": "cursor/ux-dialogv2-stabilize-repair-4b38",
+      "title": "DialogV2 migration (stabilize & repair)",
+      "priority": "P1",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/flows/*.ts", "public/templates/window/promptStabilize.hbs"],
+      "acceptance": ["No legacy Dialog for stabilize/full repair flows"]
+    },
+    {
+      "id": 19,
+      "release": "2.16.0",
+      "branch": "cursor/ux-hud-focus-trap-4b38",
+      "title": "HUD focus trap & modal behavior",
+      "priority": "P1",
+      "parallel": false,
+      "dependsOn": [7],
+      "files": ["src/module/apps/acc_diff/AccDiffHUD.svelte", "src/module/apps/damage/DamageHUD.svelte", "src/module/apps/struct_stress/StructStressHUD.svelte"],
+      "acceptance": ["aria-modal and focus trap while HUD open; Escape still cancels"]
+    },
+    {
+      "id": 20,
+      "release": "2.16.0",
+      "branch": "cursor/ux-hud-i18n-4b38",
+      "title": "Svelte HUD i18n",
+      "priority": "P1",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/apps/**/*.svelte", "lang/en.json"],
+      "acceptance": ["No hardcoded English in combat HUD components"]
+    },
+    {
+      "id": 21,
+      "release": "2.16.0",
+      "branch": "cursor/ux-sheet-aria-audit-4b38",
+      "title": "Sheet icon aria-label audit",
+      "priority": "P2",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/helpers/index.ts", "src/module/helpers/item.ts", "src/module/helpers/actor.ts"],
+      "acceptance": ["Icon-only sheet controls have aria-label matching combat tracker standard"]
+    },
+    {
+      "id": 22,
+      "release": "2.17.0",
+      "branch": "cursor/ux-contextual-help-4b38",
+      "title": "Contextual help links",
+      "priority": "P1",
+      "parallel": false,
+      "dependsOn": [10],
+      "files": ["public/templates/window/lancerHelp.hbs", "lang/en.json"],
+      "acceptance": ["Help links on Cloud tab, Automation settings, first Acc/Diff open"]
+    },
+    {
+      "id": 23,
+      "release": "2.17.0",
+      "branch": "cursor/ux-help-whats-new-4b38",
+      "title": "What's new in help dialog",
+      "priority": "P2",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["public/templates/window/lancerHelp.hbs", "src/lancer.ts"],
+      "acceptance": ["Help dialog shows recent CHANGELOG entries"]
+    },
+    {
+      "id": 24,
+      "release": "2.17.0",
+      "branch": "cursor/ux-tours-maintenance-4b38",
+      "title": "Guided tour maintenance pass",
+      "priority": "P1",
+      "parallel": false,
+      "dependsOn": [8, 10, 11, 15],
+      "files": ["public/tours/*.json"],
+      "acceptance": ["Tour selectors match new layouts; click-to-equip step added"]
+    },
+    {
+      "id": 25,
+      "release": "2.18.0",
+      "branch": "cursor/ux-scss-inline-migration-4b38",
+      "title": "SCSS migration (pilot cloud, chat, mech)",
+      "priority": "P2",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["public/templates/actor/pilot.hbs", "public/templates/chat/*.hbs", "src/styles/applications/_actor-sheet.scss"],
+      "acceptance": ["Inline style attributes replaced with SCSS utility classes"]
+    },
+    {
+      "id": 26,
+      "release": "2.18.0",
+      "branch": "cursor/ux-remove-legacy-lcp-hbs-4b38",
+      "title": "Remove legacy LCP Handlebars manager",
+      "priority": "P2",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/preload-templates.ts", "public/templates/lcp/"],
+      "acceptance": ["Only Svelte LCP manager preloaded"]
+    },
+    {
+      "id": 27,
+      "release": "2.19.0",
+      "branch": "cursor/ux-async-loading-pattern-4b38",
+      "title": "Shared async loading pattern",
+      "priority": "P1",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["src/module/helpers/async-ui.ts", "src/module/helpers/refs.ts"],
+      "acceptance": ["Loading indicators for async ref slots and license refresh"]
+    },
+    {
+      "id": 28,
+      "release": "2.19.0",
+      "branch": "cursor/ux-mount-reset-4b38",
+      "title": "Mount reset implementation",
+      "priority": "P1",
+      "parallel": true,
+      "dependsOn": [2],
+      "files": ["src/module/actor/mech-sheet.ts", "lang/en.json"],
+      "acceptance": ["Single-mount and reset-all with confirm dialog"]
+    },
+    {
+      "id": 29,
+      "release": "2.19.0",
+      "branch": "cursor/ux-combat-tracker-targets-4b38",
+      "title": "Combat tracker target controls",
+      "priority": "P1",
+      "parallel": true,
+      "dependsOn": [],
+      "files": ["public/templates/combat/tracker.hbs", "src/styles/combat/_lancer-combat-tracker.scss"],
+      "acceptance": ["Target selection controls implemented per tracker TODOs"]
+    },
+    {
+      "id": 30,
+      "release": "2.20.0",
+      "branch": "cursor/ux-svelte-cloud-island-4b38",
+      "title": "Svelte Cloud import island",
+      "priority": "P2",
+      "parallel": false,
+      "dependsOn": [10, 12],
+      "files": ["src/module/apps/pilot-cloud/", "public/templates/actor/pilot.hbs"],
+      "acceptance": ["Cloud tab hosts Svelte wizard; HBS is thin mount point"]
+    },
+    {
+      "id": 31,
+      "release": "2.20.0",
+      "branch": "cursor/ux-svelte-loadout-editor-4b38",
+      "title": "Svelte loadout editor (experimental)",
+      "priority": "P2",
+      "parallel": false,
+      "dependsOn": [11],
+      "files": ["src/module/apps/loadout/", "public/templates/actor/mech.hbs"],
+      "acceptance": ["Feature-flagged visual loadout editor on mech Loadout tab"]
+    },
+    {
+      "id": 32,
+      "release": "3.0.0",
+      "branch": "cursor/ux-loadout-editor-ga-4b38",
+      "title": "Loadout editor GA (optional major)",
+      "priority": "P2",
+      "parallel": false,
+      "dependsOn": [31],
+      "files": ["src/module/apps/loadout/", "src/module/world_migration.ts"],
+      "acceptance": ["Remove experimental flag; document breaking change if legacy loadout removed"]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds tooling to document and track the full UX roadmap (releases **v2.12.11** through **v2.20.0**, optional **v3.0.0**) as GitHub issues and a GitHub Project board.

**43 tracking issues created** (epic #43, release epics #44–#53, PR issues #54–#85).

## Passkey / no VM credentials

You do **not** need `gh` or stored GitHub credentials on the VM. After merge, follow **`scripts/ux-roadmap/MANUAL-SETUP.md`**:

1. Create a **fine-grained PAT** in the browser (passkey login) with **Projects** + **Issues** on this repo only.
2. Add repo secret **`UX_ROADMAP_GH_TOKEN`**.
3. Run **Actions → UX Roadmap bootstrap** (mode `project-only` since issues already exist).

Or use **Option B** in that doc to build the Project entirely in the GitHub UI.

## What's included

| Path | Purpose |
|------|---------|
| `scripts/ux-roadmap/roadmap.json` | Source of truth |
| `scripts/ux-roadmap/bootstrap.mjs` | Creates labels, milestones, project, fields |
| `scripts/ux-roadmap/MANUAL-SETUP.md` | Passkey + browser-only instructions |
| `.github/workflows/ux-roadmap-bootstrap.yml` | One-click bootstrap via Actions |

## Epic

https://github.com/VacantFanatic/foundryvtt-lancer/issues/43

## Test plan

- [x] Issues #43–#85 created via bootstrap `--issues-only`
- [ ] Merge PR → add `UX_ROADMAP_GH_TOKEN` → run workflow `project-only`
- [ ] Close stray test issues #40–#42 if still open
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

