### PR TITLE
v2.15.0 — Sheet IA (Sprint D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.15.0 (2026-06-06)
+
+## Added
+
+- **Dismissible sync banner** on the pilot Tactical tab for never-synced pilots, with a shortcut to the Cloud tab.
+- Mech Stats tab **Combat** and **Systems** collapsible sections with sticky headers.
+- NPC sheet **Stats | Features | Effects** tabs; feature drag-sort behavior preserved.
+
+## Changed
+
+- NPC guided tour selectors updated for the tabbed sheet layout.
+
 # 2.14.0 (2026-06-06)
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -127,9 +127,21 @@
       "system": {
         "label": "LOADOUT",
         "sp-used": "SP USED"
+      },
+      "sections": {
+        "combat": "COMBAT",
+        "systems": "SYSTEMS"
+      },
+      "inventory": {
+        "label": "View Inventory"
       }
     },
     "npc-sheet": {
+      "tabs": {
+        "stats": "<NPC//STATS>",
+        "features": "<NPC//FEATURES>",
+        "effects": "<EFFECTS//ACTIVE>"
+      },
       "header": {
         "class": "CLASS",
         "templates": "TEMPLATES"
@@ -179,6 +191,11 @@
       },
       "json-import": {
         "label": "IMPORT"
+      },
+      "sync-banner": {
+        "message": "This pilot has not been imported from COMP/CON yet. Open the Sync tab to download or upload a JSON export.",
+        "action": "Open Sync tab",
+        "dismiss": "Dismiss"
       },
       "cloud-wizard": {
         "steps-label": "COMP/CON import steps",

--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -3,107 +3,159 @@
   <div>
     <header class="sheet-header lancer-mech-sheet-header card clipped-bot {{#if (not is_active)}}inactive-mech{{/if}}">
       <h1 class="name">
-        <input class="lancer-input" name="name" type="text" value="{{actor.name}}" placeholder="{{localize "
-          lancer.placeholder.name"}}" />
+        <input
+          class="lancer-input"
+          name="name"
+          type="text"
+          value="{{actor.name}}"
+          placeholder='{{localize "lancer.placeholder.name"}}'
+        />
       </h1>
       {{{ref-portrait-img actor.img "img" actor}}}
       <div class="header-details monospace">
         {{#if (not is_active)}}
           {{localize "lancer.mech-sheet.inactive-warning"}}
         {{else}}
-          <span>{{localize "TYPES.Actor.pilot"}} :: {{pilot.system.callsign}}</br>
-          {{localize "TYPES.Item.frame"}} :: {{itemTypes.frame.0.system.manufacturer}} {{itemTypes.frame.0.name}}</span>
+          <span>{{localize "TYPES.Actor.pilot"}} :: {{pilot.system.callsign}}<br />
+            {{localize "TYPES.Item.frame"}} :: {{itemTypes.frame.0.system.manufacturer}}
+            {{itemTypes.frame.0.name}}</span>
         {{/if}}
       </div>
     </header>
 
     {{!-- Sheet Tab Navigation --}}
     <nav class="tabs lancer-tabs" data-group="primary">
-      <a class="item lancer-tab medium {{tabs.primary.stats.cssClass}}" data-action="tab" data-group="primary" data-tab="stats">{{localize "lancer.mech-sheet.tabs.stats"}}</a>
-      <a class="item lancer-tab medium {{tabs.primary.loadout.cssClass}}" data-action="tab" data-group="primary" data-tab="loadout">{{localize "lancer.mech-sheet.tabs.loadout"}}</a>
-      <a class="item lancer-tab medium {{tabs.primary.talents.cssClass}}" data-action="tab" data-group="primary" data-tab="talents">{{localize "lancer.mech-sheet.tabs.talents"}}</a>
-      <a class="item lancer-tab medium {{tabs.primary.effects.cssClass}}" data-action="tab" data-group="primary" data-tab="effects">{{localize "lancer.common-sheet.tabs.effects"}}</a>
+      <a
+        class="item lancer-tab medium {{tabs.primary.stats.cssClass}}"
+        data-action="tab"
+        data-group="primary"
+        data-tab="stats"
+      >{{localize "lancer.mech-sheet.tabs.stats"}}</a>
+      <a
+        class="item lancer-tab medium {{tabs.primary.loadout.cssClass}}"
+        data-action="tab"
+        data-group="primary"
+        data-tab="loadout"
+      >{{localize "lancer.mech-sheet.tabs.loadout"}}</a>
+      <a
+        class="item lancer-tab medium {{tabs.primary.talents.cssClass}}"
+        data-action="tab"
+        data-group="primary"
+        data-tab="talents"
+      >{{localize "lancer.mech-sheet.tabs.talents"}}</a>
+      <a
+        class="item lancer-tab medium {{tabs.primary.effects.cssClass}}"
+        data-action="tab"
+        data-group="primary"
+        data-tab="effects"
+      >{{localize "lancer.common-sheet.tabs.effects"}}</a>
     </nav>
   </div>
 
   {{!-- Sheet Body --}}
   <section class="sheet-body scroll-body">
     <div class="tab stats {{tabs.primary.stats.cssClass}}" data-group="primary" data-tab="stats">
-      <div class="stat-grid lancer-mech-stat-grid">
-        {{{stat-edit-max-card "HP" "mdi mdi-heart-outline" "system.hp.value" "system.hp.max"}}}
-        {{{stat-edit-max-card "HEAT" "cci cci-heat" "system.heat.value" "system.heat.max"}}}
-        {{{stat-view-card "EVASION" "cci cci-evasion" "system.evasion"}}}
-        {{{stat-view-card "ARMOR" "mdi mdi-shield-outline" "system.armor"}}}
-        {{{stat-edit-max-card "STRUCTURE" "cci cci-structure" "system.structure.value" "system.structure.max"}}}
-        {{{stat-edit-max-card "STRESS" "cci cci-reactor" "system.stress.value" "system.stress.max"}}}
-        {{{stat-view-card "E-DEF" "cci cci-edef" "system.edef"}}}
-        {{{stat-view-card "SPEED" "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed"}}}
-        {{{stat-view-card "SAVE" "cci cci-save" "system.save"}}}
-        {{{stat-view-card "SENSORS" "cci cci-sensor" "system.sensor_range"}}}
-        {{{tech-flow-card "TECH ATK" "cci cci-tech-full" "system.tech_attack"}}}
-        {{{stat-edit-rollable-card "BURN" "cci cci-burn" "system.burn"}}}
-        {{{stat-edit-card "O.SHIELD" "mdi mdi-shield-star-outline" "system.overshield.value"}}}
-        {{{stat-edit-max-card "REPAIRS" "cci cci-repair" "system.repairs.value" "system.repairs.max"}}}
-        <div class="size-card">
-          {{#if (eq system.size 0.5)}}
-          <i class="cci cci-size-half size-icon theme--main"></i>
-          {{else}}
-          <i class="cci cci-size-{{system.size}} size-icon theme--main"></i>
-          {{/if}}
+      <section class="mech-stat-section" data-mech-section="combat">
+        <div class="lancer-header lancer-primary sheet-section-header sticky">
+          <i
+            class="mdi mdi-unfold-less-horizontal collapse-trigger collapse-icon"
+            data-collapse-id="mech-stats-combat"
+          ></i>
+          <span class="major">{{localize "lancer.mech-sheet.sections.combat"}}</span>
         </div>
-        {{{overcharge-button actor "system.overcharge"}}}
-        <div class="flexcol card clipped">
-          <div class="lancer-header lancer-primary">
-            <span class="major">
-              {{localize "lancer.mech-sheet.core.label"}}
-            </span>
-          </div>
-          <div class="flexrow stat-container core-power-stat-container">
-            <input name="system.core_energy" class="core-power-toggle" type="checkbox" data-dtype="Boolean"
-              {{checked system.core_energy}} />
-          </div>
+        <div class="collapse lancer-mech-stat-grid mech-combat-stat-grid" data-collapse-id="mech-stats-combat">
+          {{{stat-edit-max-card "HP" "mdi mdi-heart-outline" "system.hp.value" "system.hp.max"}}}
+          {{{stat-edit-max-card "HEAT" "cci cci-heat" "system.heat.value" "system.heat.max"}}}
+          {{{stat-view-card "EVASION" "cci cci-evasion" "system.evasion"}}}
+          {{{stat-view-card "ARMOR" "mdi mdi-shield-outline" "system.armor"}}}
+          {{{stat-edit-max-card "STRUCTURE" "cci cci-structure" "system.structure.value" "system.structure.max"}}}
+          {{{stat-edit-max-card "STRESS" "cci cci-reactor" "system.stress.value" "system.stress.max"}}}
+          {{{stat-view-card "E-DEF" "cci cci-edef" "system.edef"}}}
+          {{{stat-view-card "SPEED" "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed"}}}
+          {{{stat-view-card "SAVE" "cci cci-save" "system.save"}}}
+          {{{stat-view-card "SENSORS" "cci cci-sensor" "system.sensor_range"}}}
+          {{{tech-flow-card "TECH ATK" "cci cci-tech-full" "system.tech_attack"}}}
+          {{{stat-edit-rollable-card "BURN" "cci cci-burn" "system.burn"}}}
+          {{{stat-edit-card "O.SHIELD" "mdi mdi-shield-star-outline" "system.overshield.value"}}}
+          {{{stat-edit-max-card "REPAIRS" "cci cci-repair" "system.repairs.value" "system.repairs.max"}}}
         </div>
-        {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit"}}}
-        {{{pilot-slot "system.pilot" value=pilot}}}
+      </section>
 
-        <div class="wraprow double hase">
-          {{{stat-rollable-card "HUL" "" "system.hull"}}}
-          {{{stat-rollable-card "AGI" "" "system.agi"}}}
-          {{{stat-rollable-card "SYS" "" "system.sys"}}}
-          {{{stat-rollable-card "ENG" "" "system.eng"}}}
+      <section class="mech-stat-section" data-mech-section="systems">
+        <div class="lancer-header lancer-primary sheet-section-header sticky">
+          <i
+            class="mdi mdi-unfold-less-horizontal collapse-trigger collapse-icon"
+            data-collapse-id="mech-stats-systems"
+          ></i>
+          <span class="major">{{localize "lancer.mech-sheet.sections.systems"}}</span>
         </div>
-        <div class="inventory" style="flex: inherit;margin:3px 10px">
-          <button class="lancer-button" type="button" style="padding: 8px 16px"> View Inventory </button>
-        </div>
-      </div>
-      <div class="pilot-frame-wrapper flexrow">
-        <div class="card">
-          <span class="lancer-header lancer-primary submajor clipped-top">
-            {{localize "lancer.mech-sheet.macros.label" }}
-          </span>
-          <div class="lancer-flow-button-grid">
-            {{{flow-button "STABILIZE" "Stabilize" }}}
-            {{{flow-button "FULL REPAIR" "FullRepair" }}}
-            <div style="margin:0px 8px;border-left: 2px solid #a2a2a2;"></div>
-            {{{flow-button "STRUCTURE" "Structure" }}}
-            {{{flow-button "OVERHEAT" "Overheat" }}}
+        <div class="collapse mech-systems-panel" data-collapse-id="mech-stats-systems">
+          <div class="mech-systems-utilities flexrow wraprow">
+            <div class="size-card card clipped">
+              {{#if (eq system.size 0.5)}}
+                <i class="cci cci-size-half size-icon theme--main"></i>
+              {{else}}
+                <i class="cci cci-size-{{system.size}} size-icon theme--main"></i>
+              {{/if}}
+            </div>
+            {{{overcharge-button actor "system.overcharge"}}}
+            <div class="flexcol card clipped">
+              <div class="lancer-header lancer-primary">
+                <span class="major">{{localize "lancer.mech-sheet.core.label"}}</span>
+              </div>
+              <div class="flexrow stat-container core-power-stat-container">
+                <input
+                  name="system.core_energy"
+                  class="core-power-toggle"
+                  type="checkbox"
+                  data-dtype="Boolean"
+                  {{checked system.core_energy}}
+                />
+              </div>
+            </div>
+            {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit"}}}
+            {{{pilot-slot "system.pilot" value=pilot}}}
+            <div class="wraprow double hase card clipped">
+              {{{stat-rollable-card "HUL" "" "system.hull"}}}
+              {{{stat-rollable-card "AGI" "" "system.agi"}}}
+              {{{stat-rollable-card "SYS" "" "system.sys"}}}
+              {{{stat-rollable-card "ENG" "" "system.eng"}}}
+            </div>
+            <div class="inventory card clipped">
+              <button class="lancer-button" type="button">{{localize "lancer.mech-sheet.inventory.label"}}</button>
+            </div>
+          </div>
+
+          <div class="pilot-frame-wrapper flexrow">
+            <div class="card">
+              <span class="lancer-header lancer-primary submajor clipped-top">
+                {{localize "lancer.mech-sheet.macros.label"}}
+              </span>
+              <div class="lancer-flow-button-grid">
+                {{{flow-button "STABILIZE" "Stabilize"}}}
+                {{{flow-button "FULL REPAIR" "FullRepair"}}}
+                <div class="flow-button-sep"></div>
+                {{{flow-button "STRUCTURE" "Structure"}}}
+                {{{flow-button "OVERHEAT" "Overheat"}}}
+              </div>
+            </div>
+            {{#if (is-combatant actor)}}
+              <div class="card mech-combat-actions">
+                <span class="lancer-header lancer-primary submajor clipped-top">
+                  {{localize "lancer.mech-sheet.actions.label"}}
+                </span>
+                <div class="lancer-flow-button-grid">
+                  {{{action-button "Protocol" "system.action_tracker.protocol" "protocol"}}}
+                  {{{action-button "Movement" "system.action_tracker.move" "move"}}}
+                  {{{action-button "Full Action" "system.action_tracker.full" "full"}}}
+                  {{{action-button "Quick Action" "system.action_tracker.quick" "quick"}}}
+                  {{{action-button "Reaction" "system.action_tracker.reaction" "reaction"}}}
+                </div>
+              </div>
+            {{/if}}
           </div>
         </div>
-        {{#if (is-combatant actor)}}
-        <div style="min-width:560px" class="card">
-          <span class="lancer-header lancer-primary submajor clipped-top">
-            {{localize "lancer.mech-sheet.actions.label"}}
-          </span>
-          <div class="lancer-flow-button-grid">
-            {{{action-button "Protocol" "system.action_tracker.protocol" "protocol"}}}
-            {{{action-button "Movement" "system.action_tracker.move" "move"}}}
-            {{{action-button "Full Action" "system.action_tracker.full" "full"}}}
-            {{{action-button "Quick Action" "system.action_tracker.quick" "quick"}}}
-            {{{action-button "Reaction" "system.action_tracker.reaction" "reaction"}}}
-          </div>
-        </div>
-        {{/if}}
-      </div>
+      </section>
     </div>
 
     <div class="tab loadout {{tabs.primary.loadout.cssClass}}" data-group="primary" data-tab="loadout">
@@ -111,19 +163,20 @@
       <div class="card clipped">
         <span class="lancer-header lancer-primary submajor">ATTACK UTILITIES</span>
         <div class="lancer-flow-button-grid">
-          {{{flow-button "MELEE/RANGED" "BasicAttack" }}}
-          {{{flow-button "DAMAGE" "Damage" }}}
-          {{{flow-button "TECH" "TechAttack" }}}
+          {{{flow-button "MELEE/RANGED" "BasicAttack"}}}
+          {{{flow-button "DAMAGE" "Damage"}}}
+          {{{flow-button "TECH" "TechAttack"}}}
         </div>
       </div>
       <div class="card">
         <div class="lancer-header lancer-primary major">
           <span>
-          {{{localize "lancer.mech-sheet.system.label"}}}
+            {{{localize "lancer.mech-sheet.system.label"}}}
           </span>
           <span style="flex-grow: 0">
             <i class="cci cci-system-point i--4"></i>
-            {{system.loadout.sp.value}} / {{system.loadout.sp.max}} {{localize "lancer.mech-sheet.system.sp-used"}}
+            {{system.loadout.sp.value}} / {{system.loadout.sp.max}}
+            {{localize "lancer.mech-sheet.system.sp-used"}}
           </span>
         </div>
         {{{mech-loadout}}}
@@ -133,17 +186,19 @@
     <div class="tab talents {{tabs.primary.talents.cssClass}}" data-group="primary" data-tab="talents">
       {{!-- Talents --}}
       {{#if system.pilot.value}}
-      <div class="card clipped">
-        <h2 class="lancer-header lancer-primary major clipped">{{localize "lancer.pilot-sheet.abilities.talents"}}</h2>
-        {{#each system.pilot.value.itemTypes.talent as |talent index|}}
-          {{{item-preview (concat "system.pilot.value.itemTypes.talent." index) null }}}
-        {{/each}}
-      </div>
+        <div class="card clipped">
+          <h2 class="lancer-header lancer-primary major clipped">
+            {{localize "lancer.pilot-sheet.abilities.talents"}}
+          </h2>
+          {{#each system.pilot.value.itemTypes.talent as |talent index|}}
+            {{{item-preview (concat "system.pilot.value.itemTypes.talent." index) null}}}
+          {{/each}}
+        </div>
       {{/if}}
     </div>
 
     <div class="tab effects {{tabs.primary.effects.cssClass}}" data-group="primary" data-tab="effects">
-      {{{effect-categories-view actor effect_categories}}} 
+      {{{effect-categories-view actor effect_categories}}}
     </div>
   </section>
 </section>

--- a/public/templates/actor/npc.hbs
+++ b/public/templates/actor/npc.hbs
@@ -29,94 +29,114 @@
     </h1>
   </header>
 
+  <nav class="tabs lancer-tabs" data-group="primary">
+    <a
+      class="item lancer-tab medium {{tabs.primary.stats.cssClass}}"
+      data-action="tab"
+      data-group="primary"
+      data-tab="stats"
+    >{{localize "lancer.npc-sheet.tabs.stats"}}</a>
+    <a
+      class="item lancer-tab medium {{tabs.primary.features.cssClass}}"
+      data-action="tab"
+      data-group="primary"
+      data-tab="features"
+    >{{localize "lancer.npc-sheet.tabs.features"}}</a>
+    <a
+      class="item lancer-tab medium {{tabs.primary.effects.cssClass}}"
+      data-action="tab"
+      data-group="primary"
+      data-tab="effects"
+    >{{localize "lancer.npc-sheet.tabs.effects"}}</a>
+  </nav>
+
   {{!-- Sheet Body --}}
   <section class="sheet-body scroll-body">
-    <div class="flexcol">
-      {{!-- Stats --}}
-      <div class="wraprow quintuple">
-        {{{clicker-stat-card "TIER" (concat "cci cci-npc-tier-" system.tier) "system.tier" true}}}
-        {{{stat-rollable-card "HULL" "" "system.hull"}}}
-        {{{stat-rollable-card "AGI" "" "system.agi"}}}
-        {{{stat-rollable-card "SYS" "" "system.sys"}}}
-        {{{stat-rollable-card "ENG" "" "system.eng"}}}
-        {{{stat-edit-max-card "HP" "mdi mdi-heart-outline" "system.hp.value" "system.hp.max"}}}
-        {{{stat-edit-max-card "HEAT" "cci cci-heat" "system.heat.value" "system.heat.max"}}}
-        {{{stat-view-card "ARMOR" "mdi mdi-shield-outline" "system.armor"}}}
-        {{{stat-edit-card "O.SHIELD" "mdi mdi-shield-star-outline" "system.overshield.value"}}}
-        {{{stat-edit-rollable-card "BURN" "cci cci-burn" "system.burn"}}}
-        {{{stat-view-card "SPEED" "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed"}}}
-        {{{stat-view-card "EVASION" "cci cci-evasion" "system.evasion"}}}
-        {{{stat-view-card "E-DEF" "cci cci-edef" "system.edef"}}}
-        {{{stat-view-card "SENSORS" "cci cci-sensor" "system.sensor_range"}}}
-        {{{stat-view-card "SAVE" "cci cci-save" "system.save"}}}
-        {{#if (eq system.size 0.5)}}
-          {{{stat-view-card "SIZE" (concat "cci cci-size-half") "system.size"}}}
-        {{else}}
-          {{{stat-view-card "SIZE" (concat "cci cci-size-" system.size) "system.size"}}}
-        {{/if}}
-        {{{stat-view-card "ACTIV." "cci cci-activate" "system.activations"}}}
-        {{{stat-edit-max-card "STRUCT" "cci cci-structure" "system.structure.value" "system.structure.max"}}}
-        {{{stat-edit-max-card "STRESS" "cci cci-reactor" "system.stress.value" "system.stress.max"}}}
-        {{{tech-flow-card "TECH ATK" "cci cci-tech-full" "system.sys"}}}
-      </div>
+    <div class="tab stats {{tabs.primary.stats.cssClass}}" data-group="primary" data-tab="stats">
+      <div class="flexcol">
+        <div class="wraprow quintuple">
+          {{{clicker-stat-card "TIER" (concat "cci cci-npc-tier-" system.tier) "system.tier" true}}}
+          {{{stat-rollable-card "HULL" "" "system.hull"}}}
+          {{{stat-rollable-card "AGI" "" "system.agi"}}}
+          {{{stat-rollable-card "SYS" "" "system.sys"}}}
+          {{{stat-rollable-card "ENG" "" "system.eng"}}}
+          {{{stat-edit-max-card "HP" "mdi mdi-heart-outline" "system.hp.value" "system.hp.max"}}}
+          {{{stat-edit-max-card "HEAT" "cci cci-heat" "system.heat.value" "system.heat.max"}}}
+          {{{stat-view-card "ARMOR" "mdi mdi-shield-outline" "system.armor"}}}
+          {{{stat-edit-card "O.SHIELD" "mdi mdi-shield-star-outline" "system.overshield.value"}}}
+          {{{stat-edit-rollable-card "BURN" "cci cci-burn" "system.burn"}}}
+          {{{stat-view-card "SPEED" "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed"}}}
+          {{{stat-view-card "EVASION" "cci cci-evasion" "system.evasion"}}}
+          {{{stat-view-card "E-DEF" "cci cci-edef" "system.edef"}}}
+          {{{stat-view-card "SENSORS" "cci cci-sensor" "system.sensor_range"}}}
+          {{{stat-view-card "SAVE" "cci cci-save" "system.save"}}}
+          {{#if (eq system.size 0.5)}}
+            {{{stat-view-card "SIZE" (concat "cci cci-size-half") "system.size"}}}
+          {{else}}
+            {{{stat-view-card "SIZE" (concat "cci cci-size-" system.size) "system.size"}}}
+          {{/if}}
+          {{{stat-view-card "ACTIV." "cci cci-activate" "system.activations"}}}
+          {{{stat-edit-max-card "STRUCT" "cci cci-structure" "system.structure.value" "system.structure.max"}}}
+          {{{stat-edit-max-card "STRESS" "cci cci-reactor" "system.stress.value" "system.stress.max"}}}
+          {{{tech-flow-card "TECH ATK" "cci cci-tech-full" "system.sys"}}}
+        </div>
 
-      {{!-- Class and templates --}}
-      <div class="card clipped flexrow">
-        <div style="padding-right: 5px">
-          <div class="lancer-header lancer-primary submajor" style="height: 30px">
-            {{localize "lancer.npc-sheet.class.label"}}
+        <div class="card clipped flexrow" data-npc-section="class-templates">
+          <div class="npc-class-column">
+            <div class="lancer-header lancer-primary submajor">
+              {{localize "lancer.npc-sheet.class.label"}}
+            </div>
+            <div class="flexcol">
+              {{#if system.class}}
+                {{{ref-npc-class system.class "system.class"}}}
+              {{else}}
+                {{localize "lancer.npc-sheet.class.none"}}
+              {{/if}}
+            </div>
           </div>
-          <div class="flexcol">
-            {{#if system.class}}
-              {{{ref-npc-class system.class "system.class"}}}
-            {{else}}
-              {{localize "lancer.npc-sheet.class.none"}}
-            {{/if}}
+
+          <div class="flexcol npc-template-column">
+            <span class="lancer-header lancer-primary submajor clipped-top">{{
+                localize "lancer.npc-sheet.templates.label"
+              }}</span>
+            {{#each itemTypes.npc_template as |template index|}}
+              {{{ref-npc-template template (concat "itemTypes.npc_template." index)}}}
+            {{/each}}
           </div>
         </div>
 
-        <div class="flexcol" style="padding-left: 5px">
-          <span class="lancer-header lancer-primary submajor clipped-top">{{
-              localize "lancer.npc-sheet.templates.label"
-            }}</span>
-          {{#each itemTypes.npc_template as |template index|}}
-            {{{ref-npc-template template (concat "itemTypes.npc_template." index)}}}
-          {{/each}}
+        <div class="card clipped">
+          <span class="lancer-header lancer-primary submajor">ATTACK UTILITIES</span>
+          <div class="lancer-flow-button-grid">
+            {{{flow-button "MELEE/RANGED" "BasicAttack"}}}
+            {{{flow-button "DAMAGE" "Damage"}}}
+            {{{flow-button "TECH" "TechAttack"}}}
+          </div>
         </div>
-      </div>
 
-      {{!-- Basic attack buttons --}}
-      <div class="card clipped">
-        <span class="lancer-header lancer-primary submajor">ATTACK UTILITIES</span>
-        <div class="lancer-flow-button-grid">
-          {{{flow-button "MELEE/RANGED" "BasicAttack"}}}
-          {{{flow-button "DAMAGE" "Damage"}}}
-          {{{flow-button "TECH" "TechAttack"}}}
-        </div>
+        {{{textarea-card "NOTES" "system.notes"}}}
       </div>
+    </div>
 
-      {{!-- Features --}}
-      <div class="card clipped">
+    <div class="tab features {{tabs.primary.features.cssClass}}" data-group="primary" data-tab="features">
+      <div class="card clipped" data-npc-section="features">
         <div class="lancer-header lancer-primary submajor">
-          <div style="width: 120px"></div>
+          <div class="npc-features-spacer"></div>
           <span>{{localize "lancer.npc-sheet.features.label"}}</span>
-          <div class="lancer-button charge-macro" style="margin-top: 2px; margin-bottom: 2px; font-size: 0.75rem">
+          <div class="lancer-button charge-macro npc-recharge-button">
             <i class="mdi mdi-refresh i--3"></i> Recharge
           </div>
         </div>
-        <div class="wraprow double">
+        <div class="wraprow double npc-features-list">
           {{#each itemTypes.npc_feature as |feature index|}}
-            {{{npc-feat-preview (concat "itemTypes.npc_feature." index)
-          tier=../system.tier}}}
+            {{{npc-feat-preview (concat "itemTypes.npc_feature." index) tier=../system.tier}}}
           {{/each}}
         </div>
       </div>
+    </div>
 
-      {{!-- Notes --}}
-      {{{textarea-card "NOTES" "system.notes"}}}
-
-      {{!-- Active Effects --}}
-      <div class="card clipped">
+    <div class="tab effects {{tabs.primary.effects.cssClass}}" data-group="primary" data-tab="effects">
+      <div class="card clipped" data-npc-section="effects">
         <span class="lancer-header lancer-primary submajor">{{localize "lancer.npc-sheet.effects.label"}}</span>
         {{{effect-categories-view actor effect_categories}}}
       </div>

--- a/public/templates/actor/pilot.hbs
+++ b/public/templates/actor/pilot.hbs
@@ -381,6 +381,27 @@
 
     {{!-- Pilot Tactical Tab --}}
     <div class="tab tactical flexcol {{tabs.primary.tactical.cssClass}}" data-group="primary" data-tab="tactical">
+      {{#if showSyncBanner}}
+        <div class="card clipped pilot-sync-banner" data-pilot-section="sync-banner">
+          <div class="flexrow" style="align-items: center; gap: 0.5rem">
+            <i class="mdi mdi-cloud-sync-outline i--4"></i>
+            <p class="minor grow desc-text">{{localize "lancer.pilot-sheet.sync-banner.message"}}</p>
+            <button type="button" class="lancer-button" data-action="goCloudTab">
+              {{localize "lancer.pilot-sheet.sync-banner.action"}}
+            </button>
+            <button
+              type="button"
+              class="lancer-button pilot-sync-banner-dismiss"
+              data-action="dismissSyncBanner"
+              data-tooltip='{{localize "lancer.pilot-sheet.sync-banner.dismiss"}}'
+              aria-label='{{localize "lancer.pilot-sheet.sync-banner.dismiss"}}'
+            >
+              <i class="fas fa-times"></i>
+            </button>
+          </div>
+        </div>
+      {{/if}}
+
       {{!-- Counters --}}
       <div class="flexrow">
         {{{pilot-counters actor}}}

--- a/public/tours/npc.json
+++ b/public/tours/npc.json
@@ -21,7 +21,7 @@
     },
     {
       "id": "addClass",
-      "selector": ".tour-npc .window-content .sheet-body>div.flexcol>div.card.clipped.flexrow>div:nth-child(1)",
+      "selector": ".tour-npc [data-npc-section='class-templates'] .npc-class-column",
       "title": "lancer.tour.npc.addClass.title",
       "content": "lancer.tour.npc.addClass.content",
       "sidebarTab": "compendium"
@@ -40,7 +40,7 @@
     },
     {
       "id": "npcTemplates",
-      "selector": ".tour-npc .window-content .sheet-body>div.flexcol>div.card.clipped.flexrow>div:nth-child(2)",
+      "selector": ".tour-npc [data-npc-section='class-templates'] .npc-template-column",
       "title": "lancer.tour.npc.npcTemplates.title",
       "content": "lancer.tour.npc.npcTemplates.content"
     }

--- a/src/module/actor/npc-sheet.ts
+++ b/src/module/actor/npc-sheet.ts
@@ -17,6 +17,17 @@ export class LancerNPCSheet extends LancerActorSheet<EntryType.NPC> {
     body: { template: "systems/lancer/templates/actor/npc.hbs" },
   };
 
+  static override TABS = {
+    primary: {
+      initial: "stats",
+      tabs: [
+        { id: "stats", group: "primary" },
+        { id: "features", group: "primary" },
+        { id: "effects", group: "primary" },
+      ],
+    },
+  };
+
   override activateListeners(html: HTMLElement): void {
     super.activateListeners(html);
 

--- a/src/module/actor/pilot-sheet.ts
+++ b/src/module/actor/pilot-sheet.ts
@@ -196,6 +196,25 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
       });
 
     $el
+      .find('[data-action="goCloudTab"]')
+      .off("click.lancerGoCloudTab")
+      .on("click.lancerGoCloudTab", ev => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        this.changeTab("cloud", "primary");
+      });
+
+    $el
+      .find('[data-action="dismissSyncBanner"]')
+      .off("click.lancerDismissSyncBanner")
+      .on("click.lancerDismissSyncBanner", async ev => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        await pilot.setFlag("lancer", "dismissSyncBanner", true);
+        this.render();
+      });
+
+    $el
       .find('[data-action="startPilotImportTour"]')
       .off("click.lancerPilotImportTour")
       .on("click.lancerPilotImportTour", async ev => {
@@ -293,6 +312,8 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
 
     data.compConLoggedIn = await isCompconLoggedIn();
     data.compConPilotCount = pilotCache().length;
+    data.showSyncBanner =
+      pilot.system.last_cloud_update === "never" && !(pilot.getFlag("lancer", "dismissSyncBanner") as boolean);
     data.compConPilotList = pilotCache()
       .sort((p1, p2) => {
         if (p1.callsign < p2.callsign) return -1;

--- a/src/module/interfaces.ts
+++ b/src/module/interfaces.ts
@@ -53,6 +53,7 @@ export interface LancerActorSheetData<T extends LancerActorType> {
   compConPilotList?: Record<string, string>;
   compConLoggedIn?: boolean;
   compConPilotCount?: number;
+  showSyncBanner?: boolean;
   cleanedOwnerID?: string;
   vaultID?: string;
   rawID?: string;

--- a/src/module/tours/lancer-tour.ts
+++ b/src/module/tours/lancer-tour.ts
@@ -172,6 +172,7 @@ export class LancerNPCTour extends LancerTour {
     }
     const npcSheet = this.npc.sheet;
     await npcSheet?.["_render"](true);
+    npcSheet?.["changeTab"]?.("stats", "primary", { force: true });
     const el = npcSheet instanceof foundry.applications.api.ApplicationV2 ? npcSheet.element : npcSheet?.element[0];
     el?.classList.add("tour-npc");
     if (["baseFeatures", "optionalFeatures"].includes(this.currentStep?.id!)) {

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -184,6 +184,82 @@
     }
   }
 
+  .pilot-sync-banner {
+    margin-bottom: 0.5rem;
+  }
+
+  .pilot-sync-banner-dismiss {
+    flex: 0 0 auto;
+    padding: 0.35rem 0.55rem;
+  }
+
+  .mech-stat-section {
+    margin-bottom: 0.75rem;
+  }
+
+  .sheet-section-header.sticky {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    margin-bottom: 0.35rem;
+  }
+
+  .mech-combat-stat-grid {
+    grid-template: repeat(3, minmax(3.25em, auto)) / repeat(5, 1fr);
+  }
+
+  .mech-systems-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .mech-systems-utilities {
+    align-items: stretch;
+    gap: 0.5rem;
+
+    .size-card,
+    .inventory {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 6rem;
+      padding: 0.35rem;
+    }
+
+    .hase {
+      flex: 1 1 12rem;
+      margin: 0;
+    }
+  }
+
+  .flow-button-sep {
+    margin: 0 8px;
+    border-left: 2px solid #a2a2a2;
+  }
+
+  .mech-combat-actions {
+    min-width: min(560px, 100%);
+    flex: 1 1 auto;
+  }
+
+  .npc-class-column,
+  .npc-template-column {
+    flex: 1 1 0;
+    min-width: 0;
+    padding: 0 5px;
+  }
+
+  .npc-features-spacer {
+    width: 120px;
+  }
+
+  .npc-recharge-button {
+    margin-top: 2px;
+    margin-bottom: 2px;
+    font-size: 0.75rem;
+  }
+
   /* Mech stats: class on the grid so layout survives App V2 host/class quirks */
   .lancer-mech-stat-grid {
     display: grid;

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "compatibility": {
     "minimum": 13,
     "verified": 14,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sprint D (v2.15.0) improves sheet information architecture across pilot, mech, and NPC actors:

- **#66 — Pilot sheet IA:** Dismissible Tactical-tab banner for never-synced pilots with a one-click jump to the Cloud tab (Cloud default for unsynced pilots landed in #63).
- **#67 — Mech stats sections:** Stats tab split into collapsible **Combat** and **Systems** groups with sticky section headers.
- **#68 — NPC sheet tabs:** **Stats | Features | Effects** tabs; NPC tour selectors updated; feature drag-sort path unchanged.

Closes #66, #67, #68. Part of release epic #47.

## Test plan

- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build` passes
- [x] `npm run test:e2e` — 7/7 passed locally
- [ ] Never-synced pilot on Tactical tab shows dismissible sync banner → Open Sync tab / dismiss
- [ ] Mech sheet Stats: Combat and Systems sections collapse independently; headers stay visible while scrolling
- [ ] NPC sheet: three tabs render; drag-sort NPC features on Features tab; NPC tour steps still target class/templates
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

