### PR TITLE
v2.14.0 — Import & equip (Sprint C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.14.0 (2026-06-06)
+
+## Added
+
+- Pilot Cloud tab **import wizard** with numbered steps (Login → Select → Download/JSON), COMP/CON login status, and a link to start the pilot-import tour.
+- **Empty loadout slots** show drag/click hints; clicking opens a filtered **compendium picker** for the accepted item types.
+- Unified **import result dialog** (DialogV2) for COMP/CON v2/v3 and JSON imports — success, partial, and failure — replacing fragmented toasts.
+
+## Changed
+
+- Pilots that have **never synced** (`last_cloud_update === "never"`) open on the Cloud tab by default.
+- Invalid item drops on ref slots show a notification listing accepted item types.
+- Pilot-import tour selectors updated for the new Cloud tab layout.
+
 # 2.13.0 (2026-06-06)
 
 ## Added

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -18,11 +18,11 @@ sudo docker start foundry   # or see AGENTS.md for full docker run
 
 Environment variables:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `FOUNDRY_URL` | `http://localhost:30000` | Foundry base URL |
-| `FOUNDRY_ADMIN_KEY` | `devadmin` | Setup admin password |
-| `FOUNDRY_WORLD_ID` | `lancer-dev-test` | World package id |
+| Variable            | Default                  | Description          |
+| ------------------- | ------------------------ | -------------------- |
+| `FOUNDRY_URL`       | `http://localhost:30000` | Foundry base URL     |
+| `FOUNDRY_ADMIN_KEY` | `devadmin`               | Setup admin password |
+| `FOUNDRY_WORLD_ID`  | `lancer-dev-test`        | World package id     |
 
 ## Run
 
@@ -44,10 +44,10 @@ Trigger from **Actions → E2E regression (manual) → Run workflow**.
 
 ### Required repository secrets
 
-| Secret | Description |
-|--------|-------------|
+| Secret             | Description                      |
+| ------------------ | -------------------------------- |
 | `FOUNDRY_USERNAME` | FoundryVTT.com account **email** |
-| `FOUNDRY_PASSWORD` | FoundryVTT.com password |
+| `FOUNDRY_PASSWORD` | FoundryVTT.com password          |
 
 Optional: `FOUNDRY_LICENSE_KEY` — license key for headless EULA acceptance in Docker.
 
@@ -55,11 +55,11 @@ The workflow builds `dist/`, starts `felddy/foundryvtt`, seeds the `lancer-dev-t
 
 ## Regression suite
 
-| Spec | Covers |
-|------|--------|
-| `world-load.spec.ts` | World join, Lancer system version, console errors |
-| `automation-settings.spec.ts` | `prompt_damage_after_attack` setting (#59) |
-| `accdiff-hud.spec.ts` | Acc/Diff Advanced disclosure (#60) |
-| `combat-loop.spec.ts` | Combat tour steps, attack reroll flags (#61, #62) |
+| Spec                          | Covers                                            |
+| ----------------------------- | ------------------------------------------------- |
+| `world-load.spec.ts`          | World join, Lancer system version, console errors |
+| `automation-settings.spec.ts` | `prompt_damage_after_attack` setting (#59)        |
+| `accdiff-hud.spec.ts`         | Acc/Diff Advanced disclosure (#60)                |
+| `combat-loop.spec.ts`         | Combat tour steps, attack reroll flags (#61, #62) |
 
 Tests seed temporary actors/scenes tagged with `flags.lancer.e2e` and clean them up on re-run.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -54,8 +54,37 @@
       "errors": {
         "core-data-title": "Core data required",
         "core-data-required": "Import Core Book Data in the Lancer Compendium Manager (Compendiums tab) before importing a pilot.",
-        "core-data-open-lcp": "Open LCP Manager"
+        "core-data-open-lcp": "Open LCP Manager",
+        "unrecognized-format": "Could not determine COMP/CON import format for this pilot data.",
+        "not-pilot": "COMP/CON import target is not a pilot actor.",
+        "missing-fields": "COMP/CON import data is missing required pilot fields (name/callsign).",
+        "invalid-json": "Selected file is not valid JSON."
+      },
+      "result": {
+        "title": "Pilot Import Result",
+        "close": "Close",
+        "success": "Successfully imported {name}.",
+        "partial": "Partially imported {name}. Some actors or items could not be found.",
+        "failure": "Failed to import {name}.",
+        "missing-actors": "Actors that could not be created or updated",
+        "missing-items": "Items not found in compendiums",
+        "lcp-hint": "Install required LCPs using the <b>Lancer Compendium Manager</b>, then re-import."
       }
+    },
+    "ref-slot": {
+      "empty-label": "Empty",
+      "empty-hint": "Drag an item here or click to browse compendiums",
+      "equip-armor": "Equip armor",
+      "equip-weapon": "Equip weapon",
+      "equip-gear": "Equip gear",
+      "equip-reserve": "Equip reserve",
+      "equip-mod": "Install mod",
+      "insert-weapon": "Insert {size} weapon",
+      "invalid-drop": "This slot accepts: {types}",
+      "picker-title": "Choose from Compendium",
+      "picker-hint": "Showing compendium items of type: {types}",
+      "picker-filter": "Filter by name…",
+      "picker-empty": "No matching compendium items found. Import the required LCP first."
     },
     "common-sheet": {
       "tabs": {
@@ -150,6 +179,19 @@
       },
       "json-import": {
         "label": "IMPORT"
+      },
+      "cloud-wizard": {
+        "steps-label": "COMP/CON import steps",
+        "step-login": "Login",
+        "step-select": "Select",
+        "step-import": "Download / JSON",
+        "login-title": "COMP/CON ACCOUNT",
+        "login-button": "Open COMP/CON Login",
+        "logged-in": "Signed in — {count} pilots available in the vault list.",
+        "logged-out": "Optional: sign in to list pilots from your COMP/CON vault. Share codes work without login.",
+        "json-hint": "Upload a pilot JSON exported from COMP/CON.",
+        "tour-link": "Take the pilot import tour",
+        "tour-missing": "Pilot import tour is not registered."
       },
       "dossier": {
         "cs": "CALLSIGN",

--- a/public/templates/actor/pilot.hbs
+++ b/public/templates/actor/pilot.hbs
@@ -90,21 +90,54 @@
   {{!-- Sheet Body --}}
   <section class="sheet-body scroll-body">
     {{!-- Cloud Management Tab --}}
-    <div class="tab manage {{tabs.primary.cloud.cssClass}}" data-group="primary" data-tab="cloud">
-      <div style="display: grid; grid-template: auto / 1fr 1fr">
-        <div class="card clipped" style="grid-area: 1/1/2/3">
+    <div class="tab manage cloud-wizard {{tabs.primary.cloud.cssClass}}" data-group="primary" data-tab="cloud">
+      <ol class="cloud-wizard-steps" aria-label='{{localize "lancer.pilot-sheet.cloud-wizard.steps-label"}}'>
+        <li class="cloud-wizard-step-label" data-cloud-step="login">
+          <span class="cloud-wizard-step-num">1</span>
+          <span class="minor">{{localize "lancer.pilot-sheet.cloud-wizard.step-login"}}</span>
+        </li>
+        <li class="cloud-wizard-step-label" data-cloud-step="select">
+          <span class="cloud-wizard-step-num">2</span>
+          <span class="minor">{{localize "lancer.pilot-sheet.cloud-wizard.step-select"}}</span>
+        </li>
+        <li class="cloud-wizard-step-label" data-cloud-step="import">
+          <span class="cloud-wizard-step-num">3</span>
+          <span class="minor">{{localize "lancer.pilot-sheet.cloud-wizard.step-import"}}</span>
+        </li>
+      </ol>
+
+      <div class="cloud-wizard-panels">
+        <div class="card clipped cloud-wizard-panel" data-cloud-step="login">
+          <span class="lancer-header lancer-primary major">{{
+              localize "lancer.pilot-sheet.cloud-wizard.login-title"
+            }}</span>
+          {{#if compConLoggedIn}}
+            <p class="minor desc-text cloud-login-status cloud-login-status--ok">
+              {{localize "lancer.pilot-sheet.cloud-wizard.logged-in" count=compConPilotCount}}
+            </p>
+          {{else}}
+            <p class="minor desc-text cloud-login-status">
+              {{localize "lancer.pilot-sheet.cloud-wizard.logged-out"}}
+            </p>
+          {{/if}}
+          <button type="button" class="lancer-button cloud-login-button" data-action="compconLogin">
+            <i class="mdi mdi-cloud-sync-outline"></i>
+            {{localize "lancer.pilot-sheet.cloud-wizard.login-button"}}
+          </button>
+        </div>
+
+        <div class="card clipped cloud-wizard-panel" data-cloud-step="select">
           <span class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.cloud-header.label"}}</span>
+          <p class="minor desc-text">{{localize "lancer.pilot-sheet.cloud-header.vaultID"}}</p>
           <select
-            class="lancer-input major lancer-text-field"
-            style="text-align: center"
+            class="lancer-input major lancer-text-field cloud-pilot-select"
             name="selectCloudId"
             data-type="text"
           >
             {{selectOptions compConPilotList selected=system.cloud_id inverted=true}}
           </select>
           <input
-            class="lancer-input major"
-            style="text-align: center"
+            class="lancer-input major cloud-share-code"
             type="text"
             name="system.cloud_id"
             value="{{system.cloud_id}}"
@@ -113,26 +146,37 @@
           />
         </div>
 
-        <div class="card clipped" style="grid-area: 2/1/3/2">
-          <span class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.cloud-download.label"}}</span>
-          <a
-            class="cloud-control lancer-button cloud-download-button"
-            style="align-self: center"
-            data-action="download"
-            aria-busy="false"
-          >
-            <i class="cci cci-tech-quick i--dark i--5 cloud-download-idle"></i>
-            <i class="fas fa-spinner fa-spin cloud-download-spinner i--dark i--5" hidden></i>
-          </a>
-          <span class="minor desc-text cloud-download-status" style="text-align: center">
-            {{localize "lancer.pilot-sheet.cloud-download.lastSync" timestamp=system.last_cloud_update}}
-          </span>
-        </div>
+        <div class="cloud-wizard-import-row">
+          <div class="card clipped cloud-wizard-panel" data-cloud-step="import">
+            <span class="lancer-header lancer-primary major">{{
+                localize "lancer.pilot-sheet.cloud-download.label"
+              }}</span>
+            <a
+              class="cloud-control lancer-button cloud-download-button"
+              data-action="download"
+              aria-busy="false"
+            >
+              <i class="cci cci-tech-quick i--dark i--5 cloud-download-idle"></i>
+              <i class="fas fa-spinner fa-spin cloud-download-spinner i--dark i--5" hidden></i>
+            </a>
+            <span class="minor desc-text cloud-download-status">
+              {{localize "lancer.pilot-sheet.cloud-download.lastSync" timestamp=system.last_cloud_update}}
+            </span>
+          </div>
 
-        <div class="card clipped" style="grid-area: 2/2/3/3">
-          <span class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.json-import.label"}}</span>
-          <input id="pilot-json-import" type="file" name="pilot-json-up" class="lcp-up" accept=".json">
+          <div class="card clipped cloud-wizard-panel" data-cloud-step="import">
+            <span class="lancer-header lancer-primary major">{{localize "lancer.pilot-sheet.json-import.label"}}</span>
+            <p class="minor desc-text">{{localize "lancer.pilot-sheet.cloud-wizard.json-hint"}}</p>
+            <input id="pilot-json-import" type="file" name="pilot-json-up" class="lcp-up" accept=".json">
+          </div>
         </div>
+      </div>
+
+      <div class="cloud-wizard-footer">
+        <button type="button" class="lancer-button cloud-tour-link" data-action="startPilotImportTour">
+          <i class="fas fa-route"></i>
+          {{localize "lancer.pilot-sheet.cloud-wizard.tour-link"}}
+        </button>
       </div>
     </div>
 

--- a/public/templates/window/compendium-slot-picker.hbs
+++ b/public/templates/window/compendium-slot-picker.hbs
@@ -1,0 +1,25 @@
+<div class="compendium-slot-picker">
+  <p class="minor desc-text">{{hint}}</p>
+  <input
+    class="lancer-input major compendium-slot-picker-filter"
+    type="search"
+    placeholder='{{localize "lancer.ref-slot.picker-filter"}}'
+    autocomplete="off"
+  />
+  <div class="compendium-slot-picker-list scroll-body">
+    {{#if items.length}}
+      {{#each items}}
+        <button
+          type="button"
+          class="compendium-slot-picker-item lancer-button"
+          data-uuid="{{uuid}}"
+        >
+          <img src="{{img}}" alt="" />
+          <span class="major">{{name}}</span>
+        </button>
+      {{/each}}
+    {{else}}
+      <p class="minor desc-text">{{localize "lancer.ref-slot.picker-empty"}}</p>
+    {{/if}}
+  </div>
+</div>

--- a/public/templates/window/import-result.hbs
+++ b/public/templates/window/import-result.hbs
@@ -1,0 +1,29 @@
+<div class="import-result import-result--{{status}}">
+  <p class="import-result-summary major">{{summary}}</p>
+
+  {{#if missingActors.length}}
+    <div class="import-result-section">
+      <span class="lancer-header lancer-primary minor">{{localize "lancer.import.result.missing-actors"}}</span>
+      <ul class="import-result-list">
+        {{#each missingActors}}
+          <li><strong>{{name}}</strong> — <code>{{lid}}</code></li>
+        {{/each}}
+      </ul>
+    </div>
+  {{/if}}
+
+  {{#if missingItems.length}}
+    <div class="import-result-section">
+      <span class="lancer-header lancer-primary minor">{{localize "lancer.import.result.missing-items"}}</span>
+      <ul class="import-result-list">
+        {{#each missingItems}}
+          <li><strong>{{actor}}</strong> — <code>{{lid}}</code></li>
+        {{/each}}
+      </ul>
+    </div>
+  {{/if}}
+
+  {{#if showLcpHint}}
+    <p class="minor desc-text import-result-hint">{{{lcpHint}}}</p>
+  {{/if}}
+</div>

--- a/public/tours/pilot-import.json
+++ b/public/tours/pilot-import.json
@@ -20,14 +20,14 @@
     },
     {
       "id": "codeEntry",
-      "selector": "#LancerPilotSheet-Actor-TOUR0PILOT000000 div[data-tab='cloud'] div div:nth-child(1)",
+      "selector": "#LancerPilotSheet-Actor-TOUR0PILOT000000 div[data-tab='cloud'] [data-cloud-step='select']",
       "title": "lancer.tour.pilot-import.codeEntry.title",
       "content": "lancer.tour.pilot-import.codeEntry.content",
       "sidebarTab": "actors"
     },
     {
       "id": "download",
-      "selector": "#LancerPilotSheet-Actor-TOUR0PILOT000000 div[data-tab='cloud'] div div:nth-child(2)",
+      "selector": "#LancerPilotSheet-Actor-TOUR0PILOT000000 div[data-tab='cloud'] .cloud-download-button",
       "title": "lancer.tour.pilot-import.download.title",
       "content": "lancer.tour.pilot-import.download.content",
       "sidebarTab": "actors"
@@ -41,7 +41,7 @@
     },
     {
       "id": "jsonImport",
-      "selector": "#LancerPilotSheet-Actor-TOUR0PILOT000000 div[data-tab='cloud'] div div:nth-child(4)",
+      "selector": "#LancerPilotSheet-Actor-TOUR0PILOT000000 input#pilot-json-import",
       "title": "lancer.tour.pilot-import.jsonImport.title",
       "content": "lancer.tour.pilot-import.jsonImport.content",
       "sidebarTab": "actors"

--- a/src/module/actor/import.ts
+++ b/src/module/actor/import.ts
@@ -57,6 +57,78 @@ import { unpackReserve } from "../models/items/reserve";
 import { unpackFrame } from "../models/items/frame";
 const lp = LANCER.log_prefix;
 
+export type ImportResultStatus = "success" | "partial" | "failure";
+export type ImportResultSource = "cloud" | "json" | "v2" | "v3";
+
+export interface ImportResultSummary {
+  status: ImportResultStatus;
+  pilotName: string;
+  source?: ImportResultSource;
+  message?: string;
+  missingActors?: { name: string; lid: string }[];
+  missingItems?: { actor: string; lid: string }[];
+}
+
+function buildImportResultSummary(
+  pilot: LancerPILOT,
+  missingActors: { name: string; lid: string }[],
+  missingItems: { actor: string; lid: string }[],
+  source?: ImportResultSource
+): ImportResultSummary {
+  const hasMissing = missingActors.length > 0 || missingItems.length > 0;
+  return {
+    status: hasMissing ? "partial" : "success",
+    pilotName: pilot.name,
+    source,
+    missingActors,
+    missingItems,
+  };
+}
+
+export async function showImportResultDialog(summary: ImportResultSummary): Promise<void> {
+  const summaryKey =
+    summary.status === "success"
+      ? "lancer.import.result.success"
+      : summary.status === "partial"
+        ? "lancer.import.result.partial"
+        : "lancer.import.result.failure";
+
+  const content = await foundry.applications.handlebars.renderTemplate(
+    `systems/${game.system.id}/templates/window/import-result.hbs`,
+    {
+      status: summary.status,
+      summary: summary.message ?? game.i18n.format(summaryKey, { name: summary.pilotName }),
+      missingActors: summary.missingActors ?? [],
+      missingItems: summary.missingItems ?? [],
+      showLcpHint: summary.status === "partial",
+      lcpHint: game.i18n.localize("lancer.import.result.lcp-hint"),
+    }
+  );
+
+  const icon =
+    summary.status === "success"
+      ? "fas fa-check-circle"
+      : summary.status === "partial"
+        ? "fas fa-triangle-exclamation"
+        : "fas fa-times-circle";
+
+  await new foundry.applications.api.DialogV2({
+    window: {
+      title: game.i18n.localize("lancer.import.result.title"),
+      icon,
+    },
+    content,
+    buttons: [
+      {
+        action: "close",
+        icon: "fas fa-check",
+        label: game.i18n.localize("lancer.import.result.close"),
+        default: true,
+      },
+    ],
+  }).render(true);
+}
+
 async function notifyCoreDataRequired(): Promise<void> {
   const message = game.i18n.localize("lancer.import.errors.core-data-required");
   ui.notifications!.warn(message, { permanent: true });
@@ -87,49 +159,16 @@ function unpackClock(clock: PackedClockBurdenData) {
   };
 }
 
-function showIncompleteImportSummary(
+async function showIncompleteImportSummary(
   pilot: LancerPILOT,
   missingActors: { name: string; lid: string }[],
-  missingItems: { actor: string; lid: string }[]
+  missingItems: { actor: string; lid: string }[],
+  source?: ImportResultSource
 ) {
-  if (!missingItems.length && !missingActors.length) {
-    ui.notifications!.info("Successfully loaded pilot new state.");
-    return;
+  if (missingItems.length || missingActors.length) {
+    console.warn(`${lp} Some actors and/or items were missed during pilot import:`, missingActors, missingItems);
   }
-
-  let message = `Partially loaded '${pilot.name}'s new state.`;
-  if (missingActors.length) {
-    message += ` ${missingActors.length} actors could not be created/updated.`;
-  }
-  if (missingItems.length) {
-    message += ` ${missingItems.length} items could not be found.`;
-  }
-  message += ` Open the dialog for missing LIDs and install required LCPs via the Compendium Manager.`;
-  ui.notifications!.warn(message, { permanent: true });
-  console.warn(`${lp} Some actors and/or items were missed during pilot import:`, missingActors, missingItems);
-
-  let content = "";
-  if (missingActors.length) {
-    content += `<div><span>The following Actors could not be created or updated:</span>
-        <ul>${missingActors.map(i => `<li>${i.name} - ${i.lid}</li>`).join("")}</ul></div>`;
-  }
-  if (missingItems.length) {
-    content += `<div><span>The following Items were not found in the compendium and could not be imported:</span>
-        <ul>${missingItems.map(i => `<li>${i.actor} - ${i.lid}</li>`).join("")}</ul>
-        <span>Import all necessary LCPs first using the <b>Lancer Compendium Manager</b>.</span></div>`;
-  }
-  new foundry.applications.api.DialogV2({
-    window: { title: `Incomplete Pilot Import`, icon: "fas fa-triangle-exclamation" },
-    content,
-    buttons: [
-      {
-        action: "close",
-        icon: "fas fa-check",
-        label: "Close",
-        default: true,
-      },
-    ],
-  }).render(true);
+  await showImportResultDialog(buildImportResultSummary(pilot, missingActors, missingItems, source));
 }
 
 /**
@@ -438,18 +477,24 @@ async function getActorItemByLid(
 export async function importCC(
   pilot: LancerPILOT,
   importedData: PackedPilotData | PackedPilotWrapper,
-  clearFirst = true
+  clearFirst = true,
+  source: ImportResultSource = "cloud"
 ) {
   const resolved = resolveImportCCPayload(importedData);
   if (!resolved) {
-    ui.notifications!.error("Could not determine COMP/CON import format for this pilot data.", { permanent: true });
     console.error(`${lp} Unrecognized COMP/CON import payload`, importedData);
+    await showImportResultDialog({
+      status: "failure",
+      pilotName: pilot.name,
+      source,
+      message: game.i18n.localize("lancer.import.errors.unrecognized-format"),
+    });
     return;
   }
   if (resolved.route === "v3") {
-    await importCCv3(pilot, resolved.wrapper, clearFirst);
+    await importCCv3(pilot, resolved.wrapper, clearFirst, source === "json" ? "json" : "v3");
   } else {
-    await importCCv2(pilot, resolved.data, clearFirst);
+    await importCCv2(pilot, resolved.data, clearFirst, source === "json" ? "json" : "v2");
   }
 }
 
@@ -457,20 +502,33 @@ export async function importCC(
  * Imports packed pilot data from CCv3.
  * Minimum import version: CCv3.0.4
  */
-export async function importCCv3(pilot: LancerPILOT, importedData: PackedPilotWrapper, clearFirst = true) {
+export async function importCCv3(
+  pilot: LancerPILOT,
+  importedData: PackedPilotWrapper,
+  clearFirst = true,
+  source: ImportResultSource = "v3"
+) {
   if (!requireCoreDataForImport()) return;
 
   console.log(`${lp} Importing v3 Pilot`, pilot, importedData);
   if (!pilot.is_pilot()) {
-    ui.notifications!.error("COMP/CON import target is not a pilot actor.", { permanent: true });
+    await showImportResultDialog({
+      status: "failure",
+      pilotName: pilot.name,
+      source,
+      message: game.i18n.localize("lancer.import.errors.not-pilot"),
+    });
     return;
   }
   const data = importedData.data;
   if (!data?.name || !data?.callsign) {
-    ui.notifications!.warn("COMP/CON v3 import data is missing required pilot fields (name/callsign).", {
-      permanent: true,
-    });
     console.error(`${lp} Invalid v3 import payload`, importedData);
+    await showImportResultDialog({
+      status: "failure",
+      pilotName: pilot.name,
+      source,
+      message: game.i18n.localize("lancer.import.errors.missing-fields"),
+    });
     return;
   }
 
@@ -1073,15 +1131,25 @@ export async function importCCv3(pilot: LancerPILOT, importedData: PackedPilotWr
 
     pilot.effectHelper.propagateEffects(true);
     pilot.render();
-    showIncompleteImportSummary(pilot, _missingActors, _missingItems);
+    await showIncompleteImportSummary(pilot, _missingActors, _missingItems, source);
   } catch (e) {
     console.warn(e);
-    ui.notifications!.warn(`Failed to update pilot: ${e instanceof Error ? e.message : e}`, { permanent: true });
+    await showImportResultDialog({
+      status: "failure",
+      pilotName: pilot.name,
+      source,
+      message: e instanceof Error ? e.message : String(e),
+    });
   }
 }
 
 // Imports packed pilot data, from either a vault id or gist id
-export async function importCCv2(pilot: LancerPILOT, data: PackedPilotData, clearFirst = true) {
+export async function importCCv2(
+  pilot: LancerPILOT,
+  data: PackedPilotData,
+  clearFirst = true,
+  source: ImportResultSource = "v2"
+) {
   if (!requireCoreDataForImport()) return;
   console.log(`${lp} Importing v2 Pilot`, pilot, data);
   if (!pilot.is_pilot() || !data) return;
@@ -1507,9 +1575,14 @@ export async function importCCv2(pilot: LancerPILOT, data: PackedPilotData, clea
 
     // Reset curr data and render all
     pilot.render();
-    showIncompleteImportSummary(pilot, missingActors, missingItems);
+    await showIncompleteImportSummary(pilot, missingActors, missingItems, source);
   } catch (e) {
     console.warn(e);
-    ui.notifications!.warn(`Failed to update pilot: ${e instanceof Error ? e.message : e}`, { permanent: true });
+    await showImportResultDialog({
+      status: "failure",
+      pilotName: pilot.name,
+      source,
+      message: e instanceof Error ? e.message : String(e),
+    });
   }
 }

--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -27,6 +27,7 @@ import {
   handleRefClickOpen,
   handleRefDragging,
   handleRefSlotDropping,
+  handleRefSlotPicking,
   handleUsesInteraction,
 } from "../helpers/refs";
 import { LancerItem } from "../item/lancer-item";
@@ -154,7 +155,9 @@ export class LancerActorSheet<T extends LancerActorType> extends HandlebarsAppli
     handlePowerUsesInteraction($el, this.actor);
     handleContextMenus($el, this.actor);
     this._activateInventoryButton($el);
-    handleRefSlotDropping($el, this.actor, x => this.quickOwnDrop(x).then(v => v[0]));
+    const preFinalizeDrop = (x: ResolvedDropData) => this.quickOwnDrop(x).then(v => v[0]);
+    handleRefSlotDropping($el, this.actor, preFinalizeDrop);
+    handleRefSlotPicking($el, this.actor, preFinalizeDrop);
     handleGenControls($el, this.actor);
     handlePopoutTextEditor($el, this.actor);
     handleDocDropping(

--- a/src/module/actor/pilot-sheet.ts
+++ b/src/module/actor/pilot-sheet.ts
@@ -12,14 +12,16 @@ import {
   fetchPilotViaShareCode,
   fetchV2PilotViaShareCode,
   fetchV3PilotViaShareCode,
+  isCompconLoggedIn,
   pilotCache,
 } from "../util/compcon";
+import CompconLoginForm from "../helpers/compcon-login-form";
 import type { LancerFRAME } from "../item/lancer-item";
 import { clicker_num_input } from "../helpers/actor";
 import type { ResolvedDropData } from "../helpers/dragdrop";
 import { EntryType } from "../enums";
 import type { PackedPilotData } from "../util/unpacking/packed-types";
-import { importCC } from "./import";
+import { importCC, showImportResultDialog } from "./import";
 
 const shareCodeMatcherV2 = /^[A-Z0-9]{6}$/;
 const shareCodeMatcherV3 = /^[A-Z0-9]{12}$/;
@@ -169,7 +171,7 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
           }
         }
 
-        await importCC(this.actor as LancerPILOT, raw_pilot_data);
+        await importCC(this.actor as LancerPILOT, raw_pilot_data, true, "cloud");
         this.render();
       } catch (error) {
         ui.notifications!.error(cloudImportError("COMP/CON import failed.", error));
@@ -181,6 +183,28 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
         }
       }
     });
+
+    $el
+      .find('[data-action="compconLogin"]')
+      .off("click.lancerCompconLogin")
+      .on("click.lancerCompconLogin", async ev => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const app = new CompconLoginForm();
+        app.addEventListener("close", () => this.render(), { once: true });
+        await app.render(true);
+      });
+
+    $el
+      .find('[data-action="startPilotImportTour"]')
+      .off("click.lancerPilotImportTour")
+      .on("click.lancerPilotImportTour", async ev => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const tour = game.tours.get(`${game.system.id}.pilot-import`);
+        if (tour) await tour.start();
+        else ui.notifications!.warn(game.i18n.localize("lancer.pilot-sheet.cloud-wizard.tour-missing"));
+      });
 
     $el.find<HTMLInputElement>("input#pilot-json-import").on("change", ev => this._onPilotJsonUpload(ev));
 
@@ -219,8 +243,13 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
     try {
       parsed = JSON.parse(fileData) as PackedPilotData & { data?: PackedPilotData };
     } catch (error) {
-      ui.notifications!.error("Selected file is not valid JSON.");
       console.error(`${lp} Failed to parse pilot JSON:`, error);
+      await showImportResultDialog({
+        status: "failure",
+        pilotName: this.actor.name,
+        source: "json",
+        message: game.i18n.localize("lancer.import.errors.invalid-json"),
+      });
       return;
     }
 
@@ -228,16 +257,18 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
 
     if (!parsed) return;
     const displayName = parsed.name ?? parsed.data?.name ?? "Pilot";
-    const displayCallsign = parsed.callsign ?? parsed.data?.callsign ?? "";
-    ui.notifications!.info(`Starting import of ${displayName}, Callsign ${displayCallsign}. Please wait.`);
 
     try {
-      await importCC(this.actor as LancerPILOT, parsed);
-      ui.notifications!.info(`Import of ${displayName}, Callsign ${displayCallsign} complete.`);
+      await importCC(this.actor as LancerPILOT, parsed, true, "json");
       this.render();
     } catch (error) {
-      ui.notifications!.error(`Import of ${displayName} failed. See the console for details.`);
       console.error(`${lp} JSON pilot import failed:`, error);
+      await showImportResultDialog({
+        status: "failure",
+        pilotName: displayName,
+        source: "json",
+        message: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
@@ -260,6 +291,8 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
   ): Promise<LancerActorSheetData<EntryType.PILOT>> {
     const data = (await super._prepareContext(options)) as LancerActorSheetData<EntryType.PILOT>;
 
+    data.compConLoggedIn = await isCompconLoggedIn();
+    data.compConPilotCount = pilotCache().length;
     data.compConPilotList = pilotCache()
       .sort((p1, p2) => {
         if (p1.callsign < p2.callsign) return -1;
@@ -277,6 +310,16 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
       );
 
     return data;
+  }
+
+  protected override _ensureDefaultTabsIfBlank(): void {
+    const pilot = this.actor as LancerPILOT;
+    const root = (this.form ?? this.element) as HTMLElement;
+    if (pilot.system.last_cloud_update === "never" && !root.querySelector('.tab.active[data-group="primary"]')) {
+      this.changeTab("cloud", "primary", { force: true });
+      return;
+    }
+    super._ensureDefaultTabsIfBlank();
   }
 
   protected override _processFormData(

--- a/src/module/apps/compendium-slot-picker.ts
+++ b/src/module/apps/compendium-slot-picker.ts
@@ -1,0 +1,164 @@
+import type { LancerActor } from "../actor/lancer-actor";
+import { EntryType } from "../enums";
+import { LancerItem } from "../item/lancer-item";
+import { setRefSlotValue } from "../helpers/refs";
+import type { ResolvedDropData } from "../helpers/dragdrop";
+import { get_pack_id } from "../util/doc";
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+interface CompendiumSlotPickerItem {
+  uuid: string;
+  name: string;
+  img: string;
+}
+
+interface CompendiumSlotPickerOptions {
+  actor: LancerActor;
+  acceptTypes: EntryType[];
+  slotPath: string;
+  preFinalizeDrop?: ((drop: ResolvedDropData) => Promise<ResolvedDropData>) | null;
+  resolve: (item: LancerItem | null) => void;
+}
+
+export class CompendiumSlotPicker extends HandlebarsApplicationMixin(ApplicationV2) {
+  #resolve: (item: LancerItem | null) => void;
+  #settled = false;
+  #items: CompendiumSlotPickerItem[] = [];
+
+  constructor(options: CompendiumSlotPickerOptions) {
+    super({
+      actor: options.actor,
+      acceptTypes: options.acceptTypes,
+      slotPath: options.slotPath,
+      preFinalizeDrop: options.preFinalizeDrop ?? null,
+      resolve: options.resolve,
+    } as Record<string, unknown>);
+    this.#resolve = options.resolve;
+  }
+
+  static PARTS = {
+    body: { template: "systems/lancer/templates/window/compendium-slot-picker.hbs" },
+  };
+
+  static DEFAULT_OPTIONS = {
+    id: "lancer-compendium-slot-picker",
+    position: { width: 420, height: 520 },
+    classes: ["lancer", "compendium-slot-picker-app"],
+    window: {
+      resizable: true,
+    },
+  };
+
+  get actor(): LancerActor {
+    return (this.options as CompendiumSlotPickerOptions).actor;
+  }
+
+  get acceptTypes(): EntryType[] {
+    return (this.options as CompendiumSlotPickerOptions).acceptTypes;
+  }
+
+  get slotPath(): string {
+    return (this.options as CompendiumSlotPickerOptions).slotPath;
+  }
+
+  get preFinalizeDrop(): ((drop: ResolvedDropData) => Promise<ResolvedDropData>) | null {
+    return (this.options as CompendiumSlotPickerOptions).preFinalizeDrop ?? null;
+  }
+
+  static async pick(
+    actor: LancerActor,
+    acceptTypes: EntryType[],
+    slotPath: string,
+    preFinalizeDrop?: ((drop: ResolvedDropData) => Promise<ResolvedDropData>) | null
+  ): Promise<LancerItem | null> {
+    return await new Promise(resolve => {
+      const dlg = new CompendiumSlotPicker({
+        actor,
+        acceptTypes,
+        slotPath,
+        preFinalizeDrop: preFinalizeDrop ?? null,
+        resolve,
+      });
+      void dlg.render(true);
+    });
+  }
+
+  #finish(item: LancerItem | null): void {
+    if (this.#settled) return;
+    this.#settled = true;
+    this.#resolve(item);
+  }
+
+  async _prepareContext(options: Record<string, unknown>): Promise<object> {
+    const context = await super._prepareContext(options);
+    this.#items = await this.#loadItems();
+    const typeLabels = this.acceptTypes.map(t => game.i18n.localize(`TYPES.Item.${t}`)).join(", ");
+    return foundry.utils.mergeObject(context, {
+      items: this.#items,
+      hint: game.i18n.format("lancer.ref-slot.picker-hint", { types: typeLabels }),
+      window: {
+        title: game.i18n.localize("lancer.ref-slot.picker-title"),
+      },
+    });
+  }
+
+  async #loadItems(): Promise<CompendiumSlotPickerItem[]> {
+    const items: CompendiumSlotPickerItem[] = [];
+    const seen = new Set<string>();
+
+    for (const type of this.acceptTypes) {
+      const pack = game.packs.get(get_pack_id(type));
+      if (!pack) continue;
+      const docs = (await pack.getDocuments({ type })) as LancerItem[];
+      for (const doc of docs) {
+        if (seen.has(doc.uuid)) continue;
+        seen.add(doc.uuid);
+        items.push({
+          uuid: doc.uuid,
+          name: doc.name ?? doc.system?.name ?? doc.uuid,
+          img: doc.img ?? "icons/svg/item-bag.svg",
+        });
+      }
+    }
+
+    return items.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+  }
+
+  _onRender(context: object, options: Record<string, unknown>) {
+    super._onRender(context, options);
+    const html = $(this.element);
+    const filter = html.find(".compendium-slot-picker-filter");
+    const list = html.find(".compendium-slot-picker-list");
+
+    filter.on("input", () => {
+      const query = (filter.val() as string).trim().toLowerCase();
+      list.find(".compendium-slot-picker-item").each((_, el) => {
+        const name = el.querySelector("span")?.textContent?.toLowerCase() ?? "";
+        el.toggle(!query || name.includes(query));
+      });
+    });
+
+    list.find(".compendium-slot-picker-item").on("click", async ev => {
+      ev.preventDefault();
+      const uuid = (ev.currentTarget as HTMLElement).dataset.uuid;
+      if (!uuid) return;
+      const doc = await fromUuid(uuid);
+      if (!(doc instanceof LancerItem)) return;
+
+      let drop: ResolvedDropData = { type: "Item", document: doc };
+      if (this.preFinalizeDrop) {
+        drop = await this.preFinalizeDrop(drop);
+      }
+
+      await setRefSlotValue(this.actor, this.slotPath, drop.document);
+      this.#finish(drop.document);
+      await this.close();
+    });
+  }
+
+  async _onClose(options: Record<string, unknown>): Promise<void> {
+    this.#finish(null);
+    return super._onClose(options);
+  }
+}

--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -26,7 +26,7 @@ import {
   activationStyle,
   activationIcon,
 } from "./commons";
-import { limitedUsesIndicator, loadingIndicator, ref_params, reserveUsesIndicator } from "./refs";
+import { limitedUsesIndicator, loadingIndicator, ref_params, refSlotEmptyHintHtml, reserveUsesIndicator } from "./refs";
 import {
   ActivationType,
   ChipIcons,
@@ -361,11 +361,12 @@ export function pilotArmorSlot(armor_path: string, options: HelperOptions): stri
   // Generate commons
   if (!armor) {
     // Make an empty ref. Note that it still has path stuff if we are going to be dropping things here
-    return `<div class="${EntryType.PILOT_ARMOR} ref drop-settable card"
+    return `<div class="${EntryType.PILOT_ARMOR} ref slot drop-settable click-settable card"
                         data-path="${armor_path}"
                         data-accept-types="${EntryType.PILOT_ARMOR}">
           <img class="ref-icon" src="${TypeIcon(EntryType.PILOT_ARMOR)}"></img>
-          <span class="major">Equip armor</span>
+          <span class="major">${game.i18n.localize("lancer.ref-slot.equip-armor")}</span>
+          ${refSlotEmptyHintHtml()}
       </div>`;
   }
 
