### PR TITLE
Add Playwright E2E regression suite (combat loop)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,17 @@ dataPath: /home/ubuntu/foundry-data/Data
 
 Symlink built system (host-only Foundry): `ln -sfn "$(pwd)/dist" "$dataPath/systems/lancer"`.
 
+### E2E regression tests (Playwright)
+
+Requires a running Foundry instance (see Docker block above) and Firefox via `npm run test:e2e:install`.
+
+```bash
+SKIP_FOUNDRY_DIST_MIRROR=1 npm run build
+npm run test:e2e
+```
+
+Specs live under `e2e/regression/`; see `e2e/README.md`.
+
 ### Hello-world / E2E in Foundry
 
 1. Start Foundry on port 30000 with the `lancer` system installed (symlink or mirror from `dist/`).

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,3 @@
+test-results/
+report/
+playwright/.cache/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,46 @@
+# Lancer Foundry E2E regression tests
+
+Playwright tests that join a live Foundry world and verify Lancer system behavior in-browser.
+
+## Prerequisites
+
+1. **Foundry VTT** running on port `30000` with the Lancer system mounted from `dist/`.
+2. A world using the Lancer system (default: `lancer-dev-test`).
+3. **Firefox** browser for Playwright (`npm run test:e2e:install`).
+
+### Docker quick start
+
+```bash
+SKIP_FOUNDRY_DIST_MIRROR=1 npm run build
+sudo rm -rf /home/ubuntu/foundry-data/Config/options.json.lock
+sudo docker start foundry   # or see AGENTS.md for full docker run
+```
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FOUNDRY_URL` | `http://localhost:30000` | Foundry base URL |
+| `FOUNDRY_ADMIN_KEY` | `devadmin` | Setup admin password |
+| `FOUNDRY_WORLD_ID` | `lancer-dev-test` | World package id |
+
+## Run
+
+```bash
+npm run test:e2e:install   # once per machine
+SKIP_FOUNDRY_DIST_MIRROR=1 npm run build
+npm run test:e2e
+```
+
+HTML report: `npm run test:e2e:report`
+
+## Regression suite
+
+| Spec | Covers |
+|------|--------|
+| `world-load.spec.ts` | World join, Lancer system version, console errors |
+| `automation-settings.spec.ts` | `prompt_damage_after_attack` setting (#59) |
+| `accdiff-hud.spec.ts` | Acc/Diff Advanced disclosure (#60) |
+| `combat-loop.spec.ts` | Combat tour steps, attack reroll flags (#61, #62) |
+
+Tests seed temporary actors/scenes tagged with `flags.lancer.e2e` and clean them up on re-run.

--- a/e2e/helpers/foundry.ts
+++ b/e2e/helpers/foundry.ts
@@ -1,0 +1,62 @@
+import type { Page } from "@playwright/test";
+
+export const FOUNDRY_ADMIN_KEY = process.env.FOUNDRY_ADMIN_KEY ?? "devadmin";
+export const FOUNDRY_WORLD_ID = process.env.FOUNDRY_WORLD_ID ?? "lancer-dev-test";
+
+/** Collect browser console errors while navigating. */
+export function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", msg => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", err => errors.push(err.message));
+  return errors;
+}
+
+/** Authenticate, launch world if needed, and join as the first available user. */
+export async function joinLancerWorld(page: Page, worldId = FOUNDRY_WORLD_ID): Promise<void> {
+  await page.goto("/", { waitUntil: "networkidle" });
+
+  if (page.url().includes("/license")) {
+    await page.getByRole("button", { name: /agree/i }).click();
+    await page.waitForLoadState("networkidle");
+  }
+
+  if (page.url().includes("/auth")) {
+    await page.locator('input[type="password"]').first().fill(FOUNDRY_ADMIN_KEY);
+    await page.locator('button[type="submit"]').first().click();
+    await page.waitForURL(/\/(setup|join|game)/, { timeout: 60_000 });
+  }
+
+  if (page.url().includes("/setup")) {
+    await page.locator(`li.world[data-package-id="${worldId}"]`).click({ button: "right" });
+    await page.getByText("Launch World", { exact: false }).click();
+    await page.waitForURL(/\/join/, { timeout: 60_000 });
+  }
+
+  if (page.url().includes("/join")) {
+    const userId = await page
+      .locator('select[name="userid"] option:not([value=""]):not([disabled])')
+      .first()
+      .getAttribute("value");
+    if (!userId) {
+      const options = await page.locator('select[name="userid"] option').allTextContents();
+      throw new Error(`No joinable Foundry user. Options: ${options.join(", ")}`);
+    }
+    await page.locator('select[name="userid"]').selectOption(userId);
+    await page.locator('button[name="join"]').click();
+  }
+
+  await page.waitForFunction(() => window.game?.ready === true, { timeout: 120_000 });
+}
+
+export async function getGameState(page: Page) {
+  return page.evaluate(() => ({
+    ready: game.ready,
+    worldId: game.world.id,
+    systemId: game.system.id,
+    systemVersion: game.system.version,
+    actorCount: game.actors?.size ?? 0,
+    sceneCount: game.scenes?.size ?? 0,
+  }));
+}

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -1,0 +1,76 @@
+import type { Page } from "@playwright/test";
+
+const E2E_FLAG = "e2e-regression";
+
+/** Remove prior E2E artifacts and create a minimal NPC + scene + token for combat UI tests. */
+export async function seedRegressionWorld(page: Page): Promise<{ npcId: string; sceneId: string; tokenId: string }> {
+  return page.evaluate(async flag => {
+    for (const actor of game.actors.filter(a => a.getFlag("lancer", "e2e"))) {
+      await actor.delete();
+    }
+    for (const scene of game.scenes.filter(s => s.getFlag("lancer", "e2e"))) {
+      await scene.delete();
+    }
+
+    const npc = await Actor.create(
+      {
+        name: "E2E Test NPC",
+        type: "npc",
+        img: `systems/${game.system.id}/assets/icons/npc.svg`,
+        flags: { lancer: { e2e: flag } },
+        system: {
+          name: "E2E Test NPC",
+          tier: 1,
+        },
+        items: [
+          {
+            name: "E2E Test Weapon",
+            type: "npc_feature",
+            img: `systems/${game.system.id}/assets/icons/generic_item.svg`,
+            system: {
+              type: "Weapon",
+              weapon_type: "Rifle",
+              damage: [{ type: "Kinetic", val: "1d6" }],
+              range: [
+                { type: "Range", val: 5 },
+                { type: "Blast", val: 1 },
+              ],
+            },
+          },
+        ],
+      },
+      { renderSheet: false }
+    );
+
+    let scene = game.scenes.find(s => s.name === "E2E Regression Scene");
+    if (!scene) {
+      scene = await Scene.create({
+        name: "E2E Regression Scene",
+        navigation: true,
+        flags: { lancer: { e2e: flag } },
+        width: 4000,
+        height: 3000,
+        grid: { size: 100 },
+      });
+    }
+    await scene.activate();
+
+    const existing = scene.tokens.find(t => t.actorId === npc.id);
+    if (!existing) {
+      await scene.createEmbeddedDocuments("Token", [
+        {
+          name: npc.name,
+          actorId: npc.id,
+          x: 1500,
+          y: 1500,
+          width: 1,
+          height: 1,
+        },
+      ]);
+    }
+
+    const tokenDoc = scene.tokens.find(t => t.actorId === npc.id);
+    if (!tokenDoc) throw new Error("Failed to create E2E token");
+    return { npcId: npc.id!, sceneId: scene.id!, tokenId: tokenDoc.id! };
+  }, E2E_FLAG);
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.FOUNDRY_URL ?? "http://localhost:30000";
+
+export default defineConfig({
+  testDir: "./regression",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never", outputFolder: "report" }]],
+  timeout: 180_000,
+  expect: { timeout: 30_000 },
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    ...devices["Desktop Firefox"],
+    viewport: { width: 1400, height: 900 },
+  },
+  projects: [{ name: "firefox", use: { browserName: "firefox" } }],
+  outputDir: "test-results",
+});

--- a/e2e/regression/accdiff-hud.spec.ts
+++ b/e2e/regression/accdiff-hud.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+import { joinLancerWorld } from "../helpers/foundry";
+import { seedRegressionWorld } from "../helpers/seed";
+
+test.describe("Acc/Diff HUD @regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await joinLancerWorld(page);
+    await seedRegressionWorld(page);
+  });
+
+  test("advanced section collapses plugins and template tools by default", async ({ page }) => {
+    await page.evaluate(() => {
+      const npc = game.actors.find(a => a.name === "E2E Test NPC");
+      const weapon = npc?.items.find(i => i.name === "E2E Test Weapon");
+      if (!weapon) throw new Error("E2E weapon missing");
+      void weapon.beginWeaponAttackFlow();
+    });
+
+    await expect(page.locator("#hudzone #accdiff")).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator("#hudzone #accdiff .accdiff-advanced-toggle button")).toBeVisible();
+
+    const advancedVisible = await page.locator("#hudzone #accdiff .accdiff-advanced").isVisible();
+    expect(advancedVisible).toBe(false);
+
+    await page.locator("#hudzone #accdiff .accdiff-advanced-toggle button").click();
+    await expect(page.locator("#hudzone #accdiff .accdiff-advanced")).toBeVisible();
+
+    await page.locator("#hudzone #accdiff .lancer-hud-buttons .cancel").click();
+    await expect(page.locator("#hudzone #accdiff")).toBeHidden({ timeout: 10_000 });
+  });
+
+  test("remember advanced setting persists per weapon", async ({ page }) => {
+    await page.evaluate(async () => {
+      await game.settings.set("lancer", "accdiffRememberAdvanced", true);
+      await game.settings.set("lancer", "accdiffAdvancedExpanded", {});
+    });
+
+    await page.evaluate(() => {
+      const npc = game.actors.find(a => a.name === "E2E Test NPC");
+      const weapon = npc?.items.find(i => i.name === "E2E Test Weapon");
+      if (!weapon) throw new Error("E2E weapon missing");
+      void weapon.beginWeaponAttackFlow();
+    });
+    await expect(page.locator("#hudzone #accdiff")).toBeVisible({ timeout: 30_000 });
+
+    await page.locator("#hudzone #accdiff .accdiff-advanced-toggle button").click();
+    await page.locator("#hudzone #accdiff .lancer-hud-buttons .cancel").click();
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      const npc = game.actors.find(a => a.name === "E2E Test NPC");
+      const weapon = npc?.items.find(i => i.name === "E2E Test Weapon");
+      if (!weapon) throw new Error("E2E weapon missing");
+      void weapon.beginWeaponAttackFlow();
+    });
+    await expect(page.locator("#hudzone #accdiff")).toBeVisible({ timeout: 30_000 });
+
+    await expect(page.locator("#hudzone #accdiff .accdiff-advanced")).toBeVisible();
+    await page.locator("#hudzone #accdiff .lancer-hud-buttons .cancel").click();
+  });
+});

