### PR TITLE
Fix UX roadmap workflow secrets syntax

### DIFF
--- a/.github/workflows/ux-roadmap-bootstrap.yml
+++ b/.github/workflows/ux-roadmap-bootstrap.yml
@@ -1,7 +1,8 @@
 # Create or refresh the UX Roadmap 2026 GitHub Project, milestones, labels, and issues.
 #
 # Setup (passkey-friendly, no local gh CLI):
-#   1. Create a fine-grained PAT with Issues + Account Projects (read/write) on this repo.
+#   1. Create a CLASSIC PAT (not fine-grained) with project + repo scopes.
+#      Fine-grained PATs cannot access user-owned Projects (GitHub docs limitation).
 #   2. Add repo secret UX_ROADMAP_GH_TOKEN (see scripts/ux-roadmap/MANUAL-SETUP.md).
 #   3. Run workflow manually. GITHUB_TOKEN alone cannot create user-owned Projects.
 name: UX Roadmap bootstrap
@@ -33,17 +34,15 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Require project token
-        if: ${{ !secrets.UX_ROADMAP_GH_TOKEN }}
-        run: |
-          echo "::error::Add repository secret UX_ROADMAP_GH_TOKEN (fine-grained PAT with Projects + Issues)."
-          echo "See scripts/ux-roadmap/MANUAL-SETUP.md — no local gh credentials required."
-          exit 1
-
       - name: Bootstrap UX roadmap
         env:
           GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Add repository secret UX_ROADMAP_GH_TOKEN (classic PAT with project + repo scopes)."
+            echo "See scripts/ux-roadmap/MANUAL-SETUP.md — no local gh credentials required."
+            exit 1
+          fi
           MODE="${{ github.event.inputs.mode }}"
           FLAGS=""
           if [ "$MODE" = "issues-only" ]; then FLAGS="--issues-only"; fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes workflow parse error when queueing **UX Roadmap bootstrap**:

```
Unrecognized named-value: 'secrets'. Located at position 2 within expression: !secrets.UX_ROADMAP_GH_TOKEN
```

GitHub Actions does not allow `secrets` in `if:` conditions. The check for a missing `UX_ROADMAP_GH_TOKEN` is moved into the run step via `[ -z "$GH_TOKEN" ]`.

## Test plan

- [ ] Merge this PR
- [ ] Re-run **Actions → UX Roadmap bootstrap** with mode `project-only`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