@@ -434,11 +435,12 @@ export function pilotWeaponRefview(weapon_path: string, options: HelperOptions):
   // Generate commons
   if (!weapon) {
     // Make an empty ref. Note that it still has path stuff if we are going to be dropping things here
-    return `<div class="${EntryType.PILOT_WEAPON} ref drop-settable card flexrow"
+    return `<div class="${EntryType.PILOT_WEAPON} ref slot drop-settable click-settable card flexrow"
                         data-path="${weapon_path}"
                         data-accept-types="${EntryType.PILOT_WEAPON}">
           <img class="ref-icon" src="${TypeIcon(EntryType.PILOT_WEAPON)}"></img>
-          <span class="major">Equip weapon</span>
+          <span class="major">${game.i18n.localize("lancer.ref-slot.equip-weapon")}</span>
+          ${refSlotEmptyHintHtml()}
       </div>`;
   }
 
@@ -506,11 +508,12 @@ export function pilotGearRefview(gear_path: string, options: HelperOptions): str
 
   if (!gear) {
     // Make an empty ref. Note that it still has path stuff if we are going to be dropping things here
-    return `<div class="${EntryType.PILOT_GEAR} ref drop-settable card flexrow"
+    return `<div class="${EntryType.PILOT_GEAR} ref slot drop-settable click-settable card flexrow"
                         data-path="${gear_path}"
                         data-accept-types="${EntryType.PILOT_GEAR}">
           <img class="ref-icon" src="${TypeIcon(EntryType.PILOT_GEAR)}"></img>
-          <span class="major">Equip gear</span>
+          <span class="major">${game.i18n.localize("lancer.ref-slot.equip-gear")}</span>
+          ${refSlotEmptyHintHtml()}
       </div>`;
   }
 
