### PR TITLE
UX v2.12.11 — Trust & polish (Sprint A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2.12.11 (2026-06-06)
+
+## Added
+
+- Pilot Cloud **download** shows a spinner and “Syncing…” status while COMP/CON import is in progress.
+- Attack chat cards show a **hit summary** (hits / crits / misses) and pin **Roll Damage** above collapsible sections.
+
+## Changed
+
+- COMP/CON and import errors surface the **actual failure message** in notifications instead of “see console for details”.
+- Missing core data prompts GMs with an **Open LCP Manager** confirmation dialog.
+- Partial import summary notification points users to the dialog and Compendium Manager.
+
+## Fixed
+
+- Sliding HUD panels are **non-interactive** while faded during token drag (prevents mis-clicks).
+- Removed pilot Cloud **upload WIP** card and per-mount weapon reset control until implemented (no more TODO toasts).
+
 # 2.12.10 (2026-06-06)
 
 ## Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.12.10",
+  "version": "2.12.11",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -50,6 +50,13 @@
     "placeholder": {
       "name": "Name"
     },
+    "import": {
+      "errors": {
+        "core-data-title": "Core data required",
+        "core-data-required": "Import Core Book Data in the Lancer Compendium Manager (Compendiums tab) before importing a pilot.",
+        "core-data-open-lcp": "Open LCP Manager"
+      }
+    },
     "common-sheet": {
       "tabs": {
         "effects": "<EFFECTS//ACTIVE>"
@@ -134,7 +141,8 @@
       },
       "cloud-download": {
         "label": "DOWNLOAD",
-        "lastSync": "Last synced: {timestamp}"
+        "lastSync": "Last synced: {timestamp}",
+        "syncing": "Syncing…"
       },
       "cloud-upload": {
         "label": "UPLOAD",
@@ -214,7 +222,11 @@
         "crit": "CRIT",
         "hit": "HIT",
         "miss": "MISS",
-        "roll-all-damage": "ROLL DAMAGE"
+        "roll-all-damage": "ROLL DAMAGE",
+        "hit-summary": "{parts} / {total} targets",
+        "hit-summary-hits": "{n} hits",
+        "hit-summary-crits": "{n} crits",
+        "hit-summary-misses": "{n} misses"
       },
       "exclamation": {
         "overkill": "OVERKILL!"

--- a/public/templates/actor/pilot.hbs
+++ b/public/templates/actor/pilot.hbs
@@ -4,78 +4,132 @@
     <div class="name flexrow">
       <div class="details flexcol">
         <span>{{localize "lancer.pilot-sheet.header.ll"}}</span>
-        <h1 class="pilot-callsign">{{system.level}}</span>
+        <h1 class="pilot-callsign">{{system.level}}</h1>
       </div>
 
       <div class="details flexcol">
         <span>{{localize "lancer.pilot-sheet.header.cs"}}</span>
-        <h1 class="pilot-callsign">{{system.callsign}}</span>
+        <h1 class="pilot-callsign">{{system.callsign}}</h1>
       </div>
 
       <div class="details flexcol">
         <span>{{localize "lancer.pilot-sheet.header.name"}}</span>
-        <h2 class="medium">{{actor.name}}</span>
+        <h2 class="medium">{{actor.name}}</h2>
       </div>
 
       <div class="details flexcol">
         <span>{{localize "lancer.pilot-sheet.header.bg"}}</span>
-        <h3 class="medium">{{{system.background}}}</span>
+        <h3 class="medium">{{{system.background}}}</h3>
       </div>
     </div>
-    {{{ ref-portrait-img actor.img "img" actor }}}
+    {{{ref-portrait-img actor.img "img" actor}}}
     <div class="header-details pilot-stats flexrow">
-      {{{compact-stat-edit "mdi mdi-heart-outline" "system.hp.value" "system.hp.max" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.hp")}}}
-      {{{compact-stat-edit "mdi mdi-shield-star-outline" "system.overshield.value" "" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.overshield")}}}
-      {{{compact-stat-view "mdi mdi-shield-outline" "system.armor" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.armor")}}}
-      {{{compact-stat-view "cci cci-evasion" "system.evasion" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.evasion")}}}
+      {{
+        {compact-stat-edit "mdi mdi-heart-outline" "system.hp.value" "system.hp.max" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.hp")}
+      }}
+      {{
+        {compact-stat-edit "mdi mdi-shield-star-outline" "system.overshield.value" "" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.overshield")}
+      }}
+      {{
+        {compact-stat-view "mdi mdi-shield-outline" "system.armor" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.armor")}
+      }}
+      {{
+        {compact-stat-view "cci cci-evasion" "system.evasion" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.evasion")}
+      }}
       {{{compact-stat-view "cci cci-edef" "system.edef" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.edef")}}}
-      {{{compact-stat-view "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.speed")}}}
+      {{
+        {compact-stat-view "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.speed")}
+      }}
       {{{compact-stat-view "cci cci-save" "system.save" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.save")}}}
-      {{{compact-stat-view "cci cci-sensor" "system.sensor_range" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.sensor_range")}}}
+      {{
+        {compact-stat-view "cci cci-sensor" "system.sensor_range" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.sensor_range")}
+      }}
     </div>
   </header>
 
   {{!-- Sheet Tab Navigation --}}
   <nav class="tabs lancer-tabs" data-group="primary">
-    <a class="item lancer-tab medium {{tabs.primary.dossier.cssClass}}" data-action="tab" data-group="primary" data-tab="dossier">{{localize "lancer.pilot-sheet.tabs.dossier"}}</a>
-    <a class="item lancer-tab medium {{tabs.primary.narrative.cssClass}}" data-action="tab" data-group="primary" data-tab="narrative">{{localize "lancer.pilot-sheet.tabs.narrative"}}</a>
-    <a class="item lancer-tab medium {{tabs.primary.tactical.cssClass}}" data-action="tab" data-group="primary" data-tab="tactical">{{localize "lancer.pilot-sheet.tabs.tactical"}}</a>
-    <a class="item lancer-tab medium {{tabs.primary.loadout.cssClass}}" data-action="tab" data-group="primary" data-tab="loadout">{{localize "lancer.pilot-sheet.tabs.mech"}}</a>
-    <a class="item lancer-tab medium {{tabs.primary.effects.cssClass}}" data-action="tab" data-group="primary" data-tab="effects">{{localize "lancer.common-sheet.tabs.effects"}}</a>
-    <a class="item lancer-tab medium {{tabs.primary.cloud.cssClass}}" data-action="tab" data-group="primary" data-tab="cloud">{{localize "lancer.pilot-sheet.tabs.cloud"}}</a>
+    <a
+      class="item lancer-tab medium {{tabs.primary.dossier.cssClass}}"
+      data-action="tab"
+      data-group="primary"
+      data-tab="dossier"
+    >{{localize "lancer.pilot-sheet.tabs.dossier"}}</a>
+    <a
+      class="item lancer-tab medium {{tabs.primary.narrative.cssClass}}"
+      data-action="tab"
+      data-group="primary"
+      data-tab="narrative"
+    >{{localize "lancer.pilot-sheet.tabs.narrative"}}</a>
+    <a
+      class="item lancer-tab medium {{tabs.primary.tactical.cssClass}}"
+      data-action="tab"
+      data-group="primary"
+      data-tab="tactical"
+    >{{localize "lancer.pilot-sheet.tabs.tactical"}}</a>
+    <a
+      class="item lancer-tab medium {{tabs.primary.loadout.cssClass}}"
+      data-action="tab"
+      data-group="primary"
+      data-tab="loadout"
+    >{{localize "lancer.pilot-sheet.tabs.mech"}}</a>
+    <a
+      class="item lancer-tab medium {{tabs.primary.effects.cssClass}}"
+      data-action="tab"
+      data-group="primary"
+      data-tab="effects"
+    >{{localize "lancer.common-sheet.tabs.effects"}}</a>
+    <a
+      class="item lancer-tab medium {{tabs.primary.cloud.cssClass}}"
+      data-action="tab"
+      data-group="primary"
+      data-tab="cloud"
+    >{{localize "lancer.pilot-sheet.tabs.cloud"}}</a>
   </nav>
 
   {{!-- Sheet Body --}}
   <section class="sheet-body scroll-body">
     {{!-- Cloud Management Tab --}}
     <div class="tab manage {{tabs.primary.cloud.cssClass}}" data-group="primary" data-tab="cloud">
-      <div style="display: grid; grid-template: auto / 1fr 1fr;">
-        <div class="card clipped" style="grid-area: 1/1/2/3;">
+      <div style="display: grid; grid-template: auto / 1fr 1fr">
+        <div class="card clipped" style="grid-area: 1/1/2/3">
           <span class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.cloud-header.label"}}</span>
-          <select class="lancer-input major lancer-text-field" style="text-align: center;" name="selectCloudId"
-            data-type="text"  >
+          <select
+            class="lancer-input major lancer-text-field"
+            style="text-align: center"
+            name="selectCloudId"
+            data-type="text"
+          >
             {{selectOptions compConPilotList selected=system.cloud_id inverted=true}}
           </select>
-          <input class="lancer-input major" style="text-align: center;" type="text" name="system.cloud_id" value="{{system.cloud_id}}"
-            data-dtype="String" placeholder="{{localize "lancer.pilot-sheet.cloud-header.raw-placeholder"}}" />
+          <input
+            class="lancer-input major"
+            style="text-align: center"
+            type="text"
+            name="system.cloud_id"
+            value="{{system.cloud_id}}"
+            data-dtype="String"
+            placeholder='{{localize "lancer.pilot-sheet.cloud-header.raw-placeholder"}}'
+          />
         </div>
 
-        <div class="card clipped" style="grid-area: 2/1/3/2;">
+        <div class="card clipped" style="grid-area: 2/1/3/2">
           <span class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.cloud-download.label"}}</span>
-          <a class="cloud-control lancer-button" style="align-self: center;" data-action="download">
-            <i class="cci cci-tech-quick i--dark i--5"></i>
+          <a
+            class="cloud-control lancer-button cloud-download-button"
+            style="align-self: center"
+            data-action="download"
+            aria-busy="false"
+          >
+            <i class="cci cci-tech-quick i--dark i--5 cloud-download-idle"></i>
+            <i class="fas fa-spinner fa-spin cloud-download-spinner i--dark i--5" hidden></i>
           </a>
-          <span class="minor desc-text" style="text-align: center;">
+          <span class="minor desc-text cloud-download-status" style="text-align: center">
             {{localize "lancer.pilot-sheet.cloud-download.lastSync" timestamp=system.last_cloud_update}}
           </span>
         </div>
 
-        <div class="card clipped" style="grid-area: 2/2/3/3;">
-          <span class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.cloud-upload.label"}}</span>
-          <span>{{localize "lancer.pilot-sheet.cloud-upload.wip"}}</span>
-        </div>
-
-        <div class="card clipped" style="grid-area: 3/1/4/2;">
+        <div class="card clipped" style="grid-area: 2/2/3/3">
           <span class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.json-import.label"}}</span>
           <input id="pilot-json-import" type="file" name="pilot-json-up" class="lcp-up" accept=".json">
         </div>
@@ -107,8 +161,12 @@
     <div class="tab pilot flexcol {{tabs.primary.narrative.cssClass}}" data-group="primary" data-tab="narrative">
       <div class="card clipped">
         <div class="flexrow">
-          {{{clicker-stat-card "LICENSE LEVEL" "mdi mdi-shield-outline" "system.level" false tooltip=(localize "lancer.pilot-sheet.stat-tooltip.license_level")}}}
-          {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.grit")}}}
+          {{
+            {clicker-stat-card "LICENSE LEVEL" "mdi mdi-shield-outline" "system.level" false tooltip=(localize "lancer.pilot-sheet.stat-tooltip.license_level")}
+          }}
+          {{
+            {stat-rollable-card "GRIT" "cci cci-armor" "system.grit" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.grit")}
+          }}
         </div>
       </div>
 
@@ -134,10 +192,10 @@
             {{!-- XP Checklist --}}
             <div class="flexcol">
               {{#each system.bond.system.major_ideals as |ideal index|}}
-                  <div class="flexrow flex-center bond-xp-item">
-                    {{{std-checkbox (concat "system.bond_state.xp_checklist.major_ideals." index)}}}
-                    <span class="grow">{{ideal}}</span>
-                  </div>
+                <div class="flexrow flex-center bond-xp-item">
+                  {{{std-checkbox (concat "system.bond_state.xp_checklist.major_ideals." index)}}}
+                  <span class="grow">{{ideal}}</span>
+                </div>
               {{/each}}
               <div class="flexrow flex-center bond-xp-item">
                 {{{std-checkbox "system.bond_state.xp_checklist.minor_ideal"}}}
@@ -175,16 +233,17 @@
               {{/if}}
             {{/each}}
           </div>
-
         </div>
       {{/if}}
 
       <div class="flexrow">
         {{!-- Skill Triggers --}}
         <div class="card clipped">
-          <h2 class="lancer-header lancer-primary submajor clipped">{{localize "lancer.pilot-sheet.abilities.skills"}}</h2>
-          {{#each itemTypes.skill as |skill index|}} 
-            {{{item-preview (concat "itemTypes.skill." index) "delete" }}}
+          <h2 class="lancer-header lancer-primary submajor clipped">
+            {{localize "lancer.pilot-sheet.abilities.skills"}}
+          </h2>
+          {{#each itemTypes.skill as |skill index|}}
+            {{{item-preview (concat "itemTypes.skill." index) "delete"}}}
           {{/each}}
         </div>
         {{!-- Bond Clocks --}}
@@ -193,19 +252,29 @@
             <div class="card clipped grow">
               <div class="lancer-header lancer-primary submajor clipped">
                 <span>{{localize "lancer.pilot-sheet.narrative.burdens"}}</span>
-                <a class="gen-control fas fa-plus" data-action="append" data-path="system.bond_state.burdens" data-action-value="(struct)counter"></a>
+                <a
+                  class="gen-control fas fa-plus"
+                  data-action="append"
+                  data-path="system.bond_state.burdens"
+                  data-action-value="(struct)counter"
+                ></a>
               </div>
               {{#each system.bond_state.burdens as |burden index|}}
-                  {{{counter burden (concat "system.bond_state.burdens." index) "true"}}}
+                {{{counter burden (concat "system.bond_state.burdens." index) "true"}}}
               {{/each}}
             </div>
             <div class="card clipped grow">
               <div class="lancer-header lancer-primary submajor clipped">
                 <span>{{localize "lancer.pilot-sheet.narrative.clocks"}}</span>
-                <a class="gen-control fas fa-plus" data-action="append" data-path="system.bond_state.clocks" data-action-value="(struct)counter"></a>
+                <a
+                  class="gen-control fas fa-plus"
+                  data-action="append"
+                  data-path="system.bond_state.clocks"
+                  data-action-value="(struct)counter"
+                ></a>
               </div>
               {{#each system.bond_state.clocks as |clock index|}}
-                  {{{counter clock (concat "system.bond_state.clocks." index) "true"}}}
+                {{{counter clock (concat "system.bond_state.clocks." index) "true"}}}
               {{/each}}
             </div>
           </div>
@@ -215,8 +284,8 @@
       <div class="card clipped">
         <span class="lancer-header lancer-primary submajor">ATTACK UTILITIES</span>
         <div class="lancer-flow-button-grid">
-          {{{flow-button "BASIC ATTACK" "BasicAttack" }}}
-          {{{flow-button "DAMAGE" "Damage" }}}
+          {{{flow-button "BASIC ATTACK" "BasicAttack"}}}
+          {{{flow-button "DAMAGE" "Damage"}}}
         </div>
       </div>
 
@@ -225,13 +294,16 @@
         {{!-- Armor --}}
         <div class="card clipped">
           <h2 class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.tactical.armor"}}</h2>
-          {{#each system.loadout.armor as |armor key|}} {{{pilot-armor-slot (concat "system.loadout.armor." key ".value")}}} {{/each}}
+          {{#each system.loadout.armor as |armor key|}}
+            {{{pilot-armor-slot (concat "system.loadout.armor." key ".value")}}}
+          {{/each}}
         </div>
 
         {{!-- Weapons --}}
         <div class="card clipped">
           <h2 class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.tactical.weapons"}}</h2>
-          {{#each system.loadout.weapons as |weapon key|}} {{{pilot-weapon-slot (concat "system.loadout.weapons." key ".value")}}}
+          {{#each system.loadout.weapons as |weapon key|}}
+            {{{pilot-weapon-slot (concat "system.loadout.weapons." key ".value")}}}
           {{/each}}
         </div>
       </div>
@@ -240,8 +312,12 @@
       <div class="flexrow">
         {{!-- Gear --}}
         <div class="card clipped">
-          <h2 class="lancer-header lancer-primary major clipped-top">{{localize "lancer.pilot-sheet.tactical.gear"}}</h2>
-          {{#each system.loadout.gear as |gear key|}} {{{pilot-gear-slot (concat "system.loadout.gear." key ".value")}}} {{/each}}
+          <h2 class="lancer-header lancer-primary major clipped-top">
+            {{localize "lancer.pilot-sheet.tactical.gear"}}
+          </h2>
+          {{#each system.loadout.gear as |gear key|}}
+            {{{pilot-gear-slot (concat "system.loadout.gear." key ".value")}}}
+          {{/each}}
         </div>
       </div>
 
@@ -249,8 +325,12 @@
       <div class="flexrow">
         {{!-- Reserves --}}
         <div class="card clipped">
-          <h2 class="lancer-header lancer-primary major clipped-top">{{localize "lancer.pilot-sheet.tactical.reserves"}}</h2>
-          {{#each itemTypes.reserve as |reserve index|}} {{{reserve-slot (concat "itemTypes.reserve." index)}}} {{/each}}
+          <h2 class="lancer-header lancer-primary major clipped-top">
+            {{localize "lancer.pilot-sheet.tactical.reserves"}}
+          </h2>
+          {{#each itemTypes.reserve as |reserve index|}}
+            {{{reserve-slot (concat "itemTypes.reserve." index)}}}
+          {{/each}}
         </div>
       </div>
     </div>
@@ -272,7 +352,8 @@
       {{!-- Talents --}}
       <div class="card clipped">
         <h2 class="lancer-header lancer-primary major clipped">{{localize "lancer.pilot-sheet.abilities.talents"}}</h2>
-        {{#each itemTypes.talent as |talent index|}} {{{item-preview (concat "itemTypes.talent." index) "delete" }}}
+        {{#each itemTypes.talent as |talent index|}}
+          {{{item-preview (concat "itemTypes.talent." index) "delete"}}}
         {{/each}}
       </div>
 
@@ -280,19 +361,25 @@
       <div class="flexrow">
         {{!-- Licenses --}}
         <div class="card clipped">
-          <h2 class="lancer-header lancer-primary major clipped-top">{{localize "lancer.pilot-sheet.tactical.licenses"}}</h2>
-          {{#each itemTypes.license as |license index|}} {{{ref-license (concat "itemTypes.license." index) }}} {{/each}}
+          <h2 class="lancer-header lancer-primary major clipped-top">
+            {{localize "lancer.pilot-sheet.tactical.licenses"}}
+          </h2>
+          {{#each itemTypes.license as |license index|}}
+            {{{ref-license (concat "itemTypes.license." index)}}}
+          {{/each}}
         </div>
 
         {{!-- Core Bonuses --}}
         <div class="card clipped">
-          <h2 class="lancer-header lancer-primary major clipped-top">{{localize "lancer.pilot-sheet.tactical.cores"}}</h2>
-          {{#each itemTypes.core_bonus as |core_bonus index|}} {{{item-preview (concat "itemTypes.core_bonus." index) "delete" }}} {{/each}}
+          <h2 class="lancer-header lancer-primary major clipped-top">
+            {{localize "lancer.pilot-sheet.tactical.cores"}}
+          </h2>
+          {{#each itemTypes.core_bonus as |core_bonus index|}}
+            {{{item-preview (concat "itemTypes.core_bonus." index) "delete"}}}
+          {{/each}}
         </div>
       </div>
-
     </div>
-
 
     {{!-- Loadout Tab --}}
     {{!-- Things to put in here:
@@ -301,12 +388,12 @@
     --}}
     <div class="tab loadout flexcol {{tabs.primary.loadout.cssClass}}" data-group="primary" data-tab="loadout">
       {{!-- Active Mech --}}
-      {{{ all-mech-preview }}}
+      {{{all-mech-preview}}}
     </div>
 
     {{!-- Effects Tab --}}
     <div class="tab effects flexcol {{tabs.primary.effects.cssClass}}" data-group="primary" data-tab="effects">
-      {{{effect-categories-view actor effect_categories}}} 
+      {{{effect-categories-view actor effect_categories}}}
     </div>
   </section>
 </section>

--- a/public/templates/chat/attack-card.hbs
+++ b/public/templates/chat/attack-card.hbs
@@ -10,6 +10,15 @@
   {{#if profile}}
     {{{mini-profile profile}}}
   {{/if}}
+  {{#if hit_results.length}}
+    {{{attack-hit-summary hit_results}}}
+    <button
+      class="lancer-button lancer-damage-flow lancer-secondary lancer-attack-primary-action"
+      label="lancer.chat-card.attack.roll-all-damage"
+    >
+      <i class="mdi mdi-dice-multiple i--3 i--light"></i>&nbsp;{{localize "lancer.chat-card.attack.roll-all-damage"}}
+    </button>
+  {{/if}}
   {{#if (not hit_results.length)}}
     <div class="card clipped">
       <div class="lancer-mini-header collapse-trigger" data-collapse-id="{{_uuid}}-attacks">
@@ -76,10 +85,4 @@
     </div>
   {{/if}}
   {{{tag-list "tags"}}}
-  <button
-    class="lancer-button lancer-damage-flow lancer-secondary"
-    label="lancer.chat-card.attack.roll-all-damage"
-  >
-    <i class="mdi mdi-dice-multiple i--3 i--light"></i>&nbsp;{{localize "lancer.chat-card.attack.roll-all-damage"}}
-  </button>
 </div>

--- a/public/templates/chat/tech-attack-card.hbs
+++ b/public/templates/chat/tech-attack-card.hbs
@@ -14,6 +14,9 @@
   {{#if profile}}
     {{{mini-profile profile}}}
   {{/if}}
+  {{#if hit_results.length}}
+    {{{attack-hit-summary hit_results}}}
+  {{/if}}
   {{#if (not hit_results.length)}}
     <div class="card clipped">
       <div class="lancer-mini-header collapse-trigger" data-collapse-id="{{_uuid}}-attacks">

--- a/src/module/actor/import.ts
+++ b/src/module/actor/import.ts
@@ -57,6 +57,25 @@ import { unpackReserve } from "../models/items/reserve";
 import { unpackFrame } from "../models/items/frame";
 const lp = LANCER.log_prefix;
 
+async function notifyCoreDataRequired(): Promise<void> {
+  const message = game.i18n.localize("lancer.import.errors.core-data-required");
+  ui.notifications!.warn(message, { permanent: true });
+  if (!game.user?.isGM) return;
+
+  const { LCPManager } = await import("../apps/lcp-manager/lcp-manager");
+  const open = await foundry.applications.api.DialogV2.confirm({
+    window: { title: game.i18n.localize("lancer.import.errors.core-data-title") },
+    content: `<p>${message}</p>`,
+    yes: {
+      icon: "cci cci-content-manager",
+      label: game.i18n.localize("lancer.import.errors.core-data-open-lcp"),
+      default: true,
+    },
+    no: { icon: "fas fa-times", label: "Close" },
+  });
+  if (open) new LCPManager().render(true);
+}
+
 function unpackClock(clock: PackedClockBurdenData) {
   return {
     lid: clock.id,
@@ -85,7 +104,7 @@ function showIncompleteImportSummary(
   if (missingItems.length) {
     message += ` ${missingItems.length} items could not be found.`;
   }
-  message += ` See dialog for details.`;
+  message += ` Open the dialog for missing LIDs and install required LCPs via the Compendium Manager.`;
   ui.notifications!.warn(message, { permanent: true });
   console.warn(`${lp} Some actors and/or items were missed during pilot import:`, missingActors, missingItems);
 
@@ -278,10 +297,7 @@ async function clearPilotEmbeddedDocuments(pilot: LancerPILOT) {
 function requireCoreDataForImport(): boolean {
   const coreVersion = game.settings.get(game.system.id, LANCER.setting_core_data);
   if (!coreVersion) {
-    ui.notifications!.warn(
-      "You must import the Core Book Data in the Lancer Compendium Manager before importing a pilot.",
-      { permanent: true }
-    );
+    void notifyCoreDataRequired();
     return false;
   }
   return true;

--- a/src/module/actor/mech-sheet.ts
+++ b/src/module/actor/mech-sheet.ts
@@ -260,10 +260,6 @@ export class LancerMechSheet extends LancerActorSheet<EntryType.MECH> {
         this.actor.update({ "system.loadout.systems": [] });
         break;
       case "reset-wep":
-        if (!path) return;
-        ui.notifications?.info("TODO: Reset the weapons");
-        // let wep_mount = resolveDotpath(data, path) as WeaponMount;
-        // wep_mount?.reset();
         break;
       default:
         return; // no-op

--- a/src/module/actor/pilot-sheet.ts
+++ b/src/module/actor/pilot-sheet.ts
@@ -37,7 +37,14 @@ function normalizeCloudImportId(cloudId: string): string {
 /**
  * Extend the basic ActorSheet
  */
+function cloudImportError(prefix: string, error: unknown): string {
+  const detail = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  return detail ? `${prefix} ${detail}` : prefix;
+}
+
 export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
+  private _cloudDownloadInFlight = false;
+
   static override DEFAULT_OPTIONS = foundry.utils.mergeObject(super.DEFAULT_OPTIONS, {
     classes: ["lancer", "sheet", "actor", "pilot"],
     position: { width: 900, height: 800 },
@@ -79,9 +86,23 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
       });
 
     const download = $el.find('.cloud-control[data-action*="download"]');
-    download.removeClass("disabled-cloud");
+    const status = $el.find(".cloud-download-status");
+    const setCloudDownloading = (downloading: boolean) => {
+      this._cloudDownloadInFlight = downloading;
+      download.toggleClass("disabled-cloud cloud-downloading", downloading);
+      download.attr("aria-busy", downloading ? "true" : "false");
+      download.find(".cloud-download-idle").prop("hidden", downloading);
+      download.find(".cloud-download-spinner").prop("hidden", !downloading);
+      if (downloading) {
+        status.text(game.i18n.localize("lancer.pilot-sheet.cloud-download.syncing"));
+      }
+    };
+    if (!this._cloudDownloadInFlight) {
+      download.removeClass("disabled-cloud cloud-downloading");
+    }
     download.off("click.lancerCloudDownload").on("click.lancerCloudDownload", async ev => {
       ev.stopPropagation();
+      if (this._cloudDownloadInFlight) return;
 
       let raw_pilot_data: PackedPilotData | null = null;
       const cloudId = normalizeCloudImportId(pilot.system.cloud_id ?? "");
@@ -92,57 +113,72 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
         return;
       }
 
-      if (shareCodeMatcherV3.test(cloudId)) {
-        ui.notifications!.info("Importing character from V3 share code...");
-        try {
-          raw_pilot_data = await fetchV3PilotViaShareCode(cloudId);
-        } catch (error) {
-          ui.notifications!.error("Error importing from V3 share code.");
-          console.error(`Failed import with V3 share code ${cloudId}, error:`, error);
-          return;
-        }
-      } else if (shareCodeMatcherV2.test(cloudId)) {
-        ui.notifications!.info("Importing character from V2 share code...");
-        try {
-          raw_pilot_data = await fetchV2PilotViaShareCode(cloudId);
-        } catch (error) {
-          ui.notifications!.error("Error importing from V2 share code. Share code may need to be refreshed.");
-          console.error(`Failed import with V2 share code ${cloudId}, error:`, error);
-          return;
-        }
-      } else {
-        const cachedPilot = pilotCache().find(p => p.cloudID == cloudId);
-        if (cachedPilot != undefined) {
-          ui.notifications!.info("Importing character from COMP/CON account...");
+      const lastSyncText = status.text();
+      setCloudDownloading(true);
+      try {
+        if (shareCodeMatcherV3.test(cloudId)) {
+          ui.notifications!.info("Importing character from V3 share code...");
           try {
-            raw_pilot_data = await fetchPilotViaCache(cachedPilot);
+            raw_pilot_data = await fetchV3PilotViaShareCode(cloudId);
+          } catch (error) {
+            ui.notifications!.error(cloudImportError("Error importing from V3 share code.", error));
+            console.error(`Failed import with V3 share code ${cloudId}, error:`, error);
+            return;
+          }
+        } else if (shareCodeMatcherV2.test(cloudId)) {
+          ui.notifications!.info("Importing character from V2 share code...");
+          try {
+            raw_pilot_data = await fetchV2PilotViaShareCode(cloudId);
           } catch (error) {
             ui.notifications!.error(
-              "Failed to import from COMP/CON account. Try refreshing the page to reload pilot list."
+              cloudImportError("Error importing from V2 share code. Share code may need to be refreshed.", error)
             );
-            console.error(`Failed to import vaultID ${cloudId} via pilot list, error:`, error);
+            console.error(`Failed import with V2 share code ${cloudId}, error:`, error);
             return;
           }
         } else {
-          ui.notifications!.info("Importing character from share code...");
-          try {
-            raw_pilot_data = await fetchPilotViaShareCode(cloudId);
-          } catch (error) {
-            ui.notifications!.error(
-              "Failed to import from COMP/CON. Check the share code, vault selection, or try JSON import."
-            );
-            console.error(`Failed import for cloud id ${cloudId}, error:`, error);
-            return;
+          const cachedPilot = pilotCache().find(p => p.cloudID == cloudId);
+          if (cachedPilot != undefined) {
+            ui.notifications!.info("Importing character from COMP/CON account...");
+            try {
+              raw_pilot_data = await fetchPilotViaCache(cachedPilot);
+            } catch (error) {
+              ui.notifications!.error(
+                cloudImportError(
+                  "Failed to import from COMP/CON account. Try refreshing the page to reload pilot list.",
+                  error
+                )
+              );
+              console.error(`Failed to import vaultID ${cloudId} via pilot list, error:`, error);
+              return;
+            }
+          } else {
+            ui.notifications!.info("Importing character from share code...");
+            try {
+              raw_pilot_data = await fetchPilotViaShareCode(cloudId);
+            } catch (error) {
+              ui.notifications!.error(
+                cloudImportError(
+                  "Failed to import from COMP/CON. Check the share code, vault selection, or try JSON import.",
+                  error
+                )
+              );
+              console.error(`Failed import for cloud id ${cloudId}, error:`, error);
+              return;
+            }
           }
         }
-      }
 
-      try {
         await importCC(this.actor as LancerPILOT, raw_pilot_data);
         this.render();
       } catch (error) {
-        ui.notifications!.error("COMP/CON import failed. See the console for details.");
+        ui.notifications!.error(cloudImportError("COMP/CON import failed.", error));
         console.error(`${lp} COMP/CON import failed for cloud id ${cloudId}:`, error);
+      } finally {
+        setCloudDownloading(false);
+        if (!this._cloudDownloadInFlight) {
+          status.text(lastSyncText);
+        }
       }
     });
 

--- a/src/module/apps/slidinghud/SlidingHUDZone.svelte
+++ b/src/module/apps/slidinghud/SlidingHUDZone.svelte
@@ -152,7 +152,7 @@
       }
 
       #hudzone.faded > .component {
-        pointer-events: unset;
+        pointer-events: none;
       }
     }
   }

--- a/src/module/helpers/chat.ts
+++ b/src/module/helpers/chat.ts
@@ -59,6 +59,31 @@ export function miniProfile(
     </div>`;
 }
 
+export function attackHitSummary(hitResults: LancerFlowState.HitResultWithRoll[], _options: HelperOptions): string {
+  if (!hitResults?.length) return "";
+
+  let hits = 0;
+  let crits = 0;
+  let misses = 0;
+  for (const hit of hitResults) {
+    if (hit.crit) crits++;
+    else if (hit.hit) hits++;
+    else misses++;
+  }
+
+  const parts: string[] = [];
+  if (hits) parts.push(game.i18n.format("lancer.chat-card.attack.hit-summary-hits", { n: hits }));
+  if (crits) parts.push(game.i18n.format("lancer.chat-card.attack.hit-summary-crits", { n: crits }));
+  if (misses) parts.push(game.i18n.format("lancer.chat-card.attack.hit-summary-misses", { n: misses }));
+
+  const summary = game.i18n.format("lancer.chat-card.attack.hit-summary", {
+    parts: parts.join(", "),
+    total: hitResults.length,
+  });
+
+  return `<div class="lancer-attack-hit-summary card clipped">${summary}</div>`;
+}
+
 export function attackTarget(hit: LancerFlowState.HitResultWithRoll, options: HelperOptions): string {
   const hitChip = hit.crit
     ? `<span class="card clipped lancer-hit-chip crit">${game.i18n.format("lancer.chat-card.attack.crit")}</span>`

--- a/src/module/helpers/index.ts
+++ b/src/module/helpers/index.ts
@@ -93,7 +93,7 @@ import {
 import { effect_categories_view, effect_view } from "./effects";
 import { compactTagListHBS, itemEditTags } from "./tags";
 import { actionTypeSelector } from "./npc";
-import { attackTarget, damageTarget, miniProfile } from "./chat";
+import { attackHitSummary, attackTarget, damageTarget, miniProfile } from "./chat";
 
 export function registerHandlebarsHelpers() {
   // *******************************************************************
@@ -374,6 +374,7 @@ export function registerHandlebarsHelpers() {
   // ------------------------------------------------------------------------
   // Chat helpers
   Handlebars.registerHelper("mini-profile", miniProfile);
+  Handlebars.registerHelper("attack-hit-summary", attackHitSummary);
   Handlebars.registerHelper("attack-target", attackTarget);
   Handlebars.registerHelper("damage-target", damageTarget);
 }

--- a/src/module/helpers/loadout.ts
+++ b/src/module/helpers/loadout.ts
@@ -129,7 +129,6 @@ function weaponMount(mount_path: string, options: HelperOptions): string {
       <div class="lancer-header lancer-primary mount-type-ctx-root" data-path="${mount_path}">
         <span>${mount.type} Weapon Mount</span>
         <a class="gen-control fas fa-trash" data-action="splice" data-path="${mount_path}"></a>
-        <a class="reset-weapon-mount-button fas fa-redo" data-path="${mount_path}"></a>
       </div>
       <div class="lancer-body">
         <span class="major">LOCKED: BRACING</span>
@@ -174,7 +173,6 @@ function weaponMount(mount_path: string, options: HelperOptions): string {
       <div class="lancer-header lancer-primary mount-type-ctx-root" data-path="${mount_path}">
         <span>${mount.type} Weapon Mount</span>
         <a class="gen-control fas fa-trash" data-action="splice" data-path="${mount_path}"></a>
-        <a class="reset-weapon-mount-button fas fa-redo" data-path="${mount_path}"></a>
       </div>
       ${inc_if(`<span class="lancer-header lancer-primary error">${err.toUpperCase()}</span>`, err)}
       <div class="lancer-body">

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -437,6 +437,18 @@
     cursor: default;
   }
 
+  .cloud-download-button.cloud-downloading {
+    cursor: wait;
+  }
+
+  .cloud-download-button .cloud-download-spinner[hidden] {
+    display: none;
+  }
+
+  .cloud-download-button.cloud-downloading .cloud-download-idle[hidden] {
+    display: none;
+  }
+
   // TODO: use a mixin, specify actor sheet, echo in _item-sheet.scss
   /* Default text and background color for sheets */
   .lancer.sheet .window-content {

--- a/src/styles/components/_chat.scss
+++ b/src/styles/components/_chat.scss
@@ -1,4 +1,16 @@
 @layer lancer.components {
+  .lancer-attack-hit-summary {
+    margin: 0.35rem 0;
+    padding: 0.35rem 0.5rem;
+    text-align: center;
+    font-weight: bold;
+  }
+
+  .lancer-attack-primary-action {
+    margin: 0.35rem 0 0.5rem;
+    width: 100%;
+  }
+
   .card.lancer-charge-chip {
     color: var(--light-text);
     background-color: var(--dark-gray-color);

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.12.10",
+  "version": "2.12.11",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.10/lancer-v2.12.10.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.11/lancer-v2.12.11.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Sprint A / v2.12.11** from the LANCER UX pass — all five trust-and-polish items in one release.

Closes #54
Closes #55
Closes #56
Closes #57
Closes #58

Part of release epic #44.

## Changes

| Issue | Change |
|-------|--------|
| #54 | Import/COMP/CON errors show actual messages; GM **Open LCP Manager** dialog when core data missing |
| #55 | Removed pilot Cloud upload WIP card; removed per-mount reset buttons (unimplemented) |
| #56 | Cloud download spinner + “Syncing…” status; button disabled during import |
| #57 | Attack card hit summary; **Roll Damage** pinned above collapsibles |
| #58 | HUD panels `pointer-events: none` while faded during token drag |

Also fixes pre-existing mismatched `</span>` close tags on pilot sheet header headings (dprint).

## Version

**2.12.11** — see `CHANGELOG.md`

## Test plan

- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`
- [ ] Pilot Cloud tab: download shows spinner; errors show message text
- [ ] Missing core data: GM sees LCP Manager prompt
- [ ] Weapon attack chat card: summary + Roll Damage visible without expanding sections
- [ ] Drag token on canvas with HUD open: cannot click HUD controls
- [ ] Mech loadout: no reset icon on weapon mounts; no TODO toast
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