--- a/e2e/regression/automation-settings.spec.ts
+++ b/e2e/regression/automation-settings.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+import { joinLancerWorld } from "../helpers/foundry";
+
+test.describe("Automation settings @regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await joinLancerWorld(page);
+  });
+
+  test("prompt damage after attack setting exists and toggles", async ({ page }) => {
+    const initial = await page.evaluate(() => {
+      const opts = game.settings.get("lancer", "automationOptions");
+      return opts.prompt_damage_after_attack;
+    });
+    expect(typeof initial).toBe("boolean");
+
+    await page.evaluate(async () => {
+      const current = game.settings.get("lancer", "automationOptions");
+      const next = current.toObject();
+      next.prompt_damage_after_attack = !next.prompt_damage_after_attack;
+      await game.settings.set("lancer", "automationOptions", next);
+    });
+
+    const toggled = await page.evaluate(() => {
+      return game.settings.get("lancer", "automationOptions").prompt_damage_after_attack;
+    });
+    expect(toggled).toBe(!initial);
+
+    await page.evaluate(async initialValue => {
+      const current = game.settings.get("lancer", "automationOptions");
+      const next = current.toObject();
+      next.prompt_damage_after_attack = initialValue;
+      await game.settings.set("lancer", "automationOptions", next);
+    }, initial);
+  });
+
+  test("automation options object includes prompt damage field", async ({ page }) => {
+    const hasField = await page.evaluate(() => {
+      return "prompt_damage_after_attack" in game.settings.get("lancer", "automationOptions").toObject();
+    });
+    expect(hasField).toBe(true);
+  });
+});

