### PR TITLE
v2.16.0 — Accessibility & dialogs (Sprint E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.16.0 (2026-06-06)
+
+## Added
+
+- Collapse controls use `aria-expanded` and support **Enter/Space** keyboard activation.
+- Action tracker **text labels** optional via client setting; all action icons have `aria-label`s.
+- Combat HUDs (`aria-modal`) with **focus trap** while open; Escape still cancels.
+- `lancer.hud` i18n keys for Acc/Diff, Damage, and Structure/Stress HUD strings.
+
+## Changed
+
+- **Stabilize** and **Full Repair** flows use DialogV2 instead of legacy `Dialog`.
+- Sheet icon-only controls (context menu, chat flow, roll buttons) include localized `aria-label`s.
+
 # 2.15.0 (2026-06-06)
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -502,7 +502,114 @@
       "allowPlayers": "Allow Players",
       "allowPlayers-desc": "Allows players to modify their own actions.",
       "printMessages": "Print Messages",
-      "printMessages-desc": "Prints chat messages for start and end of a token's turn."
+      "printMessages-desc": "Prints chat messages for start and end of a token's turn.",
+      "showTextLabels": "Show text labels",
+      "showTextLabels-desc": "Show text labels beside action icons on the floating action tracker.",
+      "toolbar": "Combat actions",
+      "drag": "Drag action tracker",
+      "reset": "Reset actions",
+      "actions": {
+        "protocol": "Protocol",
+        "move": "Movement",
+        "full": "Full Action",
+        "quick": "Quick Action",
+        "reaction": "Reaction",
+        "free": "Free Action"
+      }
+    },
+    "collapse": {
+      "toggle": "Toggle section"
+    },
+    "flow": {
+      "common": {
+        "submit": "Submit",
+        "cancel": "Cancel",
+        "yes": "Yes",
+        "no": "No"
+      },
+      "stabilize": {
+        "title": "Stabilize — {name}"
+      },
+      "fullRepair": {
+        "title": "Full Repair — {name}",
+        "prompt": "Fully repair the {type} \"{name}\"?"
+      }
+    },
+    "sheet-controls": {
+      "item-menu": "Item options",
+      "delete-item": "Delete item",
+      "add-entry": "Add entry",
+      "post-chat": "Post to chat",
+      "roll-attack": "Roll attack",
+      "roll-stat": "Roll stat"
+    },
+    "hud": {
+      "common": {
+        "roll": "Roll",
+        "cancel": "Cancel",
+        "total": "Total",
+        "accuracy": "Accuracy",
+        "difficulty": "Difficulty",
+        "configuration": "Configuration",
+        "unknown-actor": "UNKNOWN MECH"
+      },
+      "accdiff": {
+        "flat-modifier": "Flat Modifier",
+        "total-vs": "Total vs {name}",
+        "grit": "Grit",
+        "weapon-base": "Weapon Base",
+        "tech-attack": "Tech Attack",
+        "tech-item-base": "Tech Item Base",
+        "tier": "Tier",
+        "accurate": "Accurate (+1)",
+        "seeking": "Seeking (*)",
+        "inaccurate": "Inaccurate (-1)",
+        "impaired": "Impaired (-1)",
+        "thrown": "Thrown (*)",
+        "engaged": "Engaged (-1)",
+        "prone": "Prone (+1)",
+        "stunned": "Stunned (EVA=5)",
+        "lock-on": "Lock On (+1)",
+        "add-global-accuracy": "Add global accuracy",
+        "global-accuracy-difficulty": "Global Accuracy/Difficulty Adjustment",
+        "add-global-difficulty": "Add global difficulty",
+        "consume-lock-on": "Consume Lock On (+1)",
+        "stunned-label": "Stunned"
+      },
+      "cover": {
+        "none": "No Cover",
+        "soft": "Soft Cover (-1)",
+        "hard": "Hard Cover (-2)"
+      },
+      "damage": {
+        "base-damage": "Base Damage",
+        "bonus-damage": "Bonus Damage",
+        "add-base-damage": "Add a base damage type",
+        "add-bonus-damage": "Add a bonus damage type",
+        "add-target-bonus-damage": "Add a bonus damage type for only this target",
+        "remove-damage-type": "Remove damage type",
+        "armor-piercing": "Armor Piercing (AP)",
+        "overkill": "Overkill",
+        "cannot-be-reduced": "Cannot be Reduced",
+        "cannot-be-reduced-tip": "For 'cannot be reduced' effects like the Paracausal mod",
+        "half-damage": "Half Damage",
+        "half-damage-tip": "For effects which cause the attacker to deal half damage in addition to resistance, like Heavy Gunner",
+        "reliable": "Reliable",
+        "armor-piercing-tip": "Armor Piercing (AP)",
+        "paracausal-tip": "For 'cannot be reduced' effects like the Paracausal mod"
+      },
+      "structstress": {
+        "damage-taken": "{name} has taken {stat} damage!",
+        "roll-prompt": "Roll {dice}d6 to determine what happens.",
+        "no-roll": "No {stat} remaining. No roll is available.",
+        "structure": "structure",
+        "stress": "stress"
+      },
+      "profile": {
+        "attack-bonus": "Attack bonus",
+        "accuracy": "Accuracy",
+        "difficulty": "Difficulty"
+      }
     },
     "initiative": {
       "sorttracker": "Sort the tracker",

--- a/public/templates/settings/action-tracker-config.hbs
+++ b/public/templates/settings/action-tracker-config.hbs
@@ -2,4 +2,5 @@
   {{formGroup fields.showHotbar value=config.showHotbar localize=true}}
   {{formGroup fields.allowPlayers value=config.allowPlayers localize=true}}
   {{formGroup fields.printMessages value=config.printMessages localize=true}}
+  {{formGroup fields.showTextLabels value=config.showTextLabels localize=true}}
 </section>

--- a/public/templates/window/action_manager.hbs
+++ b/public/templates/window/action_manager.hbs
@@ -2,31 +2,80 @@
   <div class="action-label">
     <div>{{name}}</div>
     {{#if clickable}}
-      <div style="right: 0px; position: absolute"><a id="action-manager-reset" class="mdi mdi-restore"></a></div>
+      <div class="action-manager-reset-wrap">
+        <a
+          id="action-manager-reset"
+          class="mdi mdi-restore"
+          role="button"
+          tabindex="0"
+          aria-label='{{localize "lancer.actionTracker.reset"}}'
+        ></a>
+      </div>
     {{/if}}
   </div>
-  <div class="action-manager-controls" style="display: inline-flex">
-    <i id="action-manager-drag" class="mdi mdi-drag"></i>
-    <div class="action-bar">
-      <a class="action {{#if actions.protocol}}lancer-protocol{{/if}}" data-action="protocol">
-        <i class="cci cci-protocol theme--dark white--text"></i>
+  <div class="action-manager-controls">
+    <i
+      id="action-manager-drag"
+      class="mdi mdi-drag"
+      role="img"
+      aria-label='{{localize "lancer.actionTracker.drag"}}'
+    ></i>
+    <div class="action-bar" role="toolbar" aria-label='{{localize "lancer.actionTracker.toolbar"}}'>
+      <a
+        class="action {{#if actions.protocol}}lancer-protocol{{/if}}"
+        data-action="protocol"
+        role="button"
+        tabindex="0"
+        aria-label='{{localize "lancer.actionTracker.actions.protocol"}}'
+      >
+        <i class="cci cci-protocol theme--dark white--text" aria-hidden="true"></i>
+        {{#if showTextLabels}}<span class="action-text">{{
+              localize "lancer.actionTracker.actions.protocol"
+            }}</span>{{/if}}
       </a>
-      <hr class="v-divide" role="separator" aria-orientation="undefined" />
-      <a class="action {{#if actions.move}}lancer-move{{/if}}" data-action="move">
-        <i class="mdi mdi-arrow-right-bold-hexagon-outline theme--dark white--text"></i>
+      <hr class="v-divide" role="separator" aria-orientation="vertical" />
+      <a
+        class="action {{#if actions.move}}lancer-move{{/if}}"
+        data-action="move"
+        role="button"
+        tabindex="0"
+        aria-label='{{localize "lancer.actionTracker.actions.move"}}'
+      >
+        <i class="mdi mdi-arrow-right-bold-hexagon-outline theme--dark white--text" aria-hidden="true"></i>
+        {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.move"}}</span>{{/if}}
       </a>
-      <a class="action {{#if actions.full}}lancer-full{{/if}}" data-action="full">
-        <i class="mdi mdi-hexagon-slice-6 theme--dark white--text"></i>
+      <a
+        class="action {{#if actions.full}}lancer-full{{/if}}"
+        data-action="full"
+        role="button"
+        tabindex="0"
+        aria-label='{{localize "lancer.actionTracker.actions.full"}}'
+      >
+        <i class="mdi mdi-hexagon-slice-6 theme--dark white--text" aria-hidden="true"></i>
+        {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.full"}}</span>{{/if}}
       </a>
-      <a class="action {{#if actions.quick}}lancer-quick{{/if}}" data-action="quick">
-        <i class="mdi mdi-hexagon-slice-3 theme--dark white--text"></i>
+      <a
+        class="action {{#if actions.quick}}lancer-quick{{/if}}"
+        data-action="quick"
+        role="button"
+        tabindex="0"
+        aria-label='{{localize "lancer.actionTracker.actions.quick"}}'
+      >
+        <i class="mdi mdi-hexagon-slice-3 theme--dark white--text" aria-hidden="true"></i>
+        {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.quick"}}</span>{{/if}}
       </a>
-      <a class="action {{#if actions.reaction}}lancer-reaction{{/if}}" data-action="reaction">
-        <i class="cci cci-reaction theme--dark white--text"></i>
+      <a
+        class="action {{#if actions.reaction}}lancer-reaction{{/if}}"
+        data-action="reaction"
+        role="button"
+        tabindex="0"
+        aria-label='{{localize "lancer.actionTracker.actions.reaction"}}'
+      >
+        <i class="cci cci-reaction theme--dark white--text" aria-hidden="true"></i>
+        {{#if showTextLabels}}<span class="action-text">{{
+              localize "lancer.actionTracker.actions.reaction"
+            }}</span>{{/if}}
       </a>
-      {{!-- <a class="action {{#if actions.free}}lancer-free{{/if}}" data-action="free">
-        <i class="cci cci-free-action theme--dark white--text"></i>
-      </a> --}}
     </div>
   </div>
 </div>

--- a/src/module/action/action-manager.ts
+++ b/src/module/action/action-manager.ts
@@ -61,11 +61,13 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
 
   async _prepareContext(options: Record<string, unknown>) {
     const context = await super._prepareContext(options);
+    const trackerSettings = game.settings.get(game.system.id, LANCER.setting_actionTracker);
     const data = {
       position: this.position,
       name: this.target && this.target.name.toLocaleUpperCase(),
       actions: this.getActions(),
-      clickable: game.user?.isGM || game.settings.get(game.system.id, LANCER.setting_actionTracker).allowPlayers,
+      clickable: game.user?.isGM || trackerSettings.allowPlayers,
+      showTextLabels: trackerSettings.showTextLabels,
     };
     return foundry.utils.mergeObject(context, data);
   }
@@ -195,24 +197,13 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
   }
 
   private loadTooltips() {
-    tippy('.action[data-action="protocol"]', {
-      content: "Protocol",
-    });
-    tippy('.action[data-action="full"]', {
-      content: "Full Action",
-    });
-    tippy('.action[data-action="quick"]', {
-      content: "Quick Action",
-    });
-    tippy('.action[data-action="move"]', {
-      content: "Movement Action",
-    });
-    tippy('.action[data-action="reaction"]', {
-      content: "Reaction",
-    });
-    tippy('.action[data-action="free"]', {
-      content: "Free Actions",
-    });
+    const localizeTip = (key: string) => game.i18n.localize(key);
+    tippy('.action[data-action="protocol"]', { content: localizeTip("lancer.actionTracker.actions.protocol") });
+    tippy('.action[data-action="full"]', { content: localizeTip("lancer.actionTracker.actions.full") });
+    tippy('.action[data-action="quick"]', { content: localizeTip("lancer.actionTracker.actions.quick") });
+    tippy('.action[data-action="move"]', { content: localizeTip("lancer.actionTracker.actions.move") });
+    tippy('.action[data-action="reaction"]', { content: localizeTip("lancer.actionTracker.actions.reaction") });
+    tippy('.action[data-action="free"]', { content: localizeTip("lancer.actionTracker.actions.free") });
   }
 
   // HELPERS //

--- a/src/module/apps/acc_diff/AccDiffHUD.svelte
+++ b/src/module/apps/acc_diff/AccDiffHUD.svelte
@@ -24,6 +24,8 @@
   import type { SystemTemplates } from "../../system-template";
   import { LANCER } from "../../config";
   import { onMount } from "svelte";
+  import { hudL, hudT } from "../../helpers/hud-i18n";
+  import { hudModal } from "../slidinghud/hud-modal";
 
   export let weapon: AccDiffHudWeapon;
   export let base: AccDiffHudBase;
@@ -189,33 +191,29 @@
   }
 
   function gritLabel() {
-    // This is a tech attack
     if (isTech()) {
       if (lancerItem?.is_npc_feature() && lancerItem.system.type === NpcFeatureType.Tech) {
-        return "Tech Item Base";
+        return hudL("accdiff.tech-item-base");
       }
-      return "Tech Attack";
+      return hudL("accdiff.tech-attack");
     }
-    // Not a tech attack and we have an item. Base the label on the item type.
     if (lancerItem) {
       if (lancerItem.is_mech_weapon() || lancerItem.is_pilot_weapon()) {
-        return "Grit";
+        return hudL("accdiff.grit");
       }
       if (lancerItem.is_npc_feature() && lancerItem.system.type === NpcFeatureType.Weapon) {
-        return "Weapon Base";
+        return hudL("accdiff.weapon-base");
       }
     }
-    // Not a tech attack and we have no item. Base the label on the actor type.
     if (lancerActor) {
       if (lancerActor.is_npc()) {
-        return "Tier";
+        return hudL("accdiff.tier");
       }
       if (lancerActor.is_mech() || lancerActor.is_pilot() || lancerActor.is_deployable()) {
-        return "Grit";
+        return hudL("accdiff.grit");
       }
     }
-    // Default fallback
-    return "Grit";
+    return hudL("accdiff.grit");
   }
 
   function flatSign(val: number) {
@@ -253,6 +251,7 @@
 <form
   id="accdiff"
   class="lancer lancer-hud accdiff window-content"
+  use:hudModal
   use:escToCancel
   on:submit|preventDefault={() => {
     submitted = true;
@@ -279,7 +278,9 @@
   <div id="{kind}-accdiff-dialog" class="lancer-hud-body">
     <!-- Flat attack bonus -->
     {#if isAttack()}
-      <label class="flexrow accdiff-weight lancer-border-primary" for="accdiff-flat-bonus"> Flat Modifier </label>
+      <label class="flexrow accdiff-weight lancer-border-primary" for="accdiff-flat-bonus">
+        {hudL("accdiff.flat-modifier")}
+      </label>
       <div class="accdiff-grid accdiff-flat-bonus">
         <div class="accdiff-other-grid">
           <span><b>{gritLabel()}:</b> {flatSign(base.grit)}{base.grit}</span>
@@ -295,7 +296,7 @@
           </button>
         </div>
         <div class="accdiff-other-grid">
-          <span><b>Total:</b> {flatSign(flatTotal)}{flatTotal}</span>
+          <span><b>{hudL("common.total")}:</b> {flatSign(flatTotal)}{flatTotal}</span>
         </div>
       </div>
     {/if}
@@ -305,13 +306,13 @@
       <div class="accdiff-grid__column">
         <h4 class="lancer-border-primary">
           <i class="cci cci-accuracy i--4" style="vertical-align: middle; border: none" />
-          <span>Accuracy</span>
+          <span>{hudL("common.accuracy")}</span>
         </h4>
       </div>
       <div class="accdiff-grid__column">
         <h4 class="lancer-border-primary">
           <i class="cci cci-difficulty i--4" style="vertical-align: middle; border: none" />
-          <span>Difficulty</span>
+          <span>{hudL("common.difficulty")}</span>
         </h4>
       </div>
     </div>
@@ -319,21 +320,21 @@
     <div class="accdiff-grid accdiff-grid__section">
       <!-- Accuracy column -->
       <div class="accdiff-grid__column">
-        <HudCheckbox label="Accurate (+1)" bind:value={weapon.accurate} />
+        <HudCheckbox label={hudL("accdiff.accurate")} bind:value={weapon.accurate} />
         {#if kind == "attack"}
-          <HudCheckbox label="Seeking (*)" bind:value={weapon.seeking} />
+          <HudCheckbox label={hudL("accdiff.seeking")} bind:value={weapon.seeking} />
         {/if}
       </div>
 
       <!-- Difficulty column -->
       <div class="accdiff-grid__column">
-        <HudCheckbox label="Inaccurate (-1)" bind:value={weapon.inaccurate} />
-        <HudCheckbox label="Impaired (-1)" value={!!weapon.impaired} disabled />
+        <HudCheckbox label={hudL("accdiff.inaccurate")} bind:value={weapon.inaccurate} />
+        <HudCheckbox label={hudL("accdiff.impaired")} value={!!weapon.impaired} disabled />
         {#if kind == "attack" && !isTech()}
           {#if isMelee()}
-            <HudCheckbox label="Thrown (*)" bind:value={weapon.thrown} />
+            <HudCheckbox label={hudL("accdiff.thrown")} bind:value={weapon.thrown} />
           {/if}
-          <HudCheckbox label="Engaged (-1)" bind:value={weapon.engaged} />
+          <HudCheckbox label={hudL("accdiff.engaged")} bind:value={weapon.engaged} />
         {/if}
       </div>
     </div>
@@ -342,11 +343,16 @@
       <div transition:slide|global class="accdiff-grid accdiff-grid__section" style="width: 100%">
         <div class="accdiff-grid__column">
           {#if targets.length == 1}
-            <HudCheckbox style="grid-area: prone" label="Prone (+1)" bind:value={targets[0].prone} disabled />
-            <HudCheckbox label="Stunned (EVA=5)" bind:value={targets[0].stunned} disabled />
+            <HudCheckbox
+              style="grid-area: prone"
+              label={hudL("accdiff.prone")}
+              bind:value={targets[0].prone}
+              disabled
+            />
+            <HudCheckbox label={hudL("accdiff.stunned")} bind:value={targets[0].stunned} disabled />
             <HudCheckbox
               style="grid-area: lock-on"
-              label="Lock On (+1)"
+              label={hudL("accdiff.lock-on")}
               checked={!!targets[0].usingLockOn}
               bind:value={targets[0].consumeLockOn}
               disabled={!targets[0].lockOnAvailable}
@@ -448,10 +454,13 @@
                 class="accdiff-weight total-label lancer-mini-header"
                 for="total-display-0"
               >
-                🞂 <span>Total
+                🞂 <span>
                   {#if targets.length > 0}
-                    vs {targets[0].token.name}
-                  {/if}</span> 🞀
+                    {hudT("accdiff.total-vs", { name: targets[0].token.name ?? "" })}
+                  {:else}
+                    {hudL("common.total")}
+                  {/if}
+                </span> 🞀
               </label>
             </div>
           {/key}
@@ -541,7 +550,7 @@
       use:focus
     >
       <i class="fas fa-check" />
-      Roll
+      {hudL("common.roll")}
     </button>
     <button
       class="dialog-button cancel"
@@ -553,7 +562,7 @@
       }}
     >
       <i class="fas fa-times" />
-      Cancel
+      {hudL("common.cancel")}
     </button>
   </div>
 </form>

--- a/src/module/apps/acc_diff/AccDiffInput.svelte
+++ b/src/module/apps/acc_diff/AccDiffInput.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { hudL } from "../../helpers/hud-i18n";
+
   export let value: number = 0;
   export let id: string;
 </script>
@@ -6,12 +8,13 @@
 <button
   class="lancer-button dec-set"
   type="button"
-  data-tooltip="Add global accuracy"
+  data-tooltip={hudL("accdiff.add-global-accuracy")}
+  aria-label={hudL("accdiff.add-global-accuracy")}
   on:click={() => (value = value + 1)}
 >
   <i class="cci cci-accuracy i--3" />
 </button>
-<label for={id} class="flexcol" data-tooltip="Global Accuracy/Difficulty Adjustment">
+<label for={id} class="flexcol" data-tooltip={hudL("accdiff.global-accuracy-difficulty")}>
   <strong style="text-wrap: nowrap">Manual Adjust</strong>
   <strong class="accdiff-value">
     <span>{Math.abs(value)}</span>
@@ -22,7 +25,8 @@
 <button
   class="lancer-button dec-set"
   type="button"
-  data-tooltip="Add global difficulty"
+  data-tooltip={hudL("accdiff.add-global-difficulty")}
+  aria-label={hudL("accdiff.add-global-difficulty")}
   on:click={() => (value = value - 1)}
 >
   <i class="cci cci-difficulty i--3" />

--- a/src/module/apps/acc_diff/Cover.svelte
+++ b/src/module/apps/acc_diff/Cover.svelte
@@ -5,6 +5,7 @@
 <script lang="ts">
   import { crossfade } from "svelte/transition";
   import type { Cover } from "./index";
+  import { hudL } from "../../helpers/hud-i18n";
   export let cover: Cover;
   export let disabled: boolean = false;
   export let labelClass: string = "";
@@ -14,9 +15,9 @@
   let id = `accdiff-cover-input-${counter++}`;
 
   let inputs = [
-    { slug: "no", human: "No Cover", value: 0, icon: "shield-outline" },
-    { slug: "soft", human: "Soft Cover (-1)", value: 1, icon: "shield-half-full" },
-    { slug: "hard", human: "Hard Cover (-2)", value: 2, icon: "shield" },
+    { slug: "no", human: hudL("cover.none"), value: 0, icon: "shield-outline" },
+    { slug: "soft", human: hudL("cover.soft"), value: 1, icon: "shield-half-full" },
+    { slug: "hard", human: hudL("cover.hard"), value: 2, icon: "shield" },
   ];
 
   let [send, recv] = crossfade({});

--- a/src/module/apps/acc_diff/TotalAccuracy.svelte
+++ b/src/module/apps/acc_diff/TotalAccuracy.svelte
@@ -18,6 +18,7 @@
 
   import Plugin from "./Plugin.svelte";
   import HudCheckbox from "../components/HudCheckbox.svelte";
+  import { hudL } from "../../helpers/hud-i18n";
 
   export let target: AccDiffHudBase | AccDiffHudTarget;
   export let onlyTarget: boolean = false;
@@ -72,7 +73,7 @@
       bind:this={imgElement}
     />
     {#if target.stunned}
-      <label transition:blur|global for={stunnedId} class="stunned-label" title="Stunned">
+      <label transition:blur|global for={stunnedId} class="stunned-label" title={hudL("accdiff.stunned-label")}>
         <i class="cci cci-condition-stunned i--3" />
       </label>
     {/if}
@@ -81,7 +82,7 @@
       class="lockon-label"
       class:checked={target.usingLockOn}
       class:disabled={!target.lockOnAvailable}
-      title="Consume Lock On (+1)"
+      title={hudL("accdiff.consume-lock-on")}
     >
       <i
         class="cci cci-condition-lock-on"
@@ -92,7 +93,7 @@
         on:keypress={toggleLockOn}
       />
       <HudCheckbox
-        label="Consume Lock On (+1)"
+        label={hudL("accdiff.consume-lock-on")}
         checked={!!target.usingLockOn}
         bind:value={target.consumeLockOn}
         disabled={!target.lockOnAvailable}

--- a/src/module/apps/components/MiniProfile.svelte
+++ b/src/module/apps/components/MiniProfile.svelte
@@ -2,6 +2,8 @@
   import type { DamageData } from "../../models/bits/damage";
   import type { RangeData } from "../../models/bits/range";
 
+  import { hudL } from "../../helpers/hud-i18n";
+
   export let profile: { range: RangeData[]; damage?: DamageData[]; accuracy?: number; attack?: number };
 </script>
 
@@ -9,12 +11,12 @@
   {#if profile.attack || profile.accuracy}
     <div class="mini-weapon-profile-accuracy flexrow">
       {#if profile.attack}
-        <span data-tooltip="Attack bonus"><i class="cci cci-reticule" />{profile.attack < 0 ? "-" : "+"}{
-            profile.attack
-          }</span>
+        <span data-tooltip={hudL("profile.attack-bonus")}><i class="cci cci-reticule" />{
+            profile.attack < 0 ? "-" : "+"
+          }{profile.attack}</span>
       {/if}
       {#if profile.accuracy}
-        <span data-tooltip={(profile.accuracy ?? 0) > 0 ? "Accuracy" : "Difficulty"}><i
+        <span data-tooltip={(profile.accuracy ?? 0) > 0 ? hudL("profile.accuracy") : hudL("profile.difficulty")}><i
             class="cci cci-{(profile.accuracy ?? 0) > 0 ? 'accuracy' : 'difficulty'}"
           />{Math.abs(profile.accuracy)}</span>
       {/if}

--- a/src/module/apps/damage/DamageHUD.svelte
+++ b/src/module/apps/damage/DamageHUD.svelte
@@ -18,6 +18,8 @@
   import HitRadio from "./HitRadio.svelte";
   import { LancerActor } from "../../actor/lancer-actor";
   import { LancerToken } from "../../token";
+  import { hudL } from "../../helpers/hud-i18n";
+  import { hudModal } from "../slidinghud/hud-modal";
 
   export let title: string;
   export let kind: "damage";
@@ -189,6 +191,7 @@
 <form
   id="damage-hud"
   class="lancer lancer-hud damage-hud window-content"
+  use:hudModal
   use:escToCancel
   on:submit|preventDefault={() => dispatch("submit")}
 >
@@ -207,9 +210,14 @@
     <div class="damage-grid">
       <div class="base-damage lancer-border-primary">
         <h4 class="damage-hud-section lancer-border-primary flexrow">
-          Base Damage
-          <button class="add-damage-type" type="button" on:click={addBaseDamage}>
-            <i class="mdi mdi-plus-thick" data-tooltip="Add a base damage type" />
+          {hudL("damage.base-damage")}
+          <button
+            class="add-damage-type"
+            type="button"
+            on:click={addBaseDamage}
+            aria-label={hudL("damage.add-base-damage")}
+          >
+            <i class="mdi mdi-plus-thick" data-tooltip={hudL("damage.add-base-damage")} />
           </button>
         </h4>
         {#each weaponDamage as damage, i (i)}
@@ -225,9 +233,14 @@
       </div>
       <div class="bonus-damage">
         <h4 class="damage-hud-section lancer-border-primary flexrow">
-          Bonus Damage
-          <button class="add-damage-type" type="button" on:click={addBonusDamage}>
-            <i class="mdi mdi-plus-thick" data-tooltip="Add a bonus damage type" />
+          {hudL("damage.bonus-damage")}
+          <button
+            class="add-damage-type"
+            type="button"
+            on:click={addBonusDamage}
+            aria-label={hudL("damage.add-bonus-damage")}
+          >
+            <i class="mdi mdi-plus-thick" data-tooltip={hudL("damage.add-bonus-damage")} />
           </button>
         </h4>
         {#each weaponBonusDamage as damage, i (i)}
@@ -245,39 +258,39 @@
     <!-- Checkboxes - AP etc... -->
     <div class="damage-hud-options-grid">
       <h4 class="damage-hud-section lancer-border-primary" style="justify-content: center; grid-area: title">
-        Configuration
+        {hudL("common.configuration")}
       </h4>
       <HudCheckbox
         icon="mdi mdi-shield-off-outline"
-        label="Armor Piercing (AP)"
+        label={hudL("damage.armor-piercing")}
         bind:value={base.ap}
         bind:partial={partialAP}
         on:change={toggleAP}
         disabled={base.paracausal}
         style="grid-area: ap"
       />
-      <HudCheckbox label="Overkill" bind:value={weapon.overkill} style="grid-area: overkill" />
+      <HudCheckbox label={hudL("damage.overkill")} bind:value={weapon.overkill} style="grid-area: overkill" />
       <HudCheckbox
         icon="cci cci-large-beam"
-        label="Cannot be Reduced"
+        label={hudL("damage.cannot-be-reduced")}
         bind:value={base.paracausal}
         bind:partial={partialParacausal}
         on:change={toggleParacausal}
-        tooltip="For 'cannot be reduced' effects like the Paracausal mod"
+        tooltip={hudL("damage.cannot-be-reduced-tip")}
         style="grid-area: paracausal"
       />
       <HudCheckbox
         icon="mdi mdi-fraction-one-half"
-        label="Half Damage"
+        label={hudL("damage.half-damage")}
         bind:value={base.halfDamage}
         bind:partial={partialHalfDamage}
         on:change={toggleHalfDamage}
-        tooltip="For effects which cause the attacker to deal half damage in addition to resistance, like Heavy Gunner"
+        tooltip={hudL("damage.half-damage-tip")}
         style="grid-area: halfdamage"
       />
       <div class="flexrow" style="grid-area: reliable; align-items: center">
         <HudCheckbox
-          label="Reliable"
+          label={hudL("damage.reliable")}
           bind:value={weapon.reliable}
           style="grid-area: reliable; max-width: fit-content; padding-right: 0.5em"
         />
@@ -333,11 +346,11 @@
   <div class="lancer-hud-buttons flexrow">
     <button class="dialog-button submit default" data-button="submit" type="submit" use:focus>
       <i class="fas fa-check" />
-      Roll
+      {hudL("common.roll")}
     </button>
     <button class="dialog-button cancel" data-button="cancel" type="button" on:click={() => dispatch("cancel")}>
       <i class="fas fa-times" />
-      Cancel
+      {hudL("common.cancel")}
     </button>
   </div>
 </form>

--- a/src/module/apps/damage/DamageInput.svelte
+++ b/src/module/apps/damage/DamageInput.svelte
@@ -4,6 +4,7 @@
 
   import { DamageType } from "../../enums";
   import type { DamageData } from "../../models/bits/damage";
+  import { hudL } from "../../helpers/hud-i18n";
 
   const dispatch = createEventDispatcher();
   const damageSelectOptions = Object.entries(DamageType);
@@ -48,9 +49,9 @@
       class="lancer-button damage-delete"
       type="button"
       on:click={dispatchDelete}
-      aria-label="Remove damage type"
-      title="Remove damage type"
-      data-tooltip="Remove this damage type"
+      aria-label={hudL("damage.remove-damage-type")}
+      title={hudL("damage.remove-damage-type")}
+      data-tooltip={hudL("damage.remove-damage-type")}
     >
       <i class="fas fa-trash"></i>
     </button>

--- a/src/module/apps/damage/DamageTarget.svelte
+++ b/src/module/apps/damage/DamageTarget.svelte
@@ -5,6 +5,7 @@
   import HudCheckbox from "../components/HudCheckbox.svelte";
   import { DamageHudTarget, HitQuality } from "./data";
   import DamageInput from "./DamageInput.svelte";
+  import { hudL } from "../../helpers/hud-i18n";
   import { DamageType } from "../../enums";
   import HitRadio from "./HitRadio.svelte";
 
@@ -63,9 +64,9 @@
             class="lancer-button add-damage-type small"
             type="button"
             on:click={addBonusDamage}
-            aria-label="Add bonus damage type"
-            title="Add bonus damage type"
-            data-tooltip="Add a bonus damage type for only this target"
+            aria-label={hudL("damage.add-target-bonus-damage")}
+            title={hudL("damage.add-target-bonus-damage")}
+            data-tooltip={hudL("damage.add-target-bonus-damage")}
           >
             <i class="mdi mdi-plus-thick"></i>
           </button>
@@ -81,9 +82,9 @@
           class="lancer-button add-damage-type"
           type="button"
           on:click={addBonusDamage}
-          aria-label="Add bonus damage type"
-          title="Add bonus damage type"
-          data-tooltip="Add a bonus damage type for only this target"
+          aria-label={hudL("damage.add-target-bonus-damage")}
+          title={hudL("damage.add-target-bonus-damage")}
+          data-tooltip={hudL("damage.add-target-bonus-damage")}
         >
           <i class="mdi mdi-plus-thick"></i>
         </button>
@@ -100,21 +101,21 @@
       icon="mdi mdi-shield-off-outline"
       bind:value={target.ap}
       on:change={toggleAP}
-      tooltip="Armor Piercing (AP)"
+      tooltip={hudL("damage.armor-piercing-tip")}
       disabled={target.paracausal}
     />
     <HudCheckbox
       icon="cci cci-large-beam"
       bind:value={target.paracausal}
       on:change={toggleParacausal}
-      tooltip="For 'cannot be reduced' effects like the Paracausal mod"
+      tooltip={hudL("damage.paracausal-tip")}
       style="margin: 0 0.3em"
     />
     <HudCheckbox
       icon="mdi mdi-fraction-one-half"
       bind:value={target.halfDamage}
       on:change={toggleHalfDamage}
-      tooltip="For effects which cause the attacker to deal half damage in addition to resistance, like Heavy Gunner"
+      tooltip={hudL("damage.half-damage-tip")}
     />
   </div>
 </div>

--- a/src/module/apps/slidinghud/hud-modal.ts
+++ b/src/module/apps/slidinghud/hud-modal.ts
@@ -1,0 +1,45 @@
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function focusableElements(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(el => el.offsetParent !== null);
+}
+
+/** aria-modal dialog behavior: initial focus + Tab focus trap (Escape handled separately). */
+export function hudModal(node: HTMLElement) {
+  node.setAttribute("aria-modal", "true");
+  node.setAttribute("role", "dialog");
+
+  const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+  const focusFirst = () => {
+    const items = focusableElements(node);
+    (items[0] ?? node).focus();
+  };
+
+  focusFirst();
+
+  const onKeydown = (ev: KeyboardEvent) => {
+    if (ev.key !== "Tab") return;
+    const items = focusableElements(node);
+    if (items.length < 2) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+    if (ev.shiftKey && document.activeElement === first) {
+      ev.preventDefault();
+      last.focus();
+    } else if (!ev.shiftKey && document.activeElement === last) {
+      ev.preventDefault();
+      first.focus();
+    }
+  };
+
+  node.addEventListener("keydown", onKeydown);
+
+  return {
+    destroy() {
+      node.removeEventListener("keydown", onKeydown);
+      previouslyFocused?.focus?.();
+    },
+  };
+}

--- a/src/module/apps/struct_stress/StructStressHUD.svelte
+++ b/src/module/apps/struct_stress/StructStressHUD.svelte
@@ -3,6 +3,8 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import type { LancerActor } from "../../actor/lancer-actor";
+  import { hudL, hudT } from "../../helpers/hud-i18n";
+  import { hudModal } from "../slidinghud/hud-modal";
 
   export let title: string;
   export let stat: "structure" | "stress";
@@ -14,6 +16,22 @@
 
   function focus(el: HTMLElement) {
     el.focus();
+  }
+
+  function escToCancel(_el: HTMLElement) {
+    function escHandler(ev: KeyboardEvent) {
+      if (ev.key === "Escape") {
+        ev.preventDefault();
+        dispatch("cancel");
+      }
+    }
+
+    window.addEventListener("keydown", escHandler);
+    return {
+      destroy() {
+        window.removeEventListener("keydown", escHandler);
+      },
+    };
   }
 
   function getCurrent(a: LancerActor | null) {
@@ -31,11 +49,14 @@
   $: current = getCurrent(lancerActor);
   $: damage = getDamage(lancerActor);
   $: canRoll = damage > 0;
+  $: statLabel = hudL(`structstress.${stat}`);
 </script>
 
 <form
   id="structstress"
   class="lancer-hud structstress window-content"
+  use:hudModal
+  use:escToCancel
   on:submit|preventDefault={() => {
     if (!canRoll) return;
     dispatch("submit");
@@ -47,7 +68,11 @@
   </div>
   {#if lancerActor && (lancerActor.is_mech() || lancerActor.is_npc())}
     <div class="lancer-hud-body">
-      <h4>{lancerActor?.name ?? "UNKNOWN MECH"} has taken {icon} damage!</h4>
+      <h4>
+        {
+          hudT("structstress.damage-taken", { name: lancerActor?.name ?? hudL("common.unknown-actor"), stat: statLabel })
+        }
+      </h4>
       <div class="damage-preview">
         {#each { length: current } as _}
           <i class="cci cci-{icon} i--4 damage-pip" />
@@ -58,9 +83,9 @@
       </div>
       <p class="message">
         {#if canRoll}
-          Roll {damage}d6 to determine what happens.
+          {hudT("structstress.roll-prompt", { dice: damage })}
         {:else}
-          No {stat} remaining. No roll is available.
+          {hudT("structstress.no-roll", { stat: statLabel })}
         {/if}
       </p>
     </div>
@@ -68,11 +93,11 @@
   <div class="lancer-hud-buttons flexrow">
     <button class="dialog-button submit default" data-button="submit" type="submit" use:focus disabled={!canRoll}>
       <i class="fas fa-check" />
-      Roll
+      {hudL("common.roll")}
     </button>
     <button class="dialog-button cancel" data-button="cancel" type="button" on:click={() => dispatch("cancel")}>
       <i class="fas fa-times" />
-      Cancel
+      {hudL("common.cancel")}
     </button>
   </div>
 </form>

--- a/src/module/flows/full-repair.ts
+++ b/src/module/flows/full-repair.ts
@@ -32,32 +32,29 @@ export class FullRepairFlow extends Flow<LancerFlowState.TextRollData> {
 export async function displayFullRepairDialog(state: FlowState<LancerFlowState.TextRollData>): Promise<boolean> {
   if (!state.data) throw new TypeError(`Full Repair flow state missing!`);
 
-  return new Promise<boolean>((resolve, reject) => {
-    new Dialog({
-      title: `FULL REPAIR - ${state.actor.name}`,
-      content: `<h3>Are you sure you want to fully repair the ${state.actor?.type} "${state.actor?.name}"?`,
-      buttons: {
-        submit: {
-          icon: '<i class="fas fa-check"></i>',
-          label: "Yes",
-          callback: async _dlg => {
-            // Gotta typeguard the actor again
-            if (!state.actor) {
-              return reject();
-            }
-            resolve(true);
-          },
-        },
-        cancel: {
-          icon: '<i class="fas fa-times"></i>',
-          label: "No",
-          callback: async () => resolve(false),
-        },
+  if (!state.actor) return false;
+
+  return (
+    (await foundry.applications.api.DialogV2.confirm({
+      window: {
+        title: game.i18n.format("lancer.flow.fullRepair.title", { name: state.actor.name ?? "" }),
+        icon: "cci cci-repair",
       },
-      default: "submit",
-      close: () => resolve(false),
-    }).render(true);
-  });
+      content: `<p>${game.i18n.format("lancer.flow.fullRepair.prompt", {
+        type: state.actor.type,
+        name: state.actor.name ?? "",
+      })}</p>`,
+      yes: {
+        icon: "fas fa-check",
+        label: game.i18n.localize("lancer.flow.common.yes"),
+        default: true,
+      },
+      no: {
+        icon: "fas fa-times",
+        label: game.i18n.localize("lancer.flow.common.no"),
+      },
+    })) ?? false
+  );
 }
 
 export async function executeFullRepair(state: FlowState<LancerFlowState.TextRollData>): Promise<boolean> {

--- a/src/module/flows/stabilize.ts
+++ b/src/module/flows/stabilize.ts
@@ -43,33 +43,34 @@ async function renderStabilizePrompt(state: FlowState<LancerFlowState.StabilizeD
 
   let submit: boolean | null = null;
 
-  submit = await new Promise<boolean>((resolve, _reject) => {
-    new Dialog({
-      title: `STABILIZE - ${actor.name!}`,
-      content: template,
-      buttons: {
-        submit: {
-          icon: '<i class="fas fa-check"></i>',
-          label: "Submit",
-          callback: async dlg => {
-            // Typeguard the flow data again
-            if (!state.data) return;
-            state.data.option1 = <StabOptions1>$(dlg).find(".stabilize-options-1:checked").first().val();
-            state.data.option2 = <StabOptions2>$(dlg).find(".stabilize-options-2:checked").first().val();
-            resolve(true);
-          },
-        },
-        cancel: {
-          icon: '<i class="fas fa-times"></i>',
-          label: "Cancel",
-          callback: async () => resolve(false),
+  const action = await foundry.applications.api.DialogV2.wait({
+    window: {
+      title: game.i18n.format("lancer.flow.stabilize.title", { name: actor.name ?? "" }),
+      icon: "cci cci-repair",
+    },
+    content: template,
+    buttons: [
+      {
+        action: "submit",
+        icon: "fas fa-check",
+        label: game.i18n.localize("lancer.flow.common.submit"),
+        default: true,
+        callback: (_event, _button, dialog) => {
+          if (!state.data) return false;
+          const root = dialog.element as HTMLElement;
+          state.data.option1 = <StabOptions1>$(root).find(".stabilize-options-1:checked").first().val();
+          state.data.option2 = <StabOptions2>$(root).find(".stabilize-options-2:checked").first().val();
+          return true;
         },
       },
-      default: "submit",
-      close: () => resolve(false),
-    }).render(true);
+      {
+        action: "cancel",
+        icon: "fas fa-times",
+        label: game.i18n.localize("lancer.flow.common.cancel"),
+      },
+    ],
   });
-  return submit ?? false;
+  return action === "submit";
 }
 
 async function applyStabilizeUpdates(state: FlowState<LancerFlowState.StabilizeData>): Promise<boolean> {

--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -6,6 +6,7 @@ import { LANCER } from "../config";
 import { EntryType } from "../enums";
 import { LancerFlowState } from "../flows/interfaces";
 import { extendHelper, inc_if, resolveHelperDotpath, selected, std_num_input, std_x_of_y } from "./commons";
+import { ariaLabelAttr } from "./aria";
 import { ref_params, simple_ref_slot } from "./refs";
 
 // ---------------------------------------
@@ -26,7 +27,14 @@ interface ButtonOverrides {
 
 function _flowButton(button_class: string, html_data: string, overrides: ButtonOverrides = {}): string {
   const tooltip = overrides.tooltip ? `data-tooltip="${overrides.tooltip}"` : "";
-  return `<a class="${button_class} lancer-button ${overrides.classes ?? ""}" ${html_data} ${tooltip}>
+  const ariaKey =
+    button_class === "roll-stat"
+      ? "lancer.sheet-controls.roll-stat"
+      : button_class === "lancer-flow-button"
+        ? "lancer.sheet-controls.roll-attack"
+        : "";
+  const aria = ariaKey ? `${ariaLabelAttr(ariaKey)} ` : "";
+  return `<a class="${button_class} lancer-button ${overrides.classes ?? ""}" ${aria}${html_data} ${tooltip}>
     <i class="fas ${overrides.icon ?? "fa-dice-d20"} i--dark i--2"></i>
   </a>`;
 }

--- a/src/module/helpers/aria.ts
+++ b/src/module/helpers/aria.ts
@@ -1,0 +1,5 @@
+/** Localized `aria-label="..."` attribute for icon-only controls. */
+export function ariaLabelAttr(key: string): string {
+  const label = game.i18n.localize(key).replace(/"/g, "&quot;");
+  return `aria-label="${label}"`;
+}

--- a/src/module/helpers/collapse.ts
+++ b/src/module/helpers/collapse.ts
@@ -1,5 +1,5 @@
-import { LancerActor } from "../actor/lancer-actor";
-import { LancerItem } from "../item/lancer-item";
+import type { LancerActor } from "../actor/lancer-actor";
+import type { LancerItem } from "../item/lancer-item";
 
 export type CollapseRegistry = { [LID: string]: number };
 
@@ -23,22 +23,11 @@ export class CollapseHandler {
   }
 }
 
-/**Generate a UID for the given collapse item
- *
- * */
-
-/**
- * Generate a unique id for the given collapse item
- * @param collapse Collapse ID registry to operate in
- * @param doc The document / id we are generating a new ID based off of
- * @param no_inc Whether we should re-use the previous index, if one exists. This allows consecutively generated IDs to be aliased to each other - they will collapse each other
- */
 export function collapseID(
   collapse: CollapseRegistry,
   doc: string | LancerActor | LancerItem | null | undefined,
   no_inc: boolean
 ): string {
-  // On sheet, enable collapse.
   let doc_id: string;
   if (doc instanceof foundry.abstract.Document) {
     doc_id = doc.id ?? "ephem";
@@ -57,24 +46,47 @@ export function collapseID(
   return `${doc_id}_${collapse_index}`;
 }
 
-/**
- * Generates a button for toggling collapse state of a thing. To be used in conjuncture with collapseParam
- * @param collapse G
- * @param doc
- * @param no_increment
- * @returns
- */
+export function collapseSectionForId(collapseId: string): Element | null {
+  return document.querySelector(`.collapse[data-collapse-id="${collapseId}"]`);
+}
+
+export function syncCollapseAria(trigger: Element, section?: Element | null): void {
+  const id = trigger.getAttribute("data-collapse-id");
+  const collapse =
+    section ??
+    (id ? collapseSectionForId(id) : null) ??
+    (id ? document.querySelector(`[data-collapse-id="${id}"].collapse`) : null);
+  const expanded = collapse ? !collapse.classList.contains("collapsed") : true;
+  trigger.setAttribute("aria-expanded", expanded ? "true" : "false");
+}
+
+function enhanceCollapseTrigger(trigger: Element): void {
+  if (!trigger.hasAttribute("role") && trigger.tagName !== "BUTTON") {
+    trigger.setAttribute("role", "button");
+  }
+  if (!trigger.hasAttribute("tabindex") && trigger.tagName !== "BUTTON") {
+    trigger.setAttribute("tabindex", "0");
+  }
+  if (!trigger.hasAttribute("aria-label")) {
+    trigger.setAttribute("aria-label", game.i18n.localize("lancer.collapse.toggle"));
+  }
+  syncCollapseAria(trigger);
+}
+
+export function enhanceCollapseTriggers(html: JQuery): void {
+  html.find(".collapse-trigger").each((_, el) => enhanceCollapseTrigger(el));
+}
+
 export function collapseButton(
   collapse: CollapseRegistry | undefined | null,
   doc?: string | LancerActor | LancerItem | null,
   no_increment: boolean = false
 ) {
   if (collapse) {
-    return `<i class="mdi mdi-unfold-less-horizontal collapse-trigger collapse-icon" data-collapse-id="${collapseID(
-      collapse,
-      doc,
-      no_increment
-    )}"> </i>`;
+    const id = collapseID(collapse, doc, no_increment);
+    return `<button type="button" class="collapse-trigger collapse-icon" data-collapse-id="${id}" aria-expanded="true" aria-label="${game.i18n.localize("lancer.collapse.toggle")}">
+      <i class="mdi mdi-unfold-less-horizontal" aria-hidden="true"></i>
+    </button>`;
   }
   return "";
 }
@@ -90,22 +102,12 @@ export function collapseParam(
   return "";
 }
 
-// V2
-/**
- * Generalized collapse activator
- */
-export function applyCollapseListeners(html: JQuery) {
-  html.find(".collapse-trigger").on("click", handleCollapse);
-}
+export function toggleCollapse(trigger: Element): void {
+  const id = trigger.getAttribute("data-collapse-id");
+  if (!id) return;
 
-const handleCollapse = (ev: Event) => {
-  ev.stopPropagation();
-
-  let prefix = `lancer-collapse`;
-  // On click, find matching collapse, and toggle collapsed class.
-  let id = (ev.currentTarget as Element).getAttribute("data-collapse-id");
-
-  let collapse = document.querySelector(`.collapse[data-collapse-id="${id}"]`);
+  const collapse = collapseSectionForId(id);
+  const prefix = `lancer-collapse`;
   if (collapse?.classList.contains("collapsed")) {
     collapse.classList.remove("collapsed");
     sessionStorage.setItem(`${prefix}-${id}`, "opened");
@@ -113,12 +115,29 @@ const handleCollapse = (ev: Event) => {
     collapse?.classList.add("collapsed");
     sessionStorage.setItem(`${prefix}-${id}`, "closed");
   }
-  // console.debug(collapse);
+
+  document.querySelectorAll(`.collapse-trigger[data-collapse-id="${id}"]`).forEach(t => syncCollapseAria(t, collapse));
+}
+
+const handleCollapse = (ev: Event) => {
+  ev.preventDefault();
+  ev.stopPropagation();
+  toggleCollapse(ev.currentTarget as Element);
 };
+
+const handleCollapseKeydown = (ev: JQuery.KeyDownEvent) => {
+  if (ev.key !== "Enter" && ev.key !== " ") return;
+  ev.preventDefault();
+  toggleCollapse(ev.currentTarget);
+};
+
+export function applyCollapseListeners(html: JQuery) {
+  enhanceCollapseTriggers(html);
+  html.find(".collapse-trigger").on("click", handleCollapse).on("keydown", handleCollapseKeydown);
+}
 
 export function initializeCollapses(html: JQuery) {
   let collapse_sections = html.find(".collapse");
-  // Init according to session store.
   collapse_sections.each((_index, section) => {
     let id = section.getAttribute("data-collapse-id");
     if (id) {
@@ -130,4 +149,6 @@ export function initializeCollapses(html: JQuery) {
       }
     }
   });
+  enhanceCollapseTriggers(html);
+  html.find(".collapse-trigger").each((_, trigger) => syncCollapseAria(trigger));
 }

--- a/src/module/helpers/hud-i18n.ts
+++ b/src/module/helpers/hud-i18n.ts
@@ -1,0 +1,7 @@
+export function hudL(key: string): string {
+  return game.i18n.localize(`lancer.hud.${key}`);
+}
+
+export function hudT(key: string, data: Record<string, string | number> = {}): string {
+  return game.i18n.format(`lancer.hud.${key}`, data);
+}

--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -27,6 +27,7 @@ import {
   activationIcon,
 } from "./commons";
 import { limitedUsesIndicator, loadingIndicator, ref_params, refSlotEmptyHintHtml, reserveUsesIndicator } from "./refs";
+import { ariaLabelAttr } from "./aria";
 import {
   ActivationType,
   ChipIcons,
@@ -116,7 +117,7 @@ export function rangeEditor(path: string, options: HelperOptions): string {
   let value_options = extendHelper(options, { value: range.val });
   let value_input = std_text_input(path + ".val", value_options);
 
-  let delete_button = `<a class="gen-control" data-action="splice" data-path="${path}" style="margin: 4px;"><i class="fas fa-trash"></i></a>`;
+  let delete_button = `<a class="gen-control" ${ariaLabelAttr("lancer.sheet-controls.delete-item")} data-action="splice" data-path="${path}" style="margin: 4px;"><i class="fas fa-trash"></i></a>`;
 
   return `<div class="flexrow flex-center" style="padding: 5px;">
     ${icon_html}
@@ -145,7 +146,7 @@ export function damageEditor(path: string, options: HelperOptions): string {
   let value_options = extendHelper(options, { value: damage.val });
   let value_input = std_text_input(path + ".val", value_options);
 
-  let delete_button = `<a class="gen-control" data-action="splice" data-path="${path}" style="margin: 4px;"><i class="fas fa-trash"></i></a>`;
+  let delete_button = `<a class="gen-control" ${ariaLabelAttr("lancer.sheet-controls.delete-item")} data-action="splice" data-path="${path}" style="margin: 4px;"><i class="fas fa-trash"></i></a>`;
 
   return `<div class="flexrow flex-center" style="padding: 5px;">
     ${icon_html}
@@ -284,7 +285,7 @@ export function bonusesDisplay(bonuses_path: string, edit: boolean, options: Hel
   // Render each bonus
   for (let i = 0; i < bonuses_array.length; i++) {
     let bonus = bonuses_array[i];
-    let delete_button = `<a class="gen-control" data-action="splice" data-path="${bonuses_path}.${i}"><i class="fas fa-trash"></i></a>`;
+    let delete_button = `<a class="gen-control" ${ariaLabelAttr("lancer.sheet-controls.delete-item")} data-action="splice" data-path="${bonuses_path}.${i}"><i class="fas fa-trash"></i></a>`;
     let title = `<span class="grow">${bonus.lid}</span> ${inc_if(delete_button, edit)}`; // Todo: maybe return to
     let boxed = `
       <div class="bonus ${inc_if("editable", edit)}" data-path="${bonuses_path}.${i}">
@@ -392,7 +393,7 @@ export function pilotArmorSlot(armor_path: string, options: HelperOptions): stri
             <div class="lancer-header lancer-primary">
               <i class="mdi mdi-shield-outline i--4 i--light"> </i>
               <span class="minor">${armor.name}</span>
-              <a class="lancer-context-menu" data-path="${armor_path}"">
+              <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${armor_path}"">
                 <i class="fas fa-ellipsis-v"></i>
               </a>
             </div>
@@ -471,7 +472,7 @@ export function pilotWeaponRefview(weapon_path: string, options: HelperOptions):
     <div class="lancer-header lancer-weapon">
       <i class="cci cci-weapon i--4 i--light"> </i>
       <span class="minor">${weapon.name}</span>
-              <a class="lancer-context-menu" data-path="${weapon_path}"">
+              <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${weapon_path}"">
                 <i class="fas fa-ellipsis-v"></i>
               </a>
     </div>
@@ -534,9 +535,9 @@ export function pilotGearRefview(gear_path: string, options: HelperOptions): str
   >
     <div class="lancer-header lancer-system">
       <i class="cci cci-generic-item i--4"> </i>
-      <a class="chat-flow-button"><i class="mdi mdi-message"></i></a>
+      <a class="chat-flow-button" ${ariaLabelAttr("lancer.sheet-controls.post-chat")}><i class="mdi mdi-message"></i></a>
       <span class="minor">${gear.name!}</span>
-      <a class="lancer-context-menu" data-path="${gear_path}"">
+      <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${gear_path}"">
         <i class="fas fa-ellipsis-v"></i>
       </a>
     </div>
@@ -630,9 +631,9 @@ export function reserveRefView(reserve_path: string, options: HelperOptions): st
                 ${ref_params(reserve, reserve_path)} >
     <div class="lancer-header lancer-trait">
       <i class="${icon} i--4"> </i>
-      <a class="chat-flow-button"><i class="mdi mdi-message"></i></a>
+      <a class="chat-flow-button" ${ariaLabelAttr("lancer.sheet-controls.post-chat")}><i class="mdi mdi-message"></i></a>
       <span class="minor">${reserve.name}</span>
-      <a class="lancer-context-menu" data-path="${reserve_path}"">
+      <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${reserve_path}"">
         <i class="fas fa-ellipsis-v"></i>
       </a>
     </div>
@@ -742,12 +743,12 @@ data-action="set" data-action-value="(int)${i}" data-path="${weapon_path}.system
                   style="max-height: fit-content;">
       <div class="lancer-header lancer-weapon ${weapon.system.destroyed ? "destroyed" : ""}">
         <i class="${weapon.system.destroyed ? "mdi mdi-cog" : "cci cci-weapon i--4 i--light"}"> </i>
-        <a class="chat-flow-button"><i class="mdi mdi-message"></i></a>
+        <a class="chat-flow-button" ${ariaLabelAttr("lancer.sheet-controls.post-chat")}><i class="mdi mdi-message"></i></a>
         <span class="minor" >
           ${weapon.name} // ${weapon.system.size.toUpperCase()} ${profile.type.toUpperCase()}
         </span>
         ${collapseButton(collapse, weapon)}
-        <a class="lancer-context-menu" data-path="${weapon_path}">
+        <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${weapon_path}">
           <i class="fas fa-ellipsis-v"></i>
         </a>
       </div>
@@ -842,7 +843,7 @@ export function weaponModView(mod_path: string, weapon_path: string | null, opti
     <div class="lancer-header lancer-mod">
       <i class="cci cci-weaponmod i--4 i--light"> </i>
       <span class="minor">${mod.name}</span>
-      <a class="lancer-context-menu" data-path="${mod_path}">
+      <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${mod_path}">
         <i class="fas fa-ellipsis-v"></i>
       </a>
     </div>
@@ -900,7 +901,7 @@ export function licenseRefView(item_path: string, options: HelperOptions): strin
         <i class="cci cci-license i--4 i--dark"> </i>
         <div class="major modifier-name">${license.name} ${license.system.curr_rank}</div>
         <div class="ref-controls">
-          <a class="lancer-context-menu" data-path="${item_path}"">
+          <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${item_path}"">
             <i class="fas fa-ellipsis-v"></i>
           </a>
         </div>
@@ -920,7 +921,7 @@ export function framePreview(path: string, options: HelperOptions): string {
         <span class="img-bar" style="background-image: url(${frame_img})"></span>
         <div class="major modifier-name i--light">${frame.system.manufacturer} ${frame.name}</div>
         <div class="ref-controls">
-          <a class="lancer-context-menu" data-path="${path}"">
+          <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${path}"">
             <i class="fas fa-ellipsis-v i--light"></i>
           </a>
         </div>
@@ -940,7 +941,7 @@ export function npcClassRefView(npc_class: LancerNPC_CLASS | null, item_path?: s
         <span class="img-bar" style="background-image: url(${frame_img})"></span>
         <div class="major modifier-name i--light">${npc_class.name} // ${npc_class.system.role?.toUpperCase()}</div>
         <div class="ref-controls">
-          <a class="lancer-context-menu" data-path="${item_path}"">
+          <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${item_path}"">
             <i class="fas fa-ellipsis-v i--light"></i>
           </a>
         </div>
@@ -959,7 +960,7 @@ export function npcTemplateRefView(template: LancerNPC_TEMPLATE | null, item_pat
         <span class="img-bar" style="background-image: url(${template.img})"></span>
         <div class="major modifier-name i--light">${template.name}</div>
         <div class="ref-controls">
-          <a class="lancer-context-menu" data-path="${item_path}"">
+          <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${item_path}"">
             <i class="fas fa-ellipsis-v i--light"></i>
           </a>
         </div>
@@ -1064,7 +1065,7 @@ export function buildActionHTML(
     // If it's editable, it's deletable
     editor = `
     <div class="action-editor-wrapper">
-      <a class="gen-control" data-uuid="${doc.uuid}" data-action="splice" data-path="${path}"><i class="fas fa-trash"></i></a>
+      <a class="gen-control" ${ariaLabelAttr("lancer.sheet-controls.delete-item")} data-uuid="${doc.uuid}" data-action="splice" data-path="${path}"><i class="fas fa-trash"></i></a>
       <a class="action-editor fas fa-edit" data-path="${path}"></a>
     </div>`;
   }
@@ -1322,7 +1323,7 @@ export function buildCounterHeader(
 ): string {
   const contextMenu = options?.noContextMenu
     ? ""
-    : `<a class="lancer-context-menu" data-path="${path}" data-can-delete="${
+    : `<a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${path}" data-can-delete="${
         options?.canDelete ? options.canDelete : false
       }">
         <i class="fas fa-ellipsis-v"></i>

--- a/src/module/helpers/loadout.ts
+++ b/src/module/helpers/loadout.ts
@@ -189,8 +189,10 @@ function allWeaponMountView(loadout_path: string, options: HelperOptions) {
   );
 
   return `
-    <div class="lancer-header lancer-dark-gray loadout-category submajor">
-      <i class="mdi mdi-unfold-less-horizontal collapse-trigger collapse-icon" data-collapse-id="weapons"></i>
+    <div class="lancer-header lancer-dark-gray loadout-category submajor sheet-section-header sticky">
+      <button type="button" class="collapse-trigger collapse-icon" data-collapse-id="weapons" aria-expanded="true" aria-label="${game.i18n.localize("lancer.collapse.toggle")}">
+        <i class="mdi mdi-unfold-less-horizontal" aria-hidden="true"></i>
+      </button>
       <span>MOUNTED WEAPONS</span>
       <a class="gen-control fas fa-plus" data-action="append" data-path="${loadout_path}.weapon_mounts" data-action-value="(struct)wep_mount"></a>
       <a class="reset-all-weapon-mounts-button fas fa-redo" data-path="${loadout_path}.weapon_mounts"></a>
@@ -211,8 +213,10 @@ function allMechSystemsView(loadout_path: string, options: HelperOptions) {
   // Archiving add button: <a class="gen-control fas fa-plus" data-action="append" data-path="${loadout_path}.SysMounts" data-action-value="(struct)sys_mount"></a>
 
   return `
-    <div class="lancer-header lancer-dark-gray loadout-category submajor">
-      <i class="mdi mdi-unfold-less-horizontal collapse-trigger collapse-icon" data-collapse-id="systems"></i>
+    <div class="lancer-header lancer-dark-gray loadout-category submajor sheet-section-header sticky">
+      <button type="button" class="collapse-trigger collapse-icon" data-collapse-id="systems" aria-expanded="true" aria-label="${game.i18n.localize("lancer.collapse.toggle")}">
+        <i class="mdi mdi-unfold-less-horizontal" aria-hidden="true"></i>
+      </button>
       <span>MOUNTED SYSTEMS</span>
       <span style="flex-grow: 0">
         <i class="cci cci-system-point i--4"></i>

--- a/src/module/helpers/refs.ts
+++ b/src/module/helpers/refs.ts
@@ -33,6 +33,7 @@ import { LancerActor } from "../actor/lancer-actor";
 import { coreBonusView, skillView, talent_view as talentView } from "./pilot";
 import type { SourceData } from "../source-template";
 import { LancerActiveEffect } from "../effects/lancer-active-effect";
+import { ariaLabelAttr } from "./aria";
 
 /*
 "Ref" manifesto - Things for handling everything in data that is either a ResolvedUuidRefField or ResolvedEmbeddedRefField.
@@ -216,7 +217,7 @@ export function itemPreview<T extends LancerItemType>(
         <span class="major">${doc.name}</span>
         <span class="vsep"></span>
         <div class="ref-controls">
-          <a class="lancer-context-menu" data-path="${item_path}">
+          <a class="lancer-context-menu" ${ariaLabelAttr("lancer.sheet-controls.item-menu")} data-path="${item_path}">
             <i class="fas fa-ellipsis-v"></i>
           </a>
         </div>

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -380,6 +380,7 @@ interface ActionTrackerOptionsSchema extends foundry.data.fields.DataSchema {
    * @defaultValue `true`
    */
   printMessages: fields.BooleanField<{ initial: true }>;
+  showTextLabels: fields.BooleanField<{ initial: false }>;
 }
 
 export class ActionTrackerOptions extends foundry.abstract.DataModel<ActionTrackerOptionsSchema> {
@@ -402,6 +403,12 @@ export class ActionTrackerOptions extends foundry.abstract.DataModel<ActionTrack
         required: true,
         label: "lancer.actionTracker.printMessages",
         hint: "lancer.actionTracker.printMessages-desc",
+      }),
+      showTextLabels: new fields.BooleanField({
+        initial: false,
+        required: true,
+        label: "lancer.actionTracker.showTextLabels",
+        hint: "lancer.actionTracker.showTextLabels-desc",
       }),
     };
   }

--- a/src/styles/applications/_action-manager.scss
+++ b/src/styles/applications/_action-manager.scss
@@ -55,9 +55,21 @@
     font-size: 1.35em;
     padding: 8px 2px 0 6px;
   }
+  .action-manager-reset-wrap {
+    position: absolute;
+    right: 0;
+  }
+
   #action-manager-reset {
     display: inline-flex;
     padding: 2px;
+    cursor: pointer;
+  }
+
+  a.action .action-text {
+    font-size: 0.45em;
+    margin-left: 0.15em;
+    vertical-align: middle;
   }
   #action-manager.noclick a,
   #action-manager .lancer-action-manager-surface.noclick a {

--- a/src/styles/components/_controls.scss
+++ b/src/styles/components/_controls.scss
@@ -71,6 +71,11 @@ a.item.lancer-tab {
 }
 .collapse-trigger {
   cursor: pointer;
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
 }
 .collapse {
   max-height: 1000em;

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "compatibility": {
     "minimum": 13,
     "verified": 14,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sprint **E** release **v2.16.0** — bundles UX roadmap PRs **#16–#21** (milestone [#48](https://github.com/VacantFanatic/foundryvtt-lancer/issues/48)).

### Collapse accessibility (#16)
- `aria-expanded` synced on collapse triggers
- **Enter/Space** keyboard activation
- Loadout collapse headers use semantic `<button>` elements

### Action manager accessibility (#17)
- `aria-label` on every action icon
- Optional **text labels** via new client setting (`showTextLabels`)

### DialogV2 migration (#18)
- **Stabilize** flow uses `DialogV2.wait()`
- **Full Repair** flow uses `DialogV2.confirm()`

### HUD focus trap & modal behavior (#19)
- New `hudModal` Svelte action: `aria-modal`, focus trap while open
- Applied to Acc/Diff, Damage, and Structure/Stress HUDs
- Escape still cancels as before

### Svelte HUD i18n (#20)
- `lancer.hud.*` keys for combat HUD strings
- `hudL()` / `hudT()` helpers for localized labels and tooltips

### Sheet icon aria-label audit (#21)
- Localized `aria-label` on context menus, chat-flow, roll, and delete controls in sheet helpers

## Version

- `2.16.0` in `package.json` and `system.json`
- CHANGELOG updated per Keep a Changelog

## Testing

- `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build` — pass
- `npm run test:e2e` — **7/7** passed (Firefox)

## Notes

- Legacy `Dialog` remains in a few out-of-scope call sites (`status-icons.ts`, `automation/combat.ts`, `simple-prompt.ts`) for a future pass.
- Chat template collapse headers still rely on JS enhancement via `initializeCollapses()` rather than native button markup in HBS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