@@ -568,11 +571,12 @@ export function reserveRefView(reserve_path: string, options: HelperOptions): st
   // Generate commons
   if (!reserve) {
     // Make an empty ref. Note that it still has path stuff if we are going to be dropping things here
-    return `<div class="${EntryType.RESERVE} ref drop-settable card flexrow"
+    return `<div class="${EntryType.RESERVE} ref slot drop-settable click-settable card flexrow"
                         data-path="${reserve_path}"
                         data-accept-types="${EntryType.RESERVE}">
           <img class="ref-icon" src="${TypeIcon(EntryType.RESERVE)}"></img>
-          <span class="major">Equip reserve</span>
+          <span class="major">${game.i18n.localize("lancer.ref-slot.equip-reserve")}</span>
+          ${refSlotEmptyHintHtml()}
       </div>`;
   }
 
@@ -664,11 +668,12 @@ export function mechLoadoutWeaponSlot(
         : size
       : "any";
     return `
-      <div class="${EntryType.MECH_WEAPON} ref slot drop-settable card flexrow"
+      <div class="${EntryType.MECH_WEAPON} ref slot drop-settable click-settable card flexrow"
            data-path="${weapon_path}"
            data-accept-types="${EntryType.MECH_WEAPON}">
         <img class="ref-icon" src="${TypeIcon(EntryType.MECH_WEAPON)}"></img>
-        <span class="major">Insert ${slotSize} weapon</span>
+        <span class="major">${game.i18n.format("lancer.ref-slot.insert-weapon", { size: slotSize })}</span>
+        ${refSlotEmptyHintHtml()}
       </div>`;
   } else {
     return mechWeaponDisplay(weapon_path, mod_path, options);
@@ -785,11 +790,12 @@ export function weaponModView(mod_path: string, weapon_path: string | null, opti
   let mod: LancerWEAPON_MOD | null = resolveHelperDotpath(options, mod_path);
   let weapon: LancerMECH_WEAPON | null = weapon_path ? resolveHelperDotpath(options, weapon_path) : null;
   if (!mod) {
-    return `<div class="${EntryType.WEAPON_MOD} ref slot drop-settable card flexrow"
+    return `<div class="${EntryType.WEAPON_MOD} ref slot drop-settable click-settable card flexrow"
         data-path="${mod_path}"
         data-accept-types="${EntryType.WEAPON_MOD}">
       <i class="cci cci-weaponmod i--4 i--light"> </i>
-      <span>No Mod Installed</span>
+      <span class="major">${game.i18n.localize("lancer.ref-slot.equip-mod")}</span>
+      ${refSlotEmptyHintHtml()}
     </div>`;
   }
 

