### PR TITLE
Fix UX roadmap unknown owner type (classic PAT + @me)

### DIFF
--- a/.github/workflows/ux-roadmap-bootstrap.yml
+++ b/.github/workflows/ux-roadmap-bootstrap.yml
@@ -34,15 +34,32 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Bootstrap UX roadmap
+      - name: Verify token can access Projects
         env:
           GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "::error::Add repository secret UX_ROADMAP_GH_TOKEN (classic PAT with project + repo scopes)."
-            echo "See scripts/ux-roadmap/MANUAL-SETUP.md — no local gh credentials required."
+            echo "See scripts/ux-roadmap/MANUAL-SETUP.md"
             exit 1
           fi
+          echo "Authenticated as:"
+          gh api user --jq '.login' || true
+          if ! gh project list --owner "@me" --limit 1 >/dev/null 2>&1; then
+            echo "::error::Token cannot access GitHub Projects."
+            echo "Create a CLASSIC PAT at https://github.com/settings/tokens/new"
+            echo "Required scopes: project (full) + repo"
+            echo "Fine-grained PATs do NOT work for user-owned Projects."
+            echo "Update the UX_ROADMAP_GH_TOKEN secret and re-run."
+            gh project list --owner "@me" --limit 1 || true
+            exit 1
+          fi
+          echo "Project API access OK"
+
+      - name: Bootstrap UX roadmap
+        env:
+          GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN }}
+        run: |
           MODE="${{ github.event.inputs.mode }}"
           FLAGS=""
           if [ "$MODE" = "issues-only" ]; then FLAGS="--issues-only"; fi

--- a/scripts/ux-roadmap/MANUAL-SETUP.md
+++ b/scripts/ux-roadmap/MANUAL-SETUP.md
@@ -1,147 +1,106 @@
 # UX Roadmap — setup without local GitHub credentials
 
