### PR TITLE
Rename UX roadmap project to LANCER UX pass in docs

### DIFF
--- a/scripts/ux-roadmap/MANUAL-SETUP.md
+++ b/scripts/ux-roadmap/MANUAL-SETUP.md
@@ -58,7 +58,7 @@ The workflow runs a **Verify token can access Projects** step first and prints a
 
 ### 4. Configure project views
 
-Open **UX Roadmap 2026** under your profile **Projects** tab:
+Open **LANCER UX pass** under your profile **Projects** tab:
 
 | View | Layout | Group by | Sort |
 |------|--------|----------|------|
@@ -78,7 +78,7 @@ After success, revoke at [Tokens (classic)](https://github.com/settings/tokens) 
 
 1. [foundryvtt-lancer → Projects](https://github.com/VacantFanatic/foundryvtt-lancer/projects) → **New project**
 2. Template: **Roadmap** or **Board**
-3. Title: **UX Roadmap 2026**
+3. Title: **LANCER UX pass** (live project on VacantFanatic)
 4. Link repository: `foundryvtt-lancer`
 
 ### 2. Add custom fields

--- a/scripts/ux-roadmap/README.md
+++ b/scripts/ux-roadmap/README.md
@@ -1,4 +1,4 @@
-# UX Roadmap 2026 — GitHub Project bootstrap
+# LANCER UX pass — GitHub Project bootstrap
 
 This folder defines the **UX Roadmap 2026** release plan and a script to create:
 

--- a/scripts/ux-roadmap/roadmap.json
+++ b/scripts/ux-roadmap/roadmap.json
@@ -1,6 +1,6 @@
 {
   "project": {
-    "title": "UX Roadmap 2026",
+    "title": "LANCER UX pass",
     "owner": "VacantFanatic",
     "repo": "foundryvtt-lancer",
     "description": "Foundry VTT Lancer system UX improvements from the 2026 UX pass. Tracks releases v2.12.11 through v2.20.0 (optional v3.0.0)."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Records the manually created GitHub Project name **LANCER UX pass** in `roadmap.json` and setup docs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