--- a/e2e/regression/combat-loop.spec.ts
+++ b/e2e/regression/combat-loop.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "@playwright/test";
+import { joinLancerWorld } from "../helpers/foundry";
+import { seedRegressionWorld } from "../helpers/seed";
+
+test.describe("Combat loop @regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await joinLancerWorld(page);
+    await seedRegressionWorld(page);
+  });
+
+  test("combat tour is registered with damage-loop steps", async ({ page }) => {
+    const tour = await page.evaluate(() => {
+      const t = game.tours.get("lancer.combat");
+      if (!t) return null;
+      return {
+        id: t.id,
+        stepIds: t.steps.map(s => s.id),
+      };
+    });
+
+    expect(tour).not.toBeNull();
+    expect(tour?.stepIds).toEqual(
+      expect.arrayContaining(["attackDamageLoop", "manualDamage", "autoDamagePrompt", "applyDamage"])
+    );
+  });
+
+  test("printAttackCard stores attackReroll flag and reroll button markup", async ({ page }) => {
+    const seed = await seedRegressionWorld(page);
+    const result = await page.evaluate(async ({ tokenId }) => {
+      const npc = game.actors.find(a => a.name === "E2E Test NPC");
+      const weapon = npc?.items.find(i => i.name === "E2E Test Weapon");
+      const tokenDoc = game.scenes.active?.tokens.get(tokenId);
+      const token = tokenDoc?.object;
+      if (!npc || !weapon || !token) throw new Error("E2E seed data missing");
+
+      const roll = await new Roll("1d20+5").evaluate();
+      const printStep = game.lancer.flowSteps.get("printAttackCard");
+      if (!printStep) throw new Error("printAttackCard step missing");
+
+      const state = {
+        name: "WeaponAttackFlow",
+        actor: npc,
+        item: weapon,
+        currentStep: "printAttackCard",
+        data: {
+          type: "weapon",
+          title: weapon.name,
+          grit: 1,
+          flat_bonus: 0,
+          attack_type: 1,
+          action: null,
+          is_smart: false,
+          attack_rolls: { roll: "1d20+5", targeted: [] },
+          attack_results: [{ roll, tt: await roll.getTooltip() }],
+          hit_results: [
+            {
+              target: token,
+              total: String(roll.total).padStart(2, "0"),
+              hit: true,
+              crit: false,
+              usedLockOn: false,
+            },
+          ],
+          reroll_data: "",
+          tags: [],
+          acc_diff: {
+            toObject() {
+              return {
+                weapon: {},
+                base: { grit: 1, flatBonus: 0, accuracy: 0, difficulty: 0, cover: 0, plugins: {} },
+                targets: [
+                  {
+                    token: token.document.uuid,
+                    accuracy: 0,
+                    difficulty: 0,
+                    cover: 0,
+                    plugins: {},
+                  },
+                ],
+                title: weapon.name,
+              };
+            },
+          },
+        },
+      };
+
+      await printStep(state);
+      const cm = game.messages.contents.at(-1);
+      return {
+        hasRerollFlag: !!cm?.getFlag("lancer", "attackReroll"),
+        hasAttackData: !!cm?.getFlag("lancer", "attackData"),
+        html: cm?.content ?? "",
+      };
+    }, seed);
+
+    expect(result.hasAttackData).toBe(true);
+    expect(result.hasRerollFlag).toBe(true);
+    expect(result.html).toContain("lancer-attack-reroll");
+  });
+});

