### PR TITLE
Remove redundant gh project extension install from workflow

### DIFF
--- a/.github/workflows/ux-roadmap-bootstrap.yml
+++ b/.github/workflows/ux-roadmap-bootstrap.yml
@@ -34,11 +34,6 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install gh project extension
-        env:
-          GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN }}
-        run: gh extension install github/gh-project
-
       - name: Bootstrap UX roadmap
         env:
           GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes UX Roadmap bootstrap workflow failure:

```
"project" matches the name of a built-in command or alias
```

`gh project` is built into GitHub CLI on Actions runners. The `gh extension install github/gh-project` step is removed.

## Test plan

- [ ] Merge PR
- [ ] Re-run **UX Roadmap bootstrap** (`project-only`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