--- a/src/module/helpers/refs.ts
+++ b/src/module/helpers/refs.ts
@@ -12,7 +12,13 @@ import {
   type LancerRESERVE,
 } from "../item/lancer-item";
 import { array_path_edit_changes, drilldownDocument, extendHelper, hex_array, resolveHelperDotpath } from "./commons";
-import { type FoundryDropData, handleDocDropping, handleDragging, type ResolvedDropData } from "./dragdrop";
+import {
+  type DropPredicate,
+  type FoundryDropData,
+  handleDocDropping,
+  handleDragging,
+  type ResolvedDropData,
+} from "./dragdrop";
 import {
   framePreview,
   licenseRefView,
@@ -76,11 +82,12 @@ export function simple_ref_slot(path: string = "", accept_types: string | EntryT
     let icons = (arr_types || ["dummy"]).filter(t => t).map(t => `<img class="ref-icon" src="${TypeIcon(t)}"></img>`);
 
     // Make an empty ref. Note that it still has path stuff if we are going to be dropping things here
-    return `<div class="ref ref-card slot"
+    return `<div class="ref ref-card slot drop-settable click-settable"
                  data-accept-types="${flat_types}"
                  data-path="${path}">
           ${icons.join(" ")}
-          <span class="major">Empty</span>
+          <span class="major">${game.i18n.localize("lancer.ref-slot.empty-label")}</span>
+          ${refSlotEmptyHintHtml()}
       </div>`;
   } else if (doc.then !== undefined) {
     return `<span>ASYNC not handled yet</span>`;
@@ -424,6 +431,70 @@ export function handleChargedInteraction(html: JQuery, _doc: LancerActor | Lance
   });
 }
 
+export function refSlotEmptyHintHtml(): string {
+  return `<span class="minor ref-slot-hint">${game.i18n.localize("lancer.ref-slot.empty-hint")}</span>`;
+}
+
+export function formatAcceptTypeLabels(acceptTypes: string): string {
+  return acceptTypes
+    .split(" ")
+    .filter(Boolean)
+    .map(t => game.i18n.localize(`TYPES.Item.${t}`))
+    .join(", ");
+}
+
+export function refSlotAcceptsDrop(drop: ResolvedDropData, dest: JQuery): boolean {
+  const types = dest[0]?.dataset?.acceptTypes;
+  if (!types) return true;
+  const docType = drop.type === "Item" ? drop.document.type : "err";
+  return types.split(" ").includes(docType);
+}
+
+export function notifyInvalidRefSlotDrop(dest: JQuery): void {
+  const types = dest[0]?.dataset?.acceptTypes;
+  if (!types) return;
+  ui.notifications!.warn(game.i18n.format("lancer.ref-slot.invalid-drop", { types: formatAcceptTypeLabels(types) }));
+}
+
+export async function setRefSlotValue(
+  root_doc: LancerActor | LancerItem,
+  path: string,
+  val: LancerItem
+): Promise<void> {
+  const dd = drilldownDocument(root_doc, path.endsWith(".value") ? path.slice(0, path.length - ".value".length) : path);
+  const updateData = {} as Record<string, unknown>;
+  if (path.includes("loadout") && dd.sub_doc instanceof LancerActor) {
+    if (dd.sub_doc.is_pilot()) {
+      const cl = (dd.sub_doc as LancerActor & { system: { _source: { loadout: SourceData.Pilot["loadout"] } } }).system
+        ._source.loadout;
+      if (cl.armor.some(x => x == val.id))
+        updateData["system.loadout.armor"] = cl.armor.map(x => (x == val.id ? null : x));
+      if (cl.gear.some(x => x == val.id))
+        updateData["system.loadout.gear"] = cl.gear.map(x => (x == val.id ? null : x));
+      if (cl.weapons.some(x => x == val.id))
+        updateData["system.loadout.weapons"] = cl.weapons.map(x => (x == val.id ? null : x));
+    } else if (dd.sub_doc.is_mech()) {
+      const cl = (dd.sub_doc as LancerActor & { system: { _source: { loadout: SourceData.Mech["loadout"] } } }).system
+        ._source.loadout;
+      if (cl.systems.some(x => x == val.id))
+        updateData["system.loadout.systems"] = cl.systems.map(x => (x == val.id ? null : x));
+      if (cl.weapon_mounts.some(x => x.slots.some(y => y.weapon == val.id || y.mod == val.id))) {
+        updateData["system.loadout.weapon_mounts"] = cl.weapon_mounts.map(wm => ({
+          slots: wm.slots.map(s => ({
+            weapon: s.weapon == val.id ? null : s.weapon,
+            mod: s.mod == val.id ? null : s.mod,
+            size: s.size,
+          })),
+          bracing: wm.bracing,
+          type: wm.type,
+        }));
+      }
+    }
+  }
+  updateData[dd.sub_path] = val.id;
+  await dd.sub_doc.update(updateData);
+}
+
 // Enables dragging of ref cards (or anything with .ref.set and the appropriate fields)
 // This doesn't handle natives
 export function handleRefDragging(html: JQuery) {
@@ -450,59 +521,46 @@ export function handleRefSlotDropping(
   root_doc: LancerActor | LancerItem,
   pre_finalize_drop: ((drop: ResolvedDropData) => Promise<ResolvedDropData>) | null
 ) {
-  handleDocDropping(html.find(".ref.drop-settable"), async (drop, dest, evt) => {
-    // Pre-finalize the entry
-    if (pre_finalize_drop) {
-      drop = await pre_finalize_drop(drop);
+  const allowDrop: DropPredicate = (drop, dest, evt) => {
+    const permitted = refSlotAcceptsDrop(drop, dest);
+    if (!permitted && evt.type === "drop") {
+      notifyInvalidRefSlotDrop(dest);
     }
+    return permitted;
+  };
 
-    // Decide the mode
-    let path = dest[0].dataset.path;
-    let types = dest[0].dataset.acceptTypes as string;
-    let val = drop.document;
-
-    // Check allows
-    if (types && !types.includes((drop.document as any).type ?? "err")) {
-      return;
-    }
-
-    // Then set it to path, with an added correction of unsetting any other place its set on the same document's loadout (if path in loadout)
-    if (path) {
-      let dd = drilldownDocument(
-        root_doc,
-        path.endsWith(".value") ? path.slice(0, path.length - ".value".length) : path
-      ); // If dropping onto an item.value, then truncate to target the item
-      let updateData = {} as any;
-      if (path.includes("loadout") && dd.sub_doc instanceof LancerActor) {
-        // Do clear-correction here
-        if (dd.sub_doc.is_pilot()) {
-          // If other occurrences of val
-          let cl = (dd.sub_doc as any).system._source.loadout as SourceData.Pilot["loadout"];
-          if (cl.armor.some(x => x == val.id))
-            updateData["system.loadout.armor"] = cl.armor.map(x => (x == val.id ? null : x));
-          if (cl.gear.some(x => x == val.id))
-            updateData["system.loadout.gear"] = cl.gear.map(x => (x == val.id ? null : x));
-          if (cl.weapons.some(x => x == val.id))
-            updateData["system.loadout.weapons"] = cl.weapons.map(x => (x == val.id ? null : x));
-        } else if (dd.sub_doc.is_mech()) {
-          let cl = (dd.sub_doc as any).system._source.loadout as SourceData.Mech["loadout"];
-          if (cl.systems.some(x => x == val.id))
-            updateData["system.loadout.systems"] = cl.systems.map(x => (x == val.id ? null : x));
-          if (cl.weapon_mounts.some(x => x.slots.some(y => y.weapon == val.id || y.mod == val.id))) {
-            updateData["system.loadout.weapon_mounts"] = cl.weapon_mounts.map(wm => ({
-              slots: wm.slots.map(s => ({
-                weapon: s.weapon == val.id ? null : s.weapon,
-                mod: s.mod == val.id ? null : s.mod,
-                size: s.size,
-              })),
-              bracing: wm.bracing,
-              type: wm.type,
-            }));
-          }
-        }
+  handleDocDropping(
+    html.find(".ref.drop-settable"),
+    async (drop, dest, _evt) => {
+      if (pre_finalize_drop) {
+        drop = await pre_finalize_drop(drop);
       }
-      updateData[dd.sub_path] = val.id;
-      dd.sub_doc.update(updateData);
-    }
+
+      const path = dest[0].dataset.path;
+      if (!path || drop.type !== "Item") return;
+
+      await setRefSlotValue(root_doc, path, drop.document);
+    },
+    allowDrop
+  );
+}
+
+export function handleRefSlotPicking(
+  html: JQuery,
+  root_doc: LancerActor | LancerItem,
+  pre_finalize_drop: ((drop: ResolvedDropData) => Promise<ResolvedDropData>) | null
+) {
+  if (!(root_doc instanceof LancerActor) || !root_doc.isOwner) return;
+
+  html.find(".ref.slot.click-settable").on("click", async ev => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    const elt = ev.currentTarget as HTMLElement;
+    const path = elt.dataset.path;
+    const acceptTypes = (elt.dataset.acceptTypes ?? "").split(" ").filter(Boolean) as EntryType[];
+    if (!path || !acceptTypes.length) return;
+
+    const { CompendiumSlotPicker } = await import("../apps/compendium-slot-picker");
+    await CompendiumSlotPicker.pick(root_doc, acceptTypes, path, pre_finalize_drop);
   });
 }

--- a/src/module/interfaces.ts
+++ b/src/module/interfaces.ts
@@ -51,6 +51,8 @@ export interface LancerActorSheetData<T extends LancerActorType> {
   pilot?: LancerPILOT;
   // Store cloud pilot cache and potential cloud ids at the root level (pilot sheet)
   compConPilotList?: Record<string, string>;
+  compConLoggedIn?: boolean;
+  compConPilotCount?: number;
   cleanedOwnerID?: string;
   vaultID?: string;
   rawID?: string;

--- a/src/module/util/compcon.ts
+++ b/src/module/util/compcon.ts
@@ -92,6 +92,16 @@ export function pilotCache(): CachedCloudPilot[] {
   return _cache;
 }
 
+export async function isCompconLoggedIn(): Promise<boolean> {
+  try {
+    const { Auth } = await import("@aws-amplify/auth");
+    await Auth.currentSession();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function fetchV2PilotViaShareCode(sharecode: string): Promise<PackedPilotData> {
   const shareCodeResponse = await fetchWithOptionalShareProxy(
     `${CC_API_URI}/share?code=${encodeURIComponent(sharecode)}`,

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -449,6 +449,115 @@
     display: none;
   }
 
+  .cloud-wizard {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .cloud-wizard-steps {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .cloud-wizard-step-label {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .cloud-wizard-step-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: 999px;
+    background: var(--primary-color);
+    color: var(--light-text);
+    font-size: 0.75rem;
+    font-weight: 700;
+  }
+
+  .cloud-wizard-panels {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .cloud-wizard-import-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+  }
+
+  .cloud-wizard-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .cloud-login-status--ok {
+    color: var(--secondary-color);
+  }
+
+  .cloud-wizard-footer {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .ref.slot.click-settable {
+    cursor: pointer;
+  }
+
+  .ref-slot-hint {
+    opacity: 0.85;
+    font-style: italic;
+  }
+
+  .compendium-slot-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-height: 12rem;
+  }
+
+  .compendium-slot-picker-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    max-height: 22rem;
+    overflow-y: auto;
+  }
+
+  .compendium-slot-picker-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-align: left;
+    width: 100%;
+
+    img {
+      width: 2rem;
+      height: 2rem;
+      object-fit: contain;
+      flex: 0 0 auto;
+    }
+  }
+
+  .import-result-section {
+    margin-top: 0.75rem;
+  }
+
+  .import-result-list {
+    margin: 0.35rem 0 0;
+    padding-left: 1.25rem;
+  }
+
   // TODO: use a mixin, specify actor sheet, echo in _item-sheet.scss
   /* Default text and background color for sheets */
   .lancer.sheet .window-content {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "compatibility": {
     "minimum": 13,
     "verified": 14,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sprint C (v2.14.0) delivers the import & equip UX pass:

- **#63 — Pilot Cloud import wizard:** Cloud tab uses a numbered step layout (Login → Select → Download/JSON), shows COMP/CON login status, links to the pilot-import tour, and unsynced pilots (`last_cloud_update === "never"`) open on the Cloud tab by default.
- **#64 — Empty slot affordances:** Empty ref slots show drag/click hints; clicking opens a filtered compendium picker; invalid drops explain accepted item types.
- **#65 — Unified import result dialog:** Single DialogV2 (`import-result.hbs`) for COMP/CON v2/v3 and JSON success, partial, and failure — replacing fragmented toasts.

Closes #63, #64, #65. Part of release epic #46.

## Test plan

- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build` passes
- [ ] Open an unsynced pilot → Cloud tab is active by default
- [ ] Cloud wizard: login button opens COMP/CON login; tour link starts `pilot-import` tour
- [ ] Cloud/JSON import shows unified result dialog (success / partial / failure)
- [ ] Click empty pilot armor/weapon slot → compendium picker filters by type and equips selection
- [ ] Drop wrong item type on slot → warning lists accepted types
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