--- a/e2e/regression/world-load.spec.ts
+++ b/e2e/regression/world-load.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+import { getGameState, joinLancerWorld, trackConsoleErrors } from "../helpers/foundry";
+
+test.describe("Lancer world load @regression", () => {
+  test("joins world and loads Lancer system", async ({ page }) => {
+    const errors = trackConsoleErrors(page);
+    await joinLancerWorld(page);
+
+    const state = await getGameState(page);
+    expect(state.ready).toBe(true);
+    expect(state.worldId).toBe("lancer-dev-test");
+    expect(state.systemId).toBe("lancer");
+    expect(state.systemVersion).toMatch(/^2\./);
+
+    const fatal = errors.filter(
+      e => !e.includes("screen resolution") && !e.includes("Chromium version") && !e.includes("Firefox version")
+    );
+    expect(fatal, `Unexpected console errors: ${fatal.join("; ")}`).toEqual([]);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundryvtt-lancer",
-  "version": "2.12.10",
+  "version": "2.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundryvtt-lancer",
-      "version": "2.12.10",
+      "version": "2.13.0",
       "hasInstallScript": true,
       "dependencies": {
         "@massif/dustgrave-data": "^1.4.0",
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@foundryvtt/foundryvtt-cli": "^3.0.3",
+        "@playwright/test": "^1.52.0",
         "@sveltejs/vite-plugin-svelte": "^5.1.1",
         "@tsconfig/svelte": "^5.0.4",
         "@types/node": "^24.0.1",
@@ -5548,6 +5549,22 @@
         "earcut": "^3.0.1",
         "eventemitter3": "^4.0.0",
         "url": "^0.11.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -11750,6 +11767,53 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
     "test": "node --import tsx --test scripts/import-routing.test.ts",
+    "test:e2e": "playwright test -c e2e/playwright.config.ts",
+    "test:e2e:install": "playwright install firefox",
+    "test:e2e:report": "playwright show-report e2e/report",
     "serve": "vite",
     "version": "./scripts/version.mjs && git add src/system.json",
     "watch": "vite build --watch"
@@ -28,6 +31,7 @@
   "license": "",
   "devDependencies": {
     "@foundryvtt/foundryvtt-cli": "^3.0.3",
+    "@playwright/test": "^1.52.0",
     "@sveltejs/vite-plugin-svelte": "^5.1.1",
     "@tsconfig/svelte": "^5.0.4",
     "@types/node": "^24.0.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Playwright-based E2E regression suite that joins a live Foundry world and verifies Sprint B combat-loop behavior in-browser.

**Depends on #93** (v2.13.0 combat loop) — tests target features introduced there.

## What was run

All **7 tests passed** against `Lancer Dev Test` on Foundry 14.363 with Lancer 2.13.0:

```
npm run test:e2e:install
SKIP_FOUNDRY_DIST_MIRROR=1 npm run build
npm run test:e2e
```

## Regression specs (`e2e/regression/`)

| Spec | Verifies |
|------|----------|
| `world-load.spec.ts` | World join, Lancer system version |
| `automation-settings.spec.ts` | `prompt_damage_after_attack` toggle (#59) |
| `accdiff-hud.spec.ts` | Advanced section collapse + per-weapon memory (#60) |
| `combat-loop.spec.ts` | Combat tour damage-loop steps + `attackReroll` flags (#61–#62) |

## Usage

See `e2e/README.md` and updated `AGENTS.md`. Requires Foundry on port 30000 (Docker) and Firefox via Playwright.

## Notes

- Uses **Firefox** (Chromium bundled with Playwright is too old for Foundry v14 JS requirements).
- Tests seed temporary NPC/scene/token fixtures tagged `flags.lancer.e2e` and clean up on re-run.
- Not wired into CI yet (requires live Foundry + credentials).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