-Use this guide if you sign in with a **passkey** and do not use `gh` or stored tokens on your dev machine / cloud VM.
+Use this guide if you sign in with a **passkey** and do not use `gh` on your machine or the cloud VM.
 
 **Tracking issues already exist:** epic [#43](https://github.com/VacantFanatic/foundryvtt-lancer/issues/43), releases [#44–#53](https://github.com/VacantFanatic/foundryvtt-lancer/issues/44), PRs [#54–#85](https://github.com/VacantFanatic/foundryvtt-lancer/issues/54).
 
-Pick **Option A** (recommended, ~5 minutes once) or **Option B** (pure browser, no tokens).
+Pick **Option A** (automated via Actions) or **Option B** (pure browser, no token).
 
 ---
 
-## Option A — GitHub Actions + one-time fine-grained PAT (recommended)
+## Troubleshooting: `unknown owner type`
 
-You only use the browser (passkey) once to create a token and paste it into repo secrets. No CLI on any machine.
+If the workflow fails with:
 
-### 1. Merge the bootstrap PR
+```text
+gh project list ... failed: unknown owner type
+```
 
-Merge [PR #86](https://github.com/VacantFanatic/foundryvtt-lancer/pull/86) so the workflow and scripts are on `master`.
+GitHub CLI uses that message when the token **cannot access Projects**. Almost always:
 
-### 2. Create a fine-grained personal access token
+1. You used a **fine-grained** PAT → it cannot access **user-owned** Projects. Use **classic** instead.
+2. The classic PAT is missing the **`project`** scope (not just `repo`).
+3. The token **expired** → regenerate and update the secret.
 
-1. Open [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new) (passkey sign-in).
-2. **Token name:** `foundryvtt-lancer-ux-roadmap`
-3. **Expiration:** 90 days (or custom; renew when you refresh the project).
-4. **Resource owner:** your account (`VacantFanatic`).
-5. **Repository access:** Only select repositories → `foundryvtt-lancer`.
-6. **Repository permissions:**
-   - **Issues** — Read and write
-   - **Metadata** — Read-only (required)
-   - **Contents** — Read-only (workflow checkout)
-7. **Account permissions:**
-   - **Projects** — Read and write
-8. Generate token and **copy it** (shown once).
+**Fix:** [Create a classic PAT](https://github.com/settings/tokens/new) with **`project`** + **`repo`** checked, update `UX_ROADMAP_GH_TOKEN`, re-run the workflow.
 
-### 3. Add the token as a repository secret
+---
 
-1. [Repo → Settings → Secrets and variables → Actions](https://github.com/VacantFanatic/foundryvtt-lancer/settings/secrets/actions)
-2. **New repository secret**
-3. Name: `UX_ROADMAP_GH_TOKEN`
-4. Value: paste the token → Save
+## Option A — GitHub Actions + classic PAT
 
-### 4. Run the workflow
+### 1. Create a classic personal access token
+
+Use **[Tokens (classic)](https://github.com/settings/tokens/new)** — **not** fine-grained.
+
+1. **Note:** `foundryvtt-lancer-ux-roadmap`
+2. **Expiration:** your choice (e.g. 90 days)
+3. **Scopes** — enable exactly:
+   - **`project`** — Full control of GitHub Projects (**required**)
+   - **`repo`** — Full control of private repositories (**required** for issues/labels)
+4. **Generate token** → copy it once
+
+On the classic token page, scopes are grouped checkboxes. **`project`** is under its own heading — it is easy to miss if you only enable `repo`.
+
+### 2. Add repository secret
+
+1. [Settings → Secrets → Actions](https://github.com/VacantFanatic/foundryvtt-lancer/settings/secrets/actions)
+2. Name: **`UX_ROADMAP_GH_TOKEN`**
+3. Paste the **classic** token → Save
+
+If you previously stored a fine-grained token here, **replace** it.
+
+### 3. Run the workflow
 
 1. [Actions → UX Roadmap bootstrap](https://github.com/VacantFanatic/foundryvtt-lancer/actions/workflows/ux-roadmap-bootstrap.yml)
-2. **Run workflow** → branch `master` → mode **`full`** → Run.
+2. **Run workflow** → `master` → mode **`project-only`** (issues already exist)
 
-This creates labels, milestones, the **UX Roadmap 2026** project, custom fields, and adds issues #43–#85.
+The workflow runs a **Verify token can access Projects** step first and prints a clear error if scopes are wrong.
 
-If issues already exist, use mode **`project-only`** to skip re-creating them.
+### 4. Configure project views
 
-### 5. Configure project views (browser, ~2 min)
+Open **UX Roadmap 2026** under your profile **Projects** tab:
 
-Open the new project under your profile **Projects** tab, then:
-
-| View name | Layout | Group by | Sort |
-|-----------|--------|----------|------|
+| View | Layout | Group by | Sort |
+|------|--------|----------|------|
 | Roadmap | Roadmap | Release | PR # |
 | Board | Board | Status | Priority |
-| Table | Table | — | Release, then PR # |
+| Table | Table | — | Release, PR # |
 
-### 6. Revoke the token (optional)
+### 5. Revoke token (optional)
 
-After a successful run you can delete the secret and revoke the PAT at [github.com/settings/tokens](https://github.com/settings/tokens). Re-create it only if you run bootstrap again.
+After success, revoke at [Tokens (classic)](https://github.com/settings/tokens) and delete the secret if you no longer need automated bootstrap.
 
 ---
 
-## Option B — Pure GitHub UI (no PAT, no Actions)
+## Option B — Pure GitHub UI (no PAT)
 
 ### 1. Create the project
 
-1. [foundryvtt-lancer → Projects](https://github.com/VacantFanatic/foundryvtt-lancer/projects) → **New project**.
-2. Template: **Roadmap** (or Board).
-3. Title: **UX Roadmap 2026**.
-4. Link repository: `foundryvtt-lancer`.
+1. [foundryvtt-lancer → Projects](https://github.com/VacantFanatic/foundryvtt-lancer/projects) → **New project**
+2. Template: **Roadmap** or **Board**
+3. Title: **UX Roadmap 2026**
+4. Link repository: `foundryvtt-lancer`
 
 ### 2. Add custom fields
-
-In the project → **…** → **Settings** / field menu → **New field**:
 
 | Field | Type | Options |
 |-------|------|---------|
 | Type | Single select | Epic, Release, PR |
-| Release | Single select | v2.12.11, v2.13.0, v2.14.0, v2.15.0, v2.16.0, v2.17.0, v2.18.0, v2.19.0, v2.20.0, v3.0.0 |
+| Release | Single select | v2.12.11 … v3.0.0 |
 | Sprint | Single select | A, B, C, D, E, F, G |
 | Priority | Single select | P0, P1, P2 |
 | PR # | Number | — |
 
-**Status** is built in (Todo / In progress / Done).
+### 3. Add issues
 
-### 3. Add existing issues
+**+ Add item** → search `repo:VacantFanatic/foundryvtt-lancer [UX` → add #43–#85.
 
-Click **+ Add item** → search `repo:VacantFanatic/foundryvtt-lancer [UX` → add all matches (#43–#85).
+### 4. Set fields
 
-Or paste issue numbers in bulk if your UI supports multi-add.
-
-### 4. Set field values (filter helpers)
-
-| Filter title | Type | Release | Sprint | Priority |
-|--------------|------|---------|--------|----------|
-| `[UX Epic]` | Epic | — | A | P0 |
-| `[UX Release v2.12.11]` | Release | v2.12.11 | A | P0 |
-| `[UX Release v2.13.0]` | Release | v2.13.0 | B | P0 |
-| `[UX Release v2.14.0]` | Release | v2.14.0 | C | P0 |
-| `[UX Release v2.15.0]` | Release | v2.15.0 | D | P1 |
-| `[UX Release v2.16.0]` | Release | v2.16.0 | E | P1 |
-| `[UX Release v2.17.0]` | Release | v2.17.0 | F | P1 |
-| `[UX Release v2.18.0]` | Release | v2.18.0 | F | P2 |
-| `[UX Release v2.19.0]` | Release | v2.19.0 | F | P1 |
-| `[UX Release v2.20.0]` | Release | v2.20.0 | G | P2 |
-| `[UX Release v3.0.0]` | Release | v3.0.0 | G | P2 |
-| `[UX PR1]` … `[UX PR5]` | PR | v2.12.11 | A | P0 | PR # 1–5 |
-| `[UX PR6]` … `[UX PR9]` | PR | v2.13.0 | B | P0/P1 | PR # 6–9 |
-| `[UX PR10]` … `[UX PR12]` | PR | v2.14.0 | C | P0 | PR # 10–12 |
-| `[UX PR13]` … `[UX PR15]` | PR | v2.15.0 | D | P1 | PR # 13–15 |
-| `[UX PR16]` … `[UX PR21]` | PR | v2.16.0 | E | P1/P2 | PR # 16–21 |
-| `[UX PR22]` … `[UX PR24]` | PR | v2.17.0 | F | P1/P2 | PR # 22–24 |
-| `[UX PR25]` … `[UX PR26]` | PR | v2.18.0 | F | P2 | PR # 25–26 |
-| `[UX PR27]` … `[UX PR29]` | PR | v2.19.0 | F | P1 | PR # 27–29 |
-| `[UX PR30]` … `[UX PR31]` | PR | v2.20.0 | G | P2 | PR # 30–31 |
-| `[UX PR32]` | PR | v3.0.0 | G | P2 | PR # 32 |
-
-Use **Table** view → multi-select rows → edit fields in bulk where possible.
-
-### 5. Milestones & labels (optional)
-
-**Issues → Milestones → New milestone** for each release title in `roadmap.json` (e.g. `v2.12.11 — Trust & polish`).
-
-**Issues → Labels → New label** for `ux-roadmap`, `ux/epic`, `ux/pr`, `priority/p0`, etc.
-
-Assign via issue sidebar or milestone filter — not required for the project board to work.
-
-### 6. Create views
-
-Same as Option A step 5.
+Use the tables in the previous version of this doc or set Release/Sprint/Priority per issue title prefix (`[UX Release v2.13.0]`, `[UX PR6]`, etc.).
 
 ---
 
 ## Cleanup
 
-Close stray test issues if still open: [#40](https://github.com/VacantFanatic/foundryvtt-lancer/issues/40), [#41](https://github.com/VacantFanatic/foundryvtt-lancer/issues/41), [#42](https://github.com/VacantFanatic/foundryvtt-lancer/issues/42). Canonical epic is **#43**.
-
----
-
-## Day-to-day (no credentials needed)
-
-- Cloud agents open PRs with `Closes #54` (etc.) — issues close automatically on merge.
-- You triage in the **Project** board in the browser (passkey login).
-- Edits to scope go in `scripts/ux-roadmap/roadmap.json`; re-run Option A workflow `project-only` only if you add new tracking issues via bootstrap.
+Close stray test issues [#40](https://github.com/VacantFanatic/foundryvtt-lancer/issues/40)–[#42](https://github.com/VacantFanatic/foundryvtt-lancer/issues/42). Canonical epic: **#43**.

--- a/scripts/ux-roadmap/README.md
+++ b/scripts/ux-roadmap/README.md
@@ -12,7 +12,7 @@ This folder defines the **UX Roadmap 2026** release plan and a script to create:
 
 **You do not need `gh` on your machine or the cloud VM.** See **[MANUAL-SETUP.md](./MANUAL-SETUP.md)**:
 
-- **Option A (recommended):** one fine-grained PAT in repo secrets → run the **UX Roadmap bootstrap** GitHub Action (passkey only in the browser).
+- **Option A (recommended):** one **classic** PAT (`project` + `repo` scopes) in repo secrets → run **UX Roadmap bootstrap**. If you see `unknown owner type`, the token is wrong — see MANUAL-SETUP.md.
 - **Option B:** create the Project entirely in the GitHub web UI and add issues #43–#85.
 
 ### Local CLI (optional)

--- a/scripts/ux-roadmap/bootstrap.mjs
+++ b/scripts/ux-roadmap/bootstrap.mjs
@@ -343,8 +343,26 @@ function resolveIssueNumbers(state) {
   };
 }
 
+/** Owner for gh project * — use @me when GH_TOKEN is set (CI/PAT). */
+function projectOwner() {
+  return process.env.GH_TOKEN ? "@me" : project.owner;
+}
+
+function verifyProjectToken() {
+  try {
+    ghJson(["project", "list", "--owner", projectOwner(), "--format", "json", "--limit", "1"]);
+  } catch (e) {
+    const hint =
+      "GH_TOKEN cannot access GitHub Projects. Create a new classic PAT at " +
+      "https://github.com/settings/tokens/new with scopes: project + repo. " +
+      "Fine-grained PATs do not work for user-owned Projects. " +
+      "The gh CLI error 'unknown owner type' usually means missing or wrong token scopes.";
+    throw new Error(`${hint}\n\nUnderlying error: ${e.message.split("\n")[0]}`);
+  }
+}
+
 function listProjects() {
-  const data = ghJson(["project", "list", "--owner", project.owner, "--format", "json", "--limit", "100"]);
+  const data = ghJson(["project", "list", "--owner", projectOwner(), "--format", "json", "--limit", "100"]);
   return data.projects ?? [];
 }
 
@@ -354,12 +372,13 @@ function findProjectByTitle(title) {
 
 function createProject(state) {
   log("Creating GitHub Project...");
+  verifyProjectToken();
   let proj = state.project?.number ? findProjectByTitle(project.title) : null;
   if (!proj) {
     proj = findProjectByTitle(project.title);
   }
   if (!proj) {
-    gh(["project", "create", "--owner", project.owner, "--title", project.title]);
+    gh(["project", "create", "--owner", projectOwner(), "--title", project.title]);
     proj = findProjectByTitle(project.title);
   }
   if (!proj) throw new Error(`Could not find or create project "${project.title}"`);
@@ -367,7 +386,7 @@ function createProject(state) {
   log("  project", proj.url);
 
   try {
-    gh(["project", "link", String(proj.number), "--owner", project.owner, "--repo", project.repo]);
+    gh(["project", "link", String(proj.number), "--owner", projectOwner(), "--repo", project.repo]);
     log("  linked repo", project.repo);
   } catch (e) {
     if (!String(e).includes("already")) {
@@ -380,7 +399,7 @@ function createProject(state) {
     "field-list",
     String(proj.number),
     "--owner",
-    project.owner,
+    projectOwner(),
     "--format",
     "json",
     "--limit",
@@ -398,7 +417,7 @@ function createProject(state) {
       "field-create",
       String(proj.number),
       "--owner",
-      project.owner,
+      projectOwner(),
       "--name",
       field.name,
       "--data-type",
@@ -420,7 +439,7 @@ function getFieldMap(projectNumber) {
     "field-list",
     String(projectNumber),
     "--owner",
-    project.owner,
+    projectOwner(),
     "--format",
     "json",
     "--limit",
@@ -447,7 +466,7 @@ function addIssueToProject(projectMeta, issueNumber, fieldMap, itemMeta) {
     "item-add",
     String(projectMeta.number),
     "--owner",
-    project.owner,
+    projectOwner(),
     "--url",
     issueUrl,
     "--format",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes workflow failure:

```
gh project list --owner VacantFanatic ... failed: unknown owner type
```

GitHub CLI reports **`unknown owner type`** when the token cannot access Projects (misleading message). Common causes:

- Fine-grained PAT (does not support user-owned Projects)
- Classic PAT missing the **`project`** scope
- Expired token

## Changes

- Use `gh project --owner @me` when `GH_TOKEN` is set (PAT in Actions)
- Preflight step: **Verify token can access Projects** with clear error text
- Bootstrap `verifyProjectToken()` with actionable error message
- **MANUAL-SETUP.md** rewritten for classic PAT only + troubleshooting

## What you need to do

1. Merge this PR
2. Create a **classic** PAT: https://github.com/settings/tokens/new
   - Scopes: **`project`** + **`repo`**
3. **Update** secret `UX_ROADMAP_GH_TOKEN` (replace fine-grained token if that was used)
4. Re-run workflow → `project-only`

Or skip tokens entirely: **Option B** in `MANUAL-SETUP.md` (build Project in browser).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

