### PR TITLE
UX v2.13.0: Combat loop sprint (#59–#62)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,9 @@ Handled by the VM update script: `CI=1 npm ci` from repo root (skips `postinstal
 
 ### Running the stack
 
-| Process | Port | Required? |
-|---------|------|-----------|
-| Foundry VTT | 30000 | **Yes** for in-browser testing |
+| Process                | Port  | Required?                                              |
+| ---------------------- | ----- | ------------------------------------------------------ |
+| Foundry VTT            | 30000 | **Yes** for in-browser testing                         |
 | Vite (`npm run serve`) | 30001 | Optional HMR; proxies non-`/systems/lancer` to Foundry |
 
 **Foundry is not bundled.** Install Node Foundry under `installPath` and set `dataPath` via `fvttrc.yml` (gitignored) or `~/.fvttrc.yml`, then `npx fvtt --config ./fvttrc.yml launch`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2.13.0 (2026-06-06)
+
+## Added
+
+- World automation setting **Prompt Damage After Attack** (default off): when enabled and an attack hits, the damage HUD opens automatically after the attack card.
+- Acc/Diff attack HUD **Advanced** section for weapon/target plugins, measured templates, and per-target fine modifiers; client setting remembers expanded state per weapon.
+- **Reroll** button on attack and tech-attack chat cards (visible to attacker owner and GM).
+- Combat tracker tour steps documenting the attack → damage → apply loop and the auto-damage setting.
+
+## Changed
+
+- Acc/Diff HUD default view emphasizes targets, totals, and cover; plugins and template tools move under Advanced.
+
 # 2.12.11 (2026-06-06)
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.12.11",
+  "version": "2.13.0",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -226,7 +226,8 @@
         "hit-summary": "{parts} / {total} targets",
         "hit-summary-hits": "{n} hits",
         "hit-summary-crits": "{n} crits",
-        "hit-summary-misses": "{n} misses"
+        "hit-summary-misses": "{n} misses",
+        "reroll": "Reroll this attack"
       },
       "exclamation": {
         "overkill": "OVERKILL!"
@@ -420,7 +421,18 @@
       "npc_recharge": "NPC Recharge",
       "npc_recharge-desc": "Automatically roll to recharge NPC systems at the start of their turn.",
       "token_size": "Manage Token Sizes",
-      "token_size-desc": "Automatically force tokens sizes to match the associated actor's size stat."
+      "token_size-desc": "Automatically force tokens sizes to match the associated actor's size stat.",
+      "prompt_damage_after_attack": "Prompt Damage After Attack",
+      "prompt_damage_after_attack-desc": "When an attack hits at least one target, open the damage roll HUD automatically after the attack card is posted."
+    },
+    "accdiff": {
+      "rememberAdvanced": {
+        "name": "Remember Acc/Diff Advanced Section",
+        "hint": "When enabled, the expanded/collapsed state of the Advanced section in the attack Acc/Diff HUD is remembered per weapon."
+      },
+      "advanced": "Advanced",
+      "showAdvanced": "Show plugins, templates, and per-target modifiers",
+      "hideAdvanced": "Hide advanced options"
     },
     "actionTracker": {
       "menu-name": "Action Tracker",

--- a/public/templates/chat/attack-card.hbs
+++ b/public/templates/chat/attack-card.hbs
@@ -2,10 +2,13 @@
   <div class="lancer-header lancer-weapon medium">
     <i class="cci cci-weapon i--4 i--light"> </i>
     <span>{{title}}</span>
-    {{!-- TODO: refactor reroll button --}}
-    <!-- <a class="flow-button roll-attack lancer-button lancer-macro" data-macro="{{rerollMacroData}}" title="Reroll this attack">
+    <button
+      class="lancer-attack-reroll lancer-button lancer-macro"
+      type="button"
+      title="{{localize 'lancer.chat-card.attack.reroll'}}"
+    >
       <i class="fas fa-dice-d20 i--4 i--light"></i>
-    </a> -->
+    </button>
   </div>
   {{#if profile}}
     {{{mini-profile profile}}}

--- a/public/templates/chat/tech-attack-card.hbs
+++ b/public/templates/chat/tech-attack-card.hbs
@@ -2,14 +2,13 @@
   <div class="lancer-header lancer-tech tech medium">
     <i class="cci cci-tech-quick i--4 i--light"> </i>
     <span>{{#if invade}}INVADE{{else}}TECH ATK{{/if}}{{#if title}} :: {{title}}{{/if}}</span>
-    {{! TODO: refactor reroll button }}
-    <!-- <a
-      class="flow-button roll-attack lancer-button lancer-macro"
-      data-macro="{{rerollMacroData}}"
-      title="Reroll this attack"
+    <button
+      class="lancer-attack-reroll lancer-button lancer-macro"
+      type="button"
+      title="{{localize 'lancer.chat-card.attack.reroll'}}"
     >
       <i class="fas fa-dice-d20 i--4 i--light"></i>
-    </a> -->
+    </button>
   </div>
   {{#if profile}}
     {{{mini-profile profile}}}

--- a/public/templates/settings/automation-config.hbs
+++ b/public/templates/settings/automation-config.hbs
@@ -1,5 +1,6 @@
 <section>
   {{formGroup fields.attacks value=config.attacks localize=true}}
+  {{formGroup fields.prompt_damage_after_attack value=config.prompt_damage_after_attack localize=true}}
   {{formGroup fields.structure value=config.structure localize=true}}
   {{formGroup fields.overcharge_heat value=config.overcharge_heat localize=true}}
   {{formGroup fields.attack_self_heat value=config.attack_self_heat localize=true}}

--- a/public/tours/combat.json
+++ b/public/tours/combat.json
@@ -54,6 +54,34 @@
       "title": "lancer.tour.combat.combatSettings.title",
       "content": "lancer.tour.combat.combatSettings.content",
       "sidebarTab": "combat"
+    },
+    {
+      "id": "attackDamageLoop",
+      "selector": "#combat .combat-tracker",
+      "title": "lancer.tour.combat.attackDamageLoop.title",
+      "content": "lancer.tour.combat.attackDamageLoop.content",
+      "sidebarTab": "combat"
+    },
+    {
+      "id": "manualDamage",
+      "selector": "#combat .combat-tracker",
+      "title": "lancer.tour.combat.manualDamage.title",
+      "content": "lancer.tour.combat.manualDamage.content",
+      "sidebarTab": "combat"
+    },
+    {
+      "id": "autoDamagePrompt",
+      "selector": "#combat .combat-tracker",
+      "title": "lancer.tour.combat.autoDamagePrompt.title",
+      "content": "lancer.tour.combat.autoDamagePrompt.content",
+      "sidebarTab": "combat"
+    },
+    {
+      "id": "applyDamage",
+      "selector": "#combat .combat-tracker",
+      "title": "lancer.tour.combat.applyDamage.title",
+      "content": "lancer.tour.combat.applyDamage.content",
+      "sidebarTab": "combat"
     }
   ],
   "suggestedNextTours": [],
@@ -88,6 +116,22 @@
       "combatSettings": {
         "title": "Combat Settings",
         "content": "The settings menu has been customized to allow configuring LANCER specific options."
+      },
+      "attackDamageLoop": {
+        "title": "Attack → Damage → Apply",
+        "content": "LANCER combat flows from an attack roll in chat to a damage roll, then to applying damage on each target. After a weapon attack hits, use the Roll Damage button pinned on the attack card to open the damage HUD."
+      },
+      "manualDamage": {
+        "title": "Manual damage (default)",
+        "content": "By default, you roll damage yourself after reviewing the attack card. Select targets on the damage HUD, confirm damage types, then roll. Each target can be applied from the resulting damage card."
+      },
+      "autoDamagePrompt": {
+        "title": "Optional auto-damage prompt",
+        "content": "GMs can enable <strong>Prompt Damage After Attack</strong> under Configure Settings → Automation. When enabled and an attack records at least one hit, the damage HUD opens automatically after the attack card—cancel closes the HUD without applying damage."
+      },
+      "applyDamage": {
+        "title": "Applying damage",
+        "content": "Damage cards list each target with Apply buttons. Applied damage updates the token's HP or heat on the sheet. Use Undo on a target if you need to reverse an application."
       }
     }
   }

--- a/scripts/ux-roadmap/MANUAL-SETUP.md
+++ b/scripts/ux-roadmap/MANUAL-SETUP.md
@@ -60,11 +60,11 @@ The workflow runs a **Verify token can access Projects** step first and prints a
 
 Open **LANCER UX pass** under your profile **Projects** tab:
 
-| View | Layout | Group by | Sort |
-|------|--------|----------|------|
-| Roadmap | Roadmap | Release | PR # |
-| Board | Board | Status | Priority |
-| Table | Table | — | Release, PR # |
+| View    | Layout  | Group by | Sort          |
+| ------- | ------- | -------- | ------------- |
+| Roadmap | Roadmap | Release  | PR #          |
+| Board   | Board   | Status   | Priority      |
+| Table   | Table   | —        | Release, PR # |
 
 ### 5. Revoke token (optional)
 
@@ -83,13 +83,13 @@ After success, revoke at [Tokens (classic)](https://github.com/settings/tokens) 
 
 ### 2. Add custom fields
 
-| Field | Type | Options |
-|-------|------|---------|
-| Type | Single select | Epic, Release, PR |
-| Release | Single select | v2.12.11 … v3.0.0 |
-| Sprint | Single select | A, B, C, D, E, F, G |
-| Priority | Single select | P0, P1, P2 |
-| PR # | Number | — |
+| Field    | Type          | Options             |
+| -------- | ------------- | ------------------- |
+| Type     | Single select | Epic, Release, PR   |
+| Release  | Single select | v2.12.11 … v3.0.0   |
+| Sprint   | Single select | A, B, C, D, E, F, G |
+| Priority | Single select | P0, P1, P2          |
+| PR #     | Number        | —                   |
 
 ### 3. Add issues
 

--- a/scripts/ux-roadmap/README.md
+++ b/scripts/ux-roadmap/README.md
@@ -30,11 +30,11 @@ Progress is saved to `bootstrap-state.json` (gitignored) so re-runs skip existin
 
 After bootstrap, open the project URL printed by the script and add:
 
-| View | Layout | Group by | Sort |
-|------|--------|----------|------|
-| **Roadmap** | Roadmap | Release | PR # |
-| **Board** | Board | Status | Priority |
-| **Release table** | Table | — | Release, PR # |
+| View              | Layout  | Group by | Sort          |
+| ----------------- | ------- | -------- | ------------- |
+| **Roadmap**       | Roadmap | Release  | PR #          |
+| **Board**         | Board   | Status   | Priority      |
+| **Release table** | Table   | —        | Release, PR # |
 
 Enable **Status** field (built-in) for Todo / In Progress / Done.
 
@@ -45,24 +45,24 @@ Enable **Status** field (built-in) for Todo / In Progress / Done.
 
 ## Issue index (generated)
 
-| Kind | Issue |
-|------|-------|
-| **Epic** | [#43](https://github.com/VacantFanatic/foundryvtt-lancer/issues/43) |
-| Release v2.12.11 | [#44](https://github.com/VacantFanatic/foundryvtt-lancer/issues/44) |
-| Release v2.13.0 | [#45](https://github.com/VacantFanatic/foundryvtt-lancer/issues/45) |
-| Release v2.14.0 | [#46](https://github.com/VacantFanatic/foundryvtt-lancer/issues/46) |
-| Release v2.15.0 | [#47](https://github.com/VacantFanatic/foundryvtt-lancer/issues/47) |
-| Release v2.16.0 | [#48](https://github.com/VacantFanatic/foundryvtt-lancer/issues/48) |
-| Release v2.17.0 | [#49](https://github.com/VacantFanatic/foundryvtt-lancer/issues/49) |
-| Release v2.18.0 | [#50](https://github.com/VacantFanatic/foundryvtt-lancer/issues/50) |
-| Release v2.19.0 | [#51](https://github.com/VacantFanatic/foundryvtt-lancer/issues/51) |
-| Release v2.20.0 | [#52](https://github.com/VacantFanatic/foundryvtt-lancer/issues/52) |
-| Release v3.0.0 | [#53](https://github.com/VacantFanatic/foundryvtt-lancer/issues/53) |
-| PR1–PR32 | [#54](https://github.com/VacantFanatic/foundryvtt-lancer/issues/54)–[#85](https://github.com/VacantFanatic/foundryvtt-lancer/issues/85) |
+| Kind             | Issue                                                                                                                                   |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Epic**         | [#43](https://github.com/VacantFanatic/foundryvtt-lancer/issues/43)                                                                     |
+| Release v2.12.11 | [#44](https://github.com/VacantFanatic/foundryvtt-lancer/issues/44)                                                                     |
+| Release v2.13.0  | [#45](https://github.com/VacantFanatic/foundryvtt-lancer/issues/45)                                                                     |
+| Release v2.14.0  | [#46](https://github.com/VacantFanatic/foundryvtt-lancer/issues/46)                                                                     |
+| Release v2.15.0  | [#47](https://github.com/VacantFanatic/foundryvtt-lancer/issues/47)                                                                     |
+| Release v2.16.0  | [#48](https://github.com/VacantFanatic/foundryvtt-lancer/issues/48)                                                                     |
+| Release v2.17.0  | [#49](https://github.com/VacantFanatic/foundryvtt-lancer/issues/49)                                                                     |
+| Release v2.18.0  | [#50](https://github.com/VacantFanatic/foundryvtt-lancer/issues/50)                                                                     |
+| Release v2.19.0  | [#51](https://github.com/VacantFanatic/foundryvtt-lancer/issues/51)                                                                     |
+| Release v2.20.0  | [#52](https://github.com/VacantFanatic/foundryvtt-lancer/issues/52)                                                                     |
+| Release v3.0.0   | [#53](https://github.com/VacantFanatic/foundryvtt-lancer/issues/53)                                                                     |
+| PR1–PR32         | [#54](https://github.com/VacantFanatic/foundryvtt-lancer/issues/54)–[#85](https://github.com/VacantFanatic/foundryvtt-lancer/issues/85) |
 
 Re-run `bootstrap.mjs` as repo owner to create labels, milestones, the GitHub Project, and refresh epic/release bodies with cross-links.
 
 ## Cursor cloud agents
 
-Implementation branches: `cursor/ux-<slug>-4b38`  
-Link PRs to issues: `Closes #<issue>` in PR description (PR *n* → issue *53+n* for PR1=#54).
+Implementation branches: `cursor/ux-<slug>-4b38`\
+Link PRs to issues: `Closes #<issue>` in PR description (PR _n_ → issue _53+n_ for PR1=#54).

--- a/scripts/ux-roadmap/bootstrap.mjs
+++ b/scripts/ux-roadmap/bootstrap.mjs
@@ -110,14 +110,7 @@ function createMilestones(state) {
     if (state.milestones[ms.title]) continue;
     try {
       const res = JSON.parse(
-        gh([
-          "api",
-          `repos/${REPO}/milestones`,
-          "-f",
-          `title=${ms.title}`,
-          "-f",
-          `description=${ms.description}`,
-        ])
+        gh(["api", `repos/${REPO}/milestones`, "-f", `title=${ms.title}`, "-f", `description=${ms.description}`])
       );
       state.milestones[ms.title] = res.number;
       log("  milestone", ms.title, "#" + res.number);
@@ -140,11 +133,7 @@ function createIssue(title, body, { milestone, labels: labelNames = [] }) {
     withLabels.push("-l", l);
   }
 
-  const attempts = [
-    labelNames.length ? withLabels : withMilestone,
-    withMilestone,
-    minimal,
-  ];
+  const attempts = [labelNames.length ? withLabels : withMilestone, withMilestone, minimal];
   const seen = new Set();
   let lastError;
   for (const args of attempts) {
@@ -208,7 +197,10 @@ _Tracking issue for [UX Roadmap 2026](https://github.com/${REPO}/issues/${state.
 }
 
 function releaseBody(rel, state) {
-  const prIds = prs.filter(p => p.release === rel.id).map(p => state.issues.pr?.[p.id]).filter(Boolean);
+  const prIds = prs
+    .filter(p => p.release === rel.id)
+    .map(p => state.issues.pr?.[p.id])
+    .filter(Boolean);
   return `## UX Roadmap — Release v${rel.id}
 
 | Field | Value |
@@ -271,11 +263,7 @@ function createIssues(state) {
   log("Creating tracking issues...");
 
   if (!state.issues.epic) {
-    state.issues.epic = createIssue(
-      "[UX Epic] UX Roadmap 2026",
-      epicBody(),
-      { labels: issueLabels("epic", "P0") },
-    );
+    state.issues.epic = createIssue("[UX Epic] UX Roadmap 2026", epicBody(), { labels: issueLabels("epic", "P0") });
   }
 
   state.issues.release = state.issues.release ?? {};
@@ -287,27 +275,25 @@ function createIssues(state) {
       {
         milestone: releaseMilestoneTitle(rel.id),
         labels: issueLabels("epic", rel.priority),
-      },
+      }
     );
   }
 
   state.issues.pr = state.issues.pr ?? {};
   for (const pr of prs) {
     if (state.issues.pr[pr.id]) continue;
-    state.issues.pr[pr.id] = createIssue(
-      `[UX PR${pr.id}] ${pr.title}`,
-      prBody(pr, state),
-      {
-        milestone: releaseMilestoneTitle(pr.release),
-        labels: issueLabels("pr", pr.priority),
-      },
-    );
+    state.issues.pr[pr.id] = createIssue(`[UX PR${pr.id}] ${pr.title}`, prBody(pr, state), {
+      milestone: releaseMilestoneTitle(pr.release),
+      labels: issueLabels("pr", pr.priority),
+    });
   }
 
   // Refresh epic body with issue links
   if (!dryRun && state.issues.epic) {
     const epicNum = state.issues.epic;
-    const updated = epicBody() + "\n### Release issues\n" +
+    const updated =
+      epicBody() +
+      "\n### Release issues\n" +
       releases.map(r => `- v${r.id}: #${state.issues.release[r.id]}`).join("\n");
     try {
       gh(["issue", "edit", String(epicNum), "-R", REPO, "--body", updated]);
@@ -394,17 +380,18 @@ function createProject(state) {
     }
   }
 
-  const existingFields = ghJson([
-    "project",
-    "field-list",
-    String(proj.number),
-    "--owner",
-    projectOwner(),
-    "--format",
-    "json",
-    "--limit",
-    "50",
-  ]).fields ?? [];
+  const existingFields =
+    ghJson([
+      "project",
+      "field-list",
+      String(proj.number),
+      "--owner",
+      projectOwner(),
+      "--format",
+      "json",
+      "--limit",
+      "50",
+    ]).fields ?? [];
   const existingNames = new Set(existingFields.map(f => f.name));
 
   for (const field of PROJECT_FIELD_DEFS) {

--- a/scripts/ux-roadmap/roadmap.json
+++ b/scripts/ux-roadmap/roadmap.json
@@ -14,16 +14,31 @@
     { "name": "priority/p2", "color": "FBCA04", "description": "Polish and long-term UX work" }
   ],
   "milestones": [
-    { "title": "v2.12.11 — Trust & polish", "description": "Quick wins: import errors, WIP cleanup, cloud spinner, chat layout, HUD drag fix." },
-    { "title": "v2.13.0 — Combat loop", "description": "Auto-damage prompt, Acc/Diff disclosure, combat tour, chat rerolls." },
-    { "title": "v2.14.0 — Import & equip", "description": "Pilot cloud wizard, empty slot picker, unified import dialog." },
+    {
+      "title": "v2.12.11 — Trust & polish",
+      "description": "Quick wins: import errors, WIP cleanup, cloud spinner, chat layout, HUD drag fix."
+    },
+    {
+      "title": "v2.13.0 — Combat loop",
+      "description": "Auto-damage prompt, Acc/Diff disclosure, combat tour, chat rerolls."
+    },
+    {
+      "title": "v2.14.0 — Import & equip",
+      "description": "Pilot cloud wizard, empty slot picker, unified import dialog."
+    },
     { "title": "v2.15.0 — Sheet IA", "description": "Pilot defaults, mech stat sections, NPC tabs." },
-    { "title": "v2.16.0 — A11y & dialogs", "description": "Collapse a11y, action manager labels, DialogV2, HUD focus trap, i18n." },
+    {
+      "title": "v2.16.0 — A11y & dialogs",
+      "description": "Collapse a11y, action manager labels, DialogV2, HUD focus trap, i18n."
+    },
     { "title": "v2.17.0 — Help & tours", "description": "Contextual help, what's new, tour maintenance." },
     { "title": "v2.18.0 — Visual consistency", "description": "SCSS migration, remove legacy LCP HBS." },
     { "title": "v2.19.0 — Finish stubs", "description": "Async loading, mount reset, combat tracker targets." },
     { "title": "v2.20.0 — Interactive sheets", "description": "Svelte cloud island, experimental loadout editor." },
-    { "title": "v3.0.0 — Loadout editor GA", "description": "Optional major: promote loadout editor, remove legacy markup." }
+    {
+      "title": "v3.0.0 — Loadout editor GA",
+      "description": "Optional major: promote loadout editor, remove legacy markup."
+    }
   ],
   "releases": [
     {
@@ -116,7 +131,13 @@
       "priority": "P0",
       "parallel": true,
       "dependsOn": [],
-      "files": ["src/module/actor/import.ts", "src/lancer.ts", "src/module/world_migration.ts", "src/module/apps/lcp-manager/lcp-manager.ts", "lang/en.json"],
+      "files": [
+        "src/module/actor/import.ts",
+        "src/lancer.ts",
+        "src/module/world_migration.ts",
+        "src/module/apps/lcp-manager/lcp-manager.ts",
+        "lang/en.json"
+      ],
       "acceptance": [
         "Failed COMP/CON import shows reason and next step",
         "Missing-core errors include Open LCP Manager action",
@@ -131,7 +152,11 @@
       "priority": "P0",
       "parallel": true,
       "dependsOn": [],
-      "files": ["public/templates/actor/pilot.hbs", "src/module/actor/mech-sheet.ts", "src/module/actor/lancer-actor-sheet.ts"],
+      "files": [
+        "public/templates/actor/pilot.hbs",
+        "src/module/actor/mech-sheet.ts",
+        "src/module/actor/lancer-actor-sheet.ts"
+      ],
       "acceptance": [
         "No user-visible TODO toasts",
         "Pilot upload WIP card hidden until implemented"
@@ -145,7 +170,11 @@
       "priority": "P0",
       "parallel": true,
       "dependsOn": [],
-      "files": ["src/module/actor/pilot-sheet.ts", "public/templates/actor/pilot.hbs", "src/styles/applications/_actor-sheet.scss"],
+      "files": [
+        "src/module/actor/pilot-sheet.ts",
+        "public/templates/actor/pilot.hbs",
+        "src/styles/applications/_actor-sheet.scss"
+      ],
       "acceptance": [
         "Download button disabled with spinner during sync",
         "Double-click cannot fire duplicate downloads"
@@ -159,7 +188,11 @@
       "priority": "P0",
       "parallel": true,
       "dependsOn": [],
-      "files": ["public/templates/chat/attack-card.hbs", "public/templates/chat/tech-attack-card.hbs", "src/module/helpers/chat.ts"],
+      "files": [
+        "public/templates/chat/attack-card.hbs",
+        "public/templates/chat/tech-attack-card.hbs",
+        "src/module/helpers/chat.ts"
+      ],
       "acceptance": [
         "Hit summary visible at top of card",
         "Roll Damage CTA pinned above collapsible sections"
@@ -184,7 +217,12 @@
       "priority": "P0",
       "parallel": false,
       "dependsOn": [4],
-      "files": ["src/module/flows/attack.ts", "src/module/apps/automation-settings.ts", "public/templates/settings/automation-config.hbs", "lang/en.json"],
+      "files": [
+        "src/module/flows/attack.ts",
+        "src/module/apps/automation-settings.ts",
+        "public/templates/settings/automation-config.hbs",
+        "lang/en.json"
+      ],
       "acceptance": [
         "World setting defaults to off",
         "When on and hits exist, Damage HUD opens after attack card",
@@ -236,7 +274,11 @@
       "priority": "P0",
       "parallel": true,
       "dependsOn": [3],
-      "files": ["public/templates/actor/pilot.hbs", "src/styles/applications/_actor-sheet.scss", "src/module/actor/pilot-sheet.ts"],
+      "files": [
+        "public/templates/actor/pilot.hbs",
+        "src/styles/applications/_actor-sheet.scss",
+        "src/module/actor/pilot-sheet.ts"
+      ],
       "acceptance": [
         "Stepped layout: Login → Select → Download/JSON",
         "Unsynced pilots default to Cloud tab",
@@ -251,7 +293,12 @@
       "priority": "P0",
       "parallel": true,
       "dependsOn": [],
-      "files": ["src/module/helpers/refs.ts", "src/module/helpers/dragdrop.ts", "src/module/actor/lancer-actor-sheet.ts", "lang/en.json"],
+      "files": [
+        "src/module/helpers/refs.ts",
+        "src/module/helpers/dragdrop.ts",
+        "src/module/actor/lancer-actor-sheet.ts",
+        "lang/en.json"
+      ],
       "acceptance": [
         "Empty slots show drag hint",
         "Click opens filtered compendium picker",
@@ -343,7 +390,11 @@
       "priority": "P1",
       "parallel": false,
       "dependsOn": [7],
-      "files": ["src/module/apps/acc_diff/AccDiffHUD.svelte", "src/module/apps/damage/DamageHUD.svelte", "src/module/apps/struct_stress/StructStressHUD.svelte"],
+      "files": [
+        "src/module/apps/acc_diff/AccDiffHUD.svelte",
+        "src/module/apps/damage/DamageHUD.svelte",
+        "src/module/apps/struct_stress/StructStressHUD.svelte"
+      ],
       "acceptance": ["aria-modal and focus trap while HUD open; Escape still cancels"]
     },
     {
@@ -409,7 +460,11 @@
       "priority": "P2",
       "parallel": true,
       "dependsOn": [],
-      "files": ["public/templates/actor/pilot.hbs", "public/templates/chat/*.hbs", "src/styles/applications/_actor-sheet.scss"],
+      "files": [
+        "public/templates/actor/pilot.hbs",
+        "public/templates/chat/*.hbs",
+        "src/styles/applications/_actor-sheet.scss"
+      ],
       "acceptance": ["Inline style attributes replaced with SCSS utility classes"]
     },
     {

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,5 +1,5 @@
 import type { LancerActionManager } from "./module/action/action-manager";
-import type { AttackFlag } from "./module/flows/attack";
+import type { AttackFlag, AttackRerollFlag } from "./module/flows/interfaces";
 import type { DamageFlag } from "./module/flows/damage";
 import type { DeployableModel } from "./module/models/actors/deployable";
 import type { MechModel } from "./module/models/actors/mech";
@@ -122,6 +122,7 @@ declare module "fvtt-types/configuration" {
     ChatMessage: {
       lancer: {
         attackData?: AttackFlag;
+        attackReroll?: AttackRerollFlag;
         damageData?: DamageFlag;
       };
     };

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -81,6 +81,7 @@ import { fulfillImportActor } from "./module/util/requests";
 
 import { dropStatusToCanvas } from "./module/canvas/drop-status";
 import { beginCascadeFlow } from "./module/flows/cascade";
+import { rerollAttackCallback } from "./module/flows/attack";
 import { applyDamage, rollDamageCallback, undoDamage } from "./module/flows/damage";
 import { Flow } from "./module/flows/flow";
 import { onHotbarDrop } from "./module/flows/hotbar";
@@ -812,6 +813,19 @@ Hooks.on("renderChatMessageHTML", async (cm, el, data) => {
   atkDmgTargets.on("mouseleave", hoverCallback);
 
   html.find(".lancer-damage-flow").on("click", rollDamageCallback);
+
+  html.find(".lancer-attack-reroll").each((_i, el) => {
+    const attackData = cm.flags?.lancer?.attackData;
+    const rerollData = cm.flags?.lancer?.attackReroll;
+    const attackerUuid = attackData?.attackerUuid;
+    const actor = attackerUuid ? (fromUuidSync(attackerUuid) as LancerActor | null) : null;
+    const canReroll = !!rerollData && !!actor && (actor.isOwner || game.user?.isGM);
+    if (!canReroll) {
+      el.remove();
+      return;
+    }
+    $(el).on("click", rerollAttackCallback);
+  });
 
   html.find(".lancer-damage-apply").on("click", applyDamage);
 

--- a/src/module/apps/acc_diff/AccDiffHUD.svelte
+++ b/src/module/apps/acc_diff/AccDiffHUD.svelte
@@ -22,6 +22,8 @@
   import { LancerToken } from "../../token";
   import AccDiffInput from "./AccDiffInput.svelte";
   import type { SystemTemplates } from "../../system-template";
+  import { LANCER } from "../../config";
+  import { onMount } from "svelte";
 
   export let weapon: AccDiffHudWeapon;
   export let base: AccDiffHudBase;
@@ -51,6 +53,48 @@
 
   const dispatch = createEventDispatcher();
   let submitted = false;
+  let showAdvanced = false;
+
+  $: hasAdvancedContent =
+    kind === "attack" &&
+    (accWeaponPlugins.length > 0 ||
+      diffWeaponPlugins.length > 0 ||
+      accTargetPlugins.length > 0 ||
+      diffTargetPlugins.length > 0 ||
+      (ranges && ranges.length > 0) ||
+      targets.length > 1);
+
+  function advancedStorageKey() {
+    return lancerItem?.uuid ?? title;
+  }
+
+  function loadAdvancedPreference() {
+    if (!game.settings.get(game.system.id, LANCER.setting_accdiff_remember_advanced)) return;
+    const expanded = game.settings.get(game.system.id, LANCER.setting_accdiff_advanced_expanded) as Record<
+      string,
+      boolean
+    >;
+    showAdvanced = !!expanded[advancedStorageKey()];
+  }
+
+  function persistAdvancedPreference() {
+    if (!game.settings.get(game.system.id, LANCER.setting_accdiff_remember_advanced)) return;
+    const key = advancedStorageKey();
+    const expanded = {
+      ...(game.settings.get(game.system.id, LANCER.setting_accdiff_advanced_expanded) as Record<string, boolean>),
+    };
+    expanded[key] = showAdvanced;
+    void game.settings.set(game.system.id, LANCER.setting_accdiff_advanced_expanded, expanded);
+  }
+
+  function toggleAdvanced() {
+    showAdvanced = !showAdvanced;
+    persistAdvancedPreference();
+  }
+
+  onMount(() => {
+    loadAdvancedPreference();
+  });
 
   let rollerName = lancerActor ? ` -- ${lancerActor.token?.name || lancerActor.name}` : "";
 
@@ -278,9 +322,6 @@
         <HudCheckbox label="Accurate (+1)" bind:value={weapon.accurate} />
         {#if kind == "attack"}
           <HudCheckbox label="Seeking (*)" bind:value={weapon.seeking} />
-          {#each accWeaponPlugins as plugin}
-            <Plugin data={plugin} />
-          {/each}
         {/if}
       </div>
 
@@ -293,16 +334,12 @@
             <HudCheckbox label="Thrown (*)" bind:value={weapon.thrown} />
           {/if}
           <HudCheckbox label="Engaged (-1)" bind:value={weapon.engaged} />
-          {#each diffWeaponPlugins as plugin}
-            <Plugin data={plugin} />
-          {/each}
         {/if}
       </div>
     </div>
 
-    {#if kind == "attack" && (Object.values(weapon.plugins).length > 0 || targets.length == 1)}
+    {#if kind == "attack" && (targets.length == 1 || useCover)}
       <div transition:slide|global class="accdiff-grid accdiff-grid__section" style="width: 100%">
-        <!-- Target-related Accuracy -->
         <div class="accdiff-grid__column">
           {#if targets.length == 1}
             <HudCheckbox style="grid-area: prone" label="Prone (+1)" bind:value={targets[0].prone} disabled />
@@ -314,18 +351,9 @@
               bind:value={targets[0].consumeLockOn}
               disabled={!targets[0].lockOnAvailable}
             />
-            {#each accTargetPlugins as plugin}
-              <Plugin data={plugin} />
-            {/each}
           {/if}
         </div>
-
-        <!-- Target-related Difficulty -->
         <div class="accdiff-grid__column">
-          {#each diffTargetPlugins as plugin}
-            <Plugin data={plugin} />
-          {/each}
-          <!-- Cover -->
           {#if useCover}
             <div class="grid-enforcement">
               {#if targets.length == 0}
@@ -347,25 +375,68 @@
       </div>
     {/if}
 
+    {#if hasAdvancedContent}
+      <div class="accdiff-advanced-toggle flexrow flex-center">
+        <button class="lancer-button lancer-secondary" type="button" on:click={toggleAdvanced}>
+          <i class="fas fa-{showAdvanced ? 'chevron-up' : 'chevron-down'}" />
+          {
+            showAdvanced ? game.i18n.localize("lancer.accdiff.hideAdvanced") : game.i18n.localize("lancer.accdiff.showAdvanced")
+          }
+        </button>
+      </div>
+      {#if showAdvanced}
+        <div transition:slide|global class="accdiff-advanced">
+          {#if accWeaponPlugins.length > 0 || diffWeaponPlugins.length > 0}
+            <div class="accdiff-grid accdiff-grid__section">
+              <div class="accdiff-grid__column">
+                {#each accWeaponPlugins as plugin}
+                  <Plugin data={plugin} />
+                {/each}
+              </div>
+              <div class="accdiff-grid__column">
+                {#each diffWeaponPlugins as plugin}
+                  <Plugin data={plugin} />
+                {/each}
+              </div>
+            </div>
+          {/if}
+          {#if accTargetPlugins.length > 0 || diffTargetPlugins.length > 0}
+            <div class="accdiff-grid accdiff-grid__section">
+              <div class="accdiff-grid__column">
+                {#each accTargetPlugins as plugin}
+                  <Plugin data={plugin} />
+                {/each}
+              </div>
+              <div class="accdiff-grid__column">
+                {#each diffTargetPlugins as plugin}
+                  <Plugin data={plugin} />
+                {/each}
+              </div>
+            </div>
+          {/if}
+          {#if ranges && ranges.length > 0}
+            <div class="accdiff-grid__section">
+              <span class="accdiff-weight flex-center flexrow">{game.i18n.localize("lancer.accdiff.advanced")}</span>
+              <div class="accdiff-ranges flexrow">
+                {#each ranges as range}
+                  <button class="range-button" type="button" on:click={() => deployTemplate(range)}>
+                    <i class="cci cci-{range.type.toLowerCase()} i--4 i--light" />
+                    {ranges.length && ranges.length < 3 ? range.type.toUpperCase() : ""}
+                    {range.val}
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      {/if}
+    {/if}
+
     <!-- Total accuracy / Targets -->
     <div class="flexcol accdiff-grid">
       <div class="flexrow accdiff-grid__section" style="justify-content: space-evenly">
         <AccDiffInput bind:value={base.accuracy} id="accdiff-manual-adjust" />
       </div>
-      {#if ranges && ranges.length > 0}
-        <div class="accdiff-grid__section">
-          <span class="accdiff-weight flex-center flexrow">Targeting</span>
-          <div class="accdiff-ranges flexrow">
-            {#each ranges as range}
-              <button class="range-button" type="button" on:click={() => deployTemplate(range)}>
-                <i class="cci cci-{range.type.toLowerCase()} i--4 i--light" />
-                {ranges.length && ranges.length < 3 ? range.type.toUpperCase() : ""}
-                {range.val}
-              </button>
-            {/each}
-          </div>
-        </div>
-      {/if}
     </div>
     <div class="flexcol accdiff-footer lancer-border-primary">
       <div class="accdiff-total">
@@ -416,34 +487,43 @@
                     <div class="flexrow accdiff-total">
                       <Total bind:target={data} id={`total-display-${i}`} />
                     </div>
-                    <div class="flexrow">
-                      <button
-                        class="i--4 no-grow accdiff-button"
-                        type="button"
-                        on:click={() => (data.accuracy = data.accuracy + 1)}
-                      >
-                        <i class="cci cci-accuracy i--4" style="border: none" />
-                      </button>
-                      <input style="display: none" type="number" bind:value={data.accuracy} min="0" />
-                      {#if useCover}
-                        <Cover
-                          bind:cover={data.cover}
-                          disabled={weapon.seeking}
-                          class="accdiff-targeted-cover flexrow flex-center"
-                          labelClass="i--2"
-                        />
-                      {:else}
-                        <div />
-                      {/if}
-                      <input style="display: none" type="number" bind:value={data.difficulty} min="0" />
-                      <button
-                        class="i--4 no-grow accdiff-button"
-                        type="button"
-                        on:click={() => (data.difficulty = data.difficulty + 1)}
-                      >
-                        <i class="cci cci-difficulty i--4" style="border: none" />
-                      </button>
-                    </div>
+                    {#if showAdvanced}
+                      <div class="flexrow">
+                        <button
+                          class="i--4 no-grow accdiff-button"
+                          type="button"
+                          on:click={() => (data.accuracy = data.accuracy + 1)}
+                        >
+                          <i class="cci cci-accuracy i--4" style="border: none" />
+                        </button>
+                        <input style="display: none" type="number" bind:value={data.accuracy} min="0" />
+                        {#if useCover}
+                          <Cover
+                            bind:cover={data.cover}
+                            disabled={weapon.seeking}
+                            class="accdiff-targeted-cover flexrow flex-center"
+                            labelClass="i--2"
+                          />
+                        {:else}
+                          <div />
+                        {/if}
+                        <input style="display: none" type="number" bind:value={data.difficulty} min="0" />
+                        <button
+                          class="i--4 no-grow accdiff-button"
+                          type="button"
+                          on:click={() => (data.difficulty = data.difficulty + 1)}
+                        >
+                          <i class="cci cci-difficulty i--4" style="border: none" />
+                        </button>
+                      </div>
+                    {:else if useCover}
+                      <Cover
+                        bind:cover={data.cover}
+                        disabled={weapon.seeking}
+                        class="accdiff-targeted-cover flexrow flex-center"
+                        labelClass="i--2"
+                      />
+                    {/if}
                   </div>
                 </div>
               {/each}

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -61,6 +61,8 @@ export const LANCER = {
   setting_dsn_setup: "dsnSetup",
   setting_square_grid_diagonals: "squareGridDiagonals",
   setting_tag_config: "tagConfig",
+  setting_accdiff_remember_advanced: "accdiffRememberAdvanced",
+  setting_accdiff_advanced_expanded: "accdiffAdvancedExpanded",
   // setting_120: "warningFor120", // Old setting, currently unused.
   // setting_beta_warning: "warningForBeta", // Old setting, currently unused.
 } as const;

--- a/src/module/flows/attack.ts
+++ b/src/module/flows/attack.ts
@@ -11,7 +11,8 @@ import type { SystemTemplates } from "../system-template";
 import { accDiffRollFragment, applyAccDiffDsnColors, colorizeAccDiffTooltip } from "../helpers/dice-colors";
 import { renderTemplateStep } from "./_render";
 import { Flow, type FlowState, type Step } from "./flow";
-import { LancerFlowState } from "./interfaces";
+import { LancerFlowState, type AttackFlag, type AttackRerollFlag } from "./interfaces";
+import { beginDamageFlowFromAttackData } from "./damage";
 
 const lp = LANCER.log_prefix;
 
@@ -40,19 +41,7 @@ export function attackRolls(flat_bonus: number, acc_diff: AccDiffHudData): Lance
   };
 }
 
-export type AttackFlag = {
-  origin: string; // Attacker's ID. Somewhat deprecated, kept because LWFX is probably using it.
-  attackerUuid: string; // Attacker's UUID
-  attackerItemUuid?: string; // Item UUID used for the attack, if applicable
-  invade?: boolean;
-  targets: {
-    uuid: string;
-    setConditions?: object; // keys are statusEffect ids, values are boolean to indicate whether to apply or remove
-    total: string;
-    hit: boolean;
-    crit: boolean;
-  }[];
-};
+export type { AttackFlag, AttackRerollFlag };
 
 export function registerAttackSteps(flowSteps: Map<string, Step<any, any> | Flow<any>>) {
   flowSteps.set("initAttackData", initAttackData);
@@ -64,6 +53,7 @@ export function registerAttackSteps(flowSteps: Map<string, Step<any, any> | Flow
   flowSteps.set("rollAttacks", rollAttacks);
   flowSteps.set("clearTargets", clearTargets);
   flowSteps.set("printAttackCard", printAttackCard);
+  flowSteps.set("promptDamageAfterAttack", promptDamageAfterAttack);
 }
 
 export class BasicAttackFlow extends Flow<LancerFlowState.AttackRollData> {
@@ -121,8 +111,7 @@ export class WeaponAttackFlow extends Flow<LancerFlowState.WeaponRollData> {
     "applySelfHeat",
     "updateItemAfterAction",
     "printAttackCard",
-    // TODO: Start damage flow after attack
-    // "applyDamage"
+    "promptDamageAfterAttack",
   ];
 
   constructor(uuid: UUIDRef | LancerItem | LancerActor, data?: Partial<LancerFlowState.WeaponRollData>) {
@@ -301,6 +290,7 @@ export async function initAttackData(
 }
 
 export async function checkWeaponLoaded(state: FlowState<LancerFlowState.WeaponRollData>): Promise<boolean> {
+  if (state.data?.is_reroll) return true;
   // If this automation option is not enabled, skip the check.
   const { limited_loading, attacks } = game.settings.get(game.system.id, LANCER.setting_automation);
   if (!limited_loading && attacks) return true;
@@ -403,6 +393,7 @@ export async function showAttackHUD(
   options?: {}
 ): Promise<boolean> {
   if (!state.data) throw new TypeError(`Attack flow state missing!`);
+  if (state.data.skip_attack_hud && state.data.acc_diff) return true;
   try {
     state.data.acc_diff = await openSlidingHud("attack", state.data.acc_diff!);
     state.data.grit = state.data.acc_diff.base.grit;
@@ -491,23 +482,30 @@ export async function printAttackCard(
 ): Promise<boolean> {
   if (!state.data) throw new TypeError(`Attack flow state missing!`);
   const template = options?.template || `systems/${game.system.id}/templates/chat/attack-card.hbs`;
-  const flags: { attackData: AttackFlag } = {
-    attackData: {
-      origin: state.actor.id!,
-      attackerUuid: state.actor.uuid!,
-      attackerItemUuid: state.item?.uuid,
-      targets: state.data.hit_results.map(hr => {
-        return {
-          id: hr.target.document.id,
-          uuid: hr.target.document.uuid,
-          setConditions: !!hr.usedLockOn ? { lockon: !hr.usedLockOn } : undefined,
-          total: hr.total,
-          hit: hr.hit,
-          crit: hr.crit,
-        };
-      }),
-    },
+  const attackData: AttackFlag = {
+    origin: state.actor.id!,
+    attackerUuid: state.actor.uuid!,
+    attackerItemUuid: state.item?.uuid,
+    targets: state.data.hit_results.map(hr => {
+      return {
+        uuid: hr.target.document.uuid,
+        setConditions: !!hr.usedLockOn ? { lockon: !hr.usedLockOn } : undefined,
+        total: hr.total,
+        hit: hr.hit,
+        crit: hr.crit,
+      };
+    }),
   };
+  const flags: { attackData: AttackFlag; attackReroll?: AttackRerollFlag } = {
+    attackData,
+  };
+  if (state.data.acc_diff && !state.data.is_reroll) {
+    flags.attackReroll = {
+      flow: state.data.type === "weapon" ? "weapon" : state.data.type === "tech" ? "tech" : "attack",
+      acc_diff: state.data.acc_diff.toObject(),
+      targetUuids: state.data.hit_results.map(hr => hr.target.document.uuid),
+    };
+  }
   state.data.defense = state.data.is_smart ? "E-DEF" : "EVASION";
   // Add roll data to the hit results for the HBS template
   const hitResultsWithRolls: LancerFlowState.HitResultWithRoll[] = [];
@@ -525,6 +523,87 @@ export async function printAttackCard(
   };
   await renderTemplateStep(state.actor, template, templateData, flags);
   return true;
+}
+
+export async function promptDamageAfterAttack(
+  state: FlowState<LancerFlowState.AttackRollData | LancerFlowState.WeaponRollData | LancerFlowState.TechAttackRollData>
+): Promise<boolean> {
+  if (!state.data) throw new TypeError(`Attack flow state missing!`);
+  const { prompt_damage_after_attack } = game.settings.get(game.system.id, LANCER.setting_automation);
+  if (!prompt_damage_after_attack) return true;
+  if (!state.actor.isOwner) return true;
+  if (!state.data.hit_results.some(hr => hr.hit)) return true;
+
+  const attackData: AttackFlag = {
+    origin: state.actor.id!,
+    attackerUuid: state.actor.uuid!,
+    attackerItemUuid: state.item?.uuid,
+    invade: LancerFlowState.isTechRoll(state.data)
+      ? (state.data as LancerFlowState.TechAttackRollData).invade
+      : undefined,
+    targets: state.data.hit_results.map(hr => ({
+      uuid: hr.target.document.uuid,
+      setConditions: hr.usedLockOn ? { lockon: !hr.usedLockOn } : undefined,
+      total: hr.total,
+      hit: hr.hit,
+      crit: hr.crit,
+    })),
+  };
+
+  await beginDamageFlowFromAttackData(attackData);
+  return true;
+}
+
+export async function rerollAttackCallback(event: JQuery.ClickEvent) {
+  const chatMessageElement = event.currentTarget.closest(".chat-message.message");
+  if (!chatMessageElement) return;
+  const chatMessage = game.messages?.get(chatMessageElement.dataset.messageId);
+  const attackData = chatMessage?.flags.lancer?.attackData as AttackFlag | undefined;
+  const rerollData = chatMessage?.flags.lancer?.attackReroll as AttackRerollFlag | undefined;
+  if (!chatMessage || !attackData || !rerollData) {
+    ui.notifications?.error("Attack reroll data is not available for this message");
+    return;
+  }
+
+  const actor = (await fromUuid(attackData.attackerUuid)) as LancerActor | null;
+  if (!actor) {
+    ui.notifications?.error("Invalid attacker for attack reroll");
+    return;
+  }
+  if (!actor.isOwner && !game.user?.isGM) {
+    ui.notifications?.error(`You cannot reroll attacks for ${actor.name}`);
+    return;
+  }
+
+  for (const t of game.user?.targets ?? []) {
+    t.setTarget(false, { releaseOthers: false });
+  }
+  for (const uuid of rerollData.targetUuids) {
+    const tokenDoc = (await fromUuid(uuid)) as { object?: LancerToken } | null;
+    tokenDoc?.object?.setTarget(true, { releaseOthers: false });
+  }
+
+  const flowUuid = attackData.attackerItemUuid ?? attackData.attackerUuid;
+  const flowData = {
+    skip_attack_hud: true,
+    is_reroll: true,
+    acc_diff: rerollData.acc_diff,
+  } as Partial<LancerFlowState.WeaponRollData>;
+
+  const flows = game.lancer.flows as Map<string, typeof Flow>;
+  const FlowClass = flows.get(
+    rerollData.flow === "weapon"
+      ? "WeaponAttackFlow"
+      : rerollData.flow === "tech"
+        ? "TechAttackFlow"
+        : "BasicAttackFlow"
+  );
+  if (!FlowClass) {
+    ui.notifications?.error("Attack reroll flow is not available");
+    return;
+  }
+  const flow = new FlowClass(flowUuid, flowData);
+  await flow.begin(flowData);
 }
 
 // If user is GM, apply status changes to attacked tokens

--- a/src/module/flows/damage.ts
+++ b/src/module/flows/damage.ts
@@ -8,6 +8,7 @@ import { Damage, type DamageData } from "../models/bits/damage";
 import type { UUIDRef } from "../source-template";
 import { LancerToken, LancerTokenDocument } from "../token";
 import { renderTemplateStep } from "./_render";
+import type { AttackFlag } from "./interfaces";
 import { Flow, type FlowState, type Step } from "./flow";
 import { LancerFlowState } from "./interfaces";
 
@@ -671,6 +672,65 @@ export async function getCritRoll(normal: Roll) {
   return Roll.fromTerms(terms);
 }
 
+/** Build hit results and start a damage flow from attack chat flag data. */
+export async function beginDamageFlowFromAttackData(attackData: AttackFlag): Promise<boolean> {
+  const actor = (await fromUuid(attackData.attackerUuid)) as LancerActor | null;
+  if (!actor) {
+    ui.notifications?.error("Invalid attacker for damage roll");
+    return false;
+  }
+  if (!actor.isOwner) {
+    ui.notifications?.error(`You do not own ${actor.name}, so you cannot roll damage for them`);
+    return false;
+  }
+  const item = (await fromUuid(attackData.attackerItemUuid || "")) as LancerItem | null;
+  if (item && item.parent !== actor) {
+    ui.notifications?.error(`Item ${item.uuid} is not owned by actor ${actor.uuid}!`);
+    return false;
+  }
+
+  const hit_results: LancerFlowState.HitResult[] = [];
+  for (const t of attackData.targets) {
+    const targetDoc = (await fromUuid(t.uuid)) as unknown;
+    const target = normalizeFlowTargetToken(targetDoc);
+    if (!target || target.document?.documentName !== "Token") {
+      ui.notifications?.error("Invalid target for damage roll");
+      continue;
+    }
+
+    let usedLockOn = false;
+    if (t.setConditions) {
+      usedLockOn = t.setConditions.lockOn === false ? true : false;
+    }
+
+    hit_results.push({
+      target,
+      total: t.total,
+      usedLockOn,
+      hit: t.hit,
+      crit: t.crit,
+    });
+  }
+
+  const damage: DamageData[] = [];
+  const bonus_damage: DamageData[] = [];
+  if (attackData.invade) {
+    damage.push({ type: DamageType.Heat, val: "2" });
+  }
+
+  const flow = new DamageRollFlow(item ? item.uuid : attackData.attackerUuid, {
+    title: `${item?.name || actor.name} DAMAGE`,
+    configurable: true,
+    invade: attackData.invade,
+    hit_results,
+    has_normal_hit: hit_results.some(hr => hr.hit && !hr.crit),
+    has_crit_hit: hit_results.some(hr => hr.crit),
+    damage,
+    bonus_damage,
+  });
+  return await flow.begin();
+}
+
 /*********************************************
     ======== Chat button handlers ==========
 *********************************************/
@@ -687,71 +747,12 @@ export async function rollDamageCallback(event: JQuery.ClickEvent) {
     return;
   }
   const chatMessage = game.messages?.get(chatMessageElement.dataset.messageId);
-  // Get attack data from the chat message
   const attackData = chatMessage?.flags.lancer?.attackData;
   if (!chatMessage || !attackData) {
     ui.notifications?.error("Damage roll button has no attack data available");
     return;
   }
-
-  // Get the attacker and weapon/system from the attack data
-  const actor = (await fromUuid(attackData.attackerUuid)) as LancerActor | null;
-  if (!actor) {
-    ui.notifications?.error("Invalid attacker for damage roll");
-    return;
-  }
-  if (!actor.isOwner) {
-    ui.notifications?.error(`You do not own ${actor.name}, so you cannot roll damage for them`);
-    return;
-  }
-  const item = (await fromUuid(attackData.attackerItemUuid || "")) as LancerItem | null;
-  if (item && item.parent !== actor) {
-    ui.notifications?.error(`Item ${item.uuid} is not owned by actor ${actor.uuid}!`);
-    return;
-  }
-  const hit_results: LancerFlowState.HitResult[] = [];
-  for (const t of attackData.targets) {
-    const targetDoc = (await fromUuid(t.uuid)) as unknown;
-    const target = normalizeFlowTargetToken(targetDoc);
-    if (!target || target.document?.documentName !== "Token") {
-      ui.notifications?.error("Invalid target for damage roll");
-      continue;
-    }
-
-    // Determine whether lock on was used
-    let usedLockOn = false;
-    if (t.setConditions) {
-      usedLockOn = t.setConditions.lockOn === false ? true : false;
-    }
-
-    hit_results.push({
-      target: target,
-      total: t.total,
-      usedLockOn,
-      hit: t.hit,
-      crit: t.crit,
-    });
-  }
-
-  // Collect damage from the item
-  const damage: DamageData[] = [];
-  const bonus_damage: DamageData[] = [];
-  if (attackData.invade) {
-    damage.push({ type: DamageType.Heat, val: "2" });
-  }
-
-  // Start a damage flow, prepopulated with the attack data
-  const flow = new DamageRollFlow(item ? item.uuid : attackData.attackerUuid, {
-    title: `${item?.name || actor.name} DAMAGE`,
-    configurable: true,
-    invade: attackData.invade,
-    hit_results,
-    has_normal_hit: hit_results.some(hr => hr.hit && !hr.crit),
-    has_crit_hit: hit_results.some(hr => hr.crit),
-    damage,
-    bonus_damage,
-  });
-  flow.begin();
+  await beginDamageFlowFromAttackData(attackData);
 }
 
 /**

--- a/src/module/flows/interfaces.ts
+++ b/src/module/flows/interfaces.ts
@@ -1,10 +1,30 @@
 import { AttackType, DamageType, NpcFeatureType, StabOptions1, StabOptions2, SystemType } from "../enums";
-import { AccDiffHudData } from "../apps/acc_diff";
+import { AccDiffHudData, type AccDiffHudDataSerialized } from "../apps/acc_diff";
 import type { ActionData } from "../models/bits/action";
 import type { DamageData } from "../models/bits/damage";
 import { Tag, type TagData } from "../models/bits/tag";
 import { LancerToken } from "../token";
 import { DamageHudData } from "../apps/damage";
+
+export type AttackFlag = {
+  origin: string;
+  attackerUuid: string;
+  attackerItemUuid?: string;
+  invade?: boolean;
+  targets: {
+    uuid: string;
+    setConditions?: object;
+    total: string;
+    hit: boolean;
+    crit: boolean;
+  }[];
+};
+
+export type AttackRerollFlag = {
+  flow: "weapon" | "tech" | "attack";
+  acc_diff: AccDiffHudDataSerialized;
+  targetUuids: string[];
+};
 
 // -------- Flow state data types -------------------------------------
 // Each flow uses one of these data types to track its state.
@@ -132,6 +152,10 @@ export namespace LancerFlowState {
     hit_results: HitResult[];
     // TODO: deprecate base64 encoded reroll data
     reroll_data: string;
+    /** When true, skip the Acc/Diff HUD (e.g. attack chat reroll). */
+    skip_attack_hud?: boolean;
+    /** When true, skip limited/loading consumption (e.g. attack chat reroll). */
+    is_reroll?: boolean;
   }
 
   // Specifically for weapons

--- a/src/module/flows/item-utils.ts
+++ b/src/module/flows/item-utils.ts
@@ -52,9 +52,21 @@ export async function checkItemDestroyed(
   return true;
 }
 
+function isAttackReroll(
+  state: FlowState<
+    | LancerFlowState.WeaponRollData
+    | LancerFlowState.TechAttackRollData
+    | LancerFlowState.AttackRollData
+    | LancerFlowState.ActionUseData
+  >
+): boolean {
+  return !!(state.data && "is_reroll" in state.data && state.data.is_reroll);
+}
+
 export async function checkItemLimited(
   state: FlowState<LancerFlowState.WeaponRollData | LancerFlowState.TechAttackRollData | LancerFlowState.ActionUseData>
 ): Promise<boolean> {
+  if (isAttackReroll(state)) return true;
   // If this automation option is not enabled, skip the check.
   const { limited_loading, attacks } = game.settings.get(game.system.id, LANCER.setting_automation);
   if (!limited_loading && attacks) return true;
@@ -102,6 +114,7 @@ export async function checkItemLimited(
 export async function checkItemCharged(
   state: FlowState<LancerFlowState.WeaponRollData | LancerFlowState.TechAttackRollData | LancerFlowState.ActionUseData>
 ): Promise<boolean> {
+  if (isAttackReroll(state)) return true;
   // If this automation option is not enabled, skip the check.
   const { limited_loading, attacks } = game.settings.get(game.system.id, LANCER.setting_automation);
   if (!limited_loading && attacks) return true;
@@ -163,6 +176,7 @@ export async function updateItemAfterAction(
   options?: {}
 ): Promise<boolean> {
   if (!state.data) throw new TypeError(`Flow state missing!`);
+  if (isAttackReroll(state)) return true;
   const { limited_loading, attacks } = game.settings.get(game.system.id, LANCER.setting_automation);
   if (state.item && limited_loading && attacks) {
     let itemChanges: DeepPartial<SourceData.MechWeapon | SourceData.NpcFeature | SourceData.PilotWeapon> = {};

--- a/src/module/flows/tech.ts
+++ b/src/module/flows/tech.ts
@@ -10,7 +10,7 @@ import { resolveDotpath } from "../helpers/commons";
 import { ActivationType, AttackType } from "../enums";
 import { Flow, type FlowState, type Step } from "./flow";
 import type { UUIDRef } from "../source-template";
-import type { AttackFlag } from "./attack";
+import type { AttackFlag, AttackRerollFlag } from "./interfaces";
 
 const lp = LANCER.log_prefix;
 
@@ -33,6 +33,7 @@ export class TechAttackFlow extends Flow<LancerFlowState.TechAttackRollData> {
     "applySelfHeat",
     "updateItemAfterAction",
     "printTechAttackCard",
+    "promptDamageAfterAttack",
   ];
 
   constructor(uuid: UUIDRef | LancerItem | LancerActor, data?: Partial<LancerFlowState.TechAttackRollData>) {
@@ -192,24 +193,31 @@ export async function printTechAttackCard(
 ): Promise<boolean> {
   if (!state.data) throw new TypeError(`Tech attack flow state missing!`);
   const template = options?.template || `systems/${game.system.id}/templates/chat/tech-attack-card.hbs`;
-  const flags: { attackData: AttackFlag } = {
-    attackData: {
-      origin: state.actor.id!,
-      attackerUuid: state.actor.uuid!,
-      attackerItemUuid: state.item?.uuid,
-      invade: state.data.invade,
-      targets: state.data.hit_results.map(hr => {
-        return {
-          id: hr.target.document.id,
-          uuid: hr.target.document.uuid,
-          setConditions: !!hr.usedLockOn ? { lockon: !hr.usedLockOn } : undefined,
-          total: hr.total,
-          hit: hr.hit,
-          crit: hr.crit,
-        };
-      }),
-    },
+  const attackData: AttackFlag = {
+    origin: state.actor.id!,
+    attackerUuid: state.actor.uuid!,
+    attackerItemUuid: state.item?.uuid,
+    invade: state.data.invade,
+    targets: state.data.hit_results.map(hr => {
+      return {
+        uuid: hr.target.document.uuid,
+        setConditions: !!hr.usedLockOn ? { lockon: !hr.usedLockOn } : undefined,
+        total: hr.total,
+        hit: hr.hit,
+        crit: hr.crit,
+      };
+    }),
   };
+  const flags: { attackData: AttackFlag; attackReroll?: AttackRerollFlag } = {
+    attackData,
+  };
+  if (state.data.acc_diff && !state.data.is_reroll) {
+    flags.attackReroll = {
+      flow: "tech",
+      acc_diff: state.data.acc_diff.toObject(),
+      targetUuids: state.data.hit_results.map(hr => hr.target.document.uuid),
+    };
+  }
   const hitResultsWithRolls: LancerFlowState.HitResultWithRoll[] = [];
   for (const [index, hitResult] of state.data.hit_results.entries()) {
     hitResultsWithRolls.push({

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -55,6 +55,22 @@ export const registerSettings = function () {
     default: false,
   });
 
+  game.settings.register(game.system.id, LANCER.setting_accdiff_remember_advanced, {
+    name: "lancer.accdiff.rememberAdvanced.name",
+    hint: "lancer.accdiff.rememberAdvanced.hint",
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
+
+  game.settings.register(game.system.id, LANCER.setting_accdiff_advanced_expanded, {
+    scope: "client",
+    config: false,
+    type: Object,
+    default: {},
+  });
+
   game.settings.register(game.system.id, LANCER.setting_autoanimations_enabled, {
     name: "lancer.autoAnimations.enabled.name",
     hint: "lancer.autoAnimations.enabled.hint",
@@ -270,6 +286,11 @@ interface AutomationOptionsSchema extends foundry.data.fields.DataSchema {
    * @defaultValue `true`
    */
   token_size: fields.BooleanField<{ initial: true }>;
+  /**
+   * After a successful attack with hits, open the damage roll HUD automatically.
+   * @defaultValue `false`
+   */
+  prompt_damage_after_attack: fields.BooleanField<{ initial: false }>;
 }
 
 /**
@@ -326,6 +347,12 @@ export class AutomationOptions extends foundry.abstract.DataModel<AutomationOpti
         initial: true,
         label: "lancer.automation.token_size",
         hint: "lancer.automation.token_size-desc",
+      }),
+      prompt_damage_after_attack: new fields.BooleanField({
+        required: true,
+        initial: false,
+        label: "lancer.automation.prompt_damage_after_attack",
+        hint: "lancer.automation.prompt_damage_after_attack-desc",
       }),
     };
   }

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.12.11",
+  "version": "2.13.0",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.12.11/lancer-v2.12.11.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v2.13.0/lancer-v2.13.0.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sprint B (v2.13.0) completes the combat loop UX pass: optional auto-damage prompt, Acc/Diff progressive disclosure, combat tour updates, and chat attack rerolls.

Closes #59, #60, #61, #62. Part of release epic #45.

## Changes

### #59 — Optional auto-prompt damage after attack
- New world automation setting **Prompt Damage After Attack** (default **off**)
- When enabled and an attack records at least one hit, `promptDamageAfterAttack` opens the damage HUD after the attack card
- Cancel on the damage HUD aborts without applying damage

### #60 — Acc/Diff HUD progressive disclosure
- Default view emphasizes targets, totals, cover, and core checkboxes
- **Advanced** collapsible section for weapon/target plugins, measured templates, and multi-target per-target modifiers
- Client setting **Remember Acc/Diff Advanced Section** stores expanded state per weapon

### #61 — Combat tour: attack → damage → apply
- Four new steps on the combat tracker tour documenting manual damage, auto-damage setting, and apply workflow

### #62 — Restore chat reroll buttons
- Reroll button on attack and tech-attack chat cards
- Serialized Acc/Diff data stored in `attackReroll` message flags
- Button shown only to attacker owner or GM; rerolls skip HUD and item consumption

## Version

**2.13.0** — CHANGELOG updated.

## Test plan

- [ ] Build: `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`
- [ ] Weapon attack with hits → Roll Damage still works manually (setting off)
- [ ] Enable **Prompt Damage After Attack** → damage HUD opens after hit; cancel closes without damage
- [ ] Acc/Diff HUD: Advanced toggle shows plugins/templates; preference persists per weapon
- [ ] Attack chat card: owner/GM sees reroll; reroll re-rolls without re-consuming limited/loading
- [ ] Combat tour includes new damage-loop steps
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

