### PR TITLE
v2.17.0 — Help & discoverability (Sprint F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.17.0 (2026-06-06)
+
+## Added
+
+- **Contextual help** on the pilot Cloud tab, Automation settings, and first Acc/Diff HUD open (dismissible).
+- Help dialog **What's new** section with the three most recent changelog releases.
+- **Attack dialog** guided tour registered; pilot-import tour adds **click-to-equip** step; NPC tour covers **Features** tab.
+
+## Changed
+
+- Help dialog topic sections for cloud import, automation, and Acc/Diff; links to wiki and tours from contextual banners.
+
 # 2.16.0 (2026-06-06)
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -457,6 +457,43 @@
       "walk_of_kings": "Walk of Kings",
       "warp_sensors": "Warp Sensors"
     },
+    "help": {
+      "dialog-title": "LANCER Help",
+      "whats-new": "What's new",
+      "full-changelog": "Full changelog on GitHub",
+      "basic-workflows": "Basic Workflows",
+      "helpful-links": "Helpful Links",
+      "open-help": "Open help",
+      "wiki-link": "Wiki",
+      "start-tour": "Start tour",
+      "dismiss": "Dismiss",
+      "tour-missing": "Tour \"{tour}\" is not registered.",
+      "links": {
+        "faq": "FAQ",
+        "modules": "Suggested Modules",
+        "issues": "Bug reports and enhancement suggestions",
+        "discord": "PilotNET Community on Discord"
+      },
+      "context": {
+        "cloud-import": "Import pilots from COMP/CON cloud sync or a JSON export. Use the wizard steps below, or start the guided import tour.",
+        "automation": "These options control automatic hit calculation, structure/stress prompts, template cleanup, and the optional damage prompt after attacks.",
+        "accdiff": "Confirm accuracy, difficulty, targets, and cover here. Plugins and measured templates are under Advanced."
+      },
+      "topics": {
+        "cloud-import": {
+          "title": "COMP/CON import",
+          "body": "Log into COMP/CON from Configure Settings → LANCER, then use the Cloud tab wizard to select a pilot or paste a share code. JSON exports from COMP/CON can be uploaded on the same tab."
+        },
+        "automation": {
+          "title": "Automation settings",
+          "body": "Attack roll evaluation calculates hits on attack cards. Prompt Damage After Attack (off by default) opens the damage HUD when at least one target is hit. Structure/Stress prompts appear when a mech reaches 0 HP or exceeds heat cap."
+        },
+        "accdiff": {
+          "title": "Attack Acc/Diff HUD",
+          "body": "The sliding HUD confirms bonuses and penalties before an attack roll. Select targets on the canvas or with a measured template, then confirm. Use Advanced for weapon plugins and fine per-target modifiers."
+        }
+      }
+    },
     "automation": {
       "menu-name": "Automation",
       "menu-label": "System Automation Settings",

--- a/public/templates/actor/pilot.hbs
+++ b/public/templates/actor/pilot.hbs
@@ -91,6 +91,7 @@
   <section class="sheet-body scroll-body">
     {{!-- Cloud Management Tab --}}
     <div class="tab manage cloud-wizard {{tabs.primary.cloud.cssClass}}" data-group="primary" data-tab="cloud">
+      {{{cloudHelpHtml}}}
       <ol class="cloud-wizard-steps" aria-label='{{localize "lancer.pilot-sheet.cloud-wizard.steps-label"}}'>
         <li class="cloud-wizard-step-label" data-cloud-step="login">
           <span class="cloud-wizard-step-num">1</span>

--- a/public/templates/settings/automation-config.hbs
+++ b/public/templates/settings/automation-config.hbs
@@ -1,4 +1,5 @@
 <section>
+  {{{automationHelpHtml}}}
   {{formGroup fields.attacks value=config.attacks localize=true}}
   {{formGroup fields.prompt_damage_after_attack value=config.prompt_damage_after_attack localize=true}}
   {{formGroup fields.structure value=config.structure localize=true}}

--- a/public/templates/window/contextual-help.hbs
+++ b/public/templates/window/contextual-help.hbs
@@ -1,0 +1,39 @@
+<aside class="lancer-contextual-help" data-help-topic="{{topic}}">
+  <i class="fas fa-circle-info" aria-hidden="true"></i>
+  <p class="minor desc-text grow">{{{message}}}</p>
+  {{#if showHelpButton}}
+    <button
+      type="button"
+      class="lancer-button lancer-secondary"
+      data-action="openLancerHelp"
+      data-help-topic="{{topic}}"
+    >
+      <i class="fas fa-book-open"></i>
+      {{localize "lancer.help.open-help"}}
+    </button>
+  {{/if}}
+  {{#if wikiUrl}}
+    <a class="lancer-button lancer-secondary" href="{{wikiUrl}}" target="_blank" rel="noopener noreferrer">
+      <i class="fas fa-external-link-alt"></i>
+      {{localize "lancer.help.wiki-link"}}
+    </a>
+  {{/if}}
+  {{#if tourKey}}
+    <button type="button" class="lancer-button" data-action="startSystemTour" data-tour-key="{{tourKey}}">
+      <i class="fas fa-route"></i>
+      {{localize "lancer.help.start-tour"}}
+    </button>
+  {{/if}}
+  {{#if dismissible}}
+    <button
+      type="button"
+      class="lancer-button lancer-contextual-help-dismiss"
+      data-action="dismissContextualHelp"
+      data-help-dismiss="{{dismissKey}}"
+      data-tooltip='{{localize "lancer.help.dismiss"}}'
+      aria-label='{{localize "lancer.help.dismiss"}}'
+    >
+      <i class="fas fa-times"></i>
+    </button>
+  {{/if}}
+</aside>

--- a/public/templates/window/lancerHelp.hbs
+++ b/public/templates/window/lancerHelp.hbs
@@ -1,14 +1,56 @@
 <div class="lancerHelpPage">
-  <h1>LANCER Help</h1>
-  <h2>Basic Workflows</h2>
+  <h1>{{localize "lancer.help.dialog-title"}}</h1>
+
+  {{#if releases.length}}
+    <section class="lancer-help-whats-new">
+      <h2>{{localize "lancer.help.whats-new"}}</h2>
+      {{#each releases as |release|}}
+        <article class="lancer-help-release">
+          <h3 class="lancer-help-release-version">
+            v{{release.version}} <span class="minor">({{release.date}})</span>
+          </h3>
+          {{#each release.sections as |section|}}
+            <h4 class="minor">{{section.title}}</h4>
+            <ul>
+              {{#each section.items as |item|}}
+                <li>{{{item}}}</li>
+              {{/each}}
+            </ul>
+          {{/each}}
+        </article>
+      {{/each}}
+      <p class="minor">
+        <a href="{{wiki.changelog}}" target="_blank" rel="noopener noreferrer">{{
+            localize "lancer.help.full-changelog"
+          }}</a>
+      </p>
+    </section>
+  {{/if}}
+
+  <section id="help-topic-cloud-import" class="lancer-help-topic">
+    <h2>{{localize "lancer.help.topics.cloud-import.title"}}</h2>
+    <p>{{localize "lancer.help.topics.cloud-import.body"}}</p>
+  </section>
+
+  <section id="help-topic-automation" class="lancer-help-topic">
+    <h2>{{localize "lancer.help.topics.automation.title"}}</h2>
+    <p>{{localize "lancer.help.topics.automation.body"}}</p>
+  </section>
+
+  <section id="help-topic-accdiff" class="lancer-help-topic">
+    <h2>{{localize "lancer.help.topics.accdiff.title"}}</h2>
+    <p>{{localize "lancer.help.topics.accdiff.body"}}</p>
+  </section>
+
+  <h2>{{localize "lancer.help.basic-workflows"}}</h2>
   <span>
     <p>
       First, make sure you have your LANCER data imported properly via the compendium manager in the "Compendiums" tab.
       If you have non-core content you want to use in your game, this would be the place to do it as well.
     </p>
     <p>
-      Next, go to the Actors tab and create any PCs you want to use. You can either import from COMP/CON using the
-      RM-4://SYNC tab, or manually build it out yourself. NPCs have to be manually built out for now.
+      Next, go to the Actors tab and create any PCs you want to use. You can either import from COMP/CON using the Cloud
+      tab, or manually build it out yourself. NPCs have to be manually built out for now.
     </p>
     <p>To manually build out an actor, there are two steps:</p>
     <ol>
@@ -21,24 +63,24 @@
     </ol>
   </span>
 
-  <h2>Helpful Links</h2>
+  <h2>{{localize "lancer.help.helpful-links"}}</h2>
   <ul>
     <li>
       <i class="fas fa-question"></i>
-      <a href="https://github.com/VacantFanatic/foundryvtt-lancer/wiki/FAQ">FAQ</a>
+      <a href="{{wiki.faq}}">{{localize "lancer.help.links.faq"}}</a>
     </li>
     <li>
       <i class="fas fa-cube"></i>
-      <a href="https://github.com/VacantFanatic/foundryvtt-lancer/wiki/Recommended-Modules">Suggested Modules</a>
+      <a href="{{wiki.resources}}">{{localize "lancer.help.links.modules"}}</a>
     </li>
     <li>
       <i class="fas fa-bug"></i>
       <a href="https://github.com/VacantFanatic/foundryvtt-lancer/issues">
-        Bug reports and enhancement suggestions</a>
+        {{localize "lancer.help.links.issues"}}</a>
     </li>
     <li>
       <i class="fab fa-discord"></i>
-      <a href="https://discord.gg/drxVfR3vDn">PilotNET Community on Discord</a>
+      <a href="https://discord.gg/drxVfR3vDn">{{localize "lancer.help.links.discord"}}</a>
     </li>
   </ul>
 </div>

--- a/public/tours/attack-dialog.json
+++ b/public/tours/attack-dialog.json
@@ -6,27 +6,33 @@
   "steps": [
     {
       "id": "accuracy",
-      "selector": "#hudzone #accdiff .accdiff-grid div:nth-child(1)",
+      "selector": "#hudzone #accdiff .accdiff-grid__section:nth-of-type(2) .accdiff-grid__column:first-child",
       "title": "lancer.tour.attack-dialog.accuracy.title",
       "content": "lancer.tour.attack-dialog.accuracy.content"
     },
     {
       "id": "difficulty",
-      "selector": "#hudzone #accdiff .accdiff-grid div:nth-child(2)",
+      "selector": "#hudzone #accdiff .accdiff-grid__section:nth-of-type(2) .accdiff-grid__column:last-child",
       "title": "lancer.tour.attack-dialog.difficulty.title",
       "content": "lancer.tour.attack-dialog.difficulty.content"
     },
     {
-      "id": "template",
-      "selector": "#hudzone #accdiff .lancer-header .range-button",
-      "title": "lancer.tour.attack-dialog.template.title",
-      "content": "lancer.tour.attack-dialog.template.content"
-    },
-    {
-      "id": "targeting",
-      "selector": "#hudzone #accdiff div.accdiff-footer",
+      "id": "targets",
+      "selector": "#hudzone #accdiff .accdiff-footer",
       "title": "lancer.tour.attack-dialog.targeting.title",
       "content": "lancer.tour.attack-dialog.targeting.content"
+    },
+    {
+      "id": "advanced",
+      "selector": "#hudzone #accdiff .accdiff-advanced-toggle",
+      "title": "lancer.tour.attack-dialog.advanced.title",
+      "content": "lancer.tour.attack-dialog.advanced.content"
+    },
+    {
+      "id": "template",
+      "selector": "#hudzone #accdiff .accdiff-advanced .range-button",
+      "title": "lancer.tour.attack-dialog.template.title",
+      "content": "lancer.tour.attack-dialog.template.content"
     },
     {
       "id": "finish",
@@ -35,26 +41,30 @@
       "content": "lancer.tour.attack-dialog.finish.content"
     }
   ],
-  "suggestedNextTours": [],
+  "suggestedNextTours": ["lancer.combat"],
   "localization": {
     "lancer.tour.attack-dialog": {
       "title": "Attack Dialog",
       "description": "Using the LANCER sliding HUD attack dialog",
       "accuracy": {
         "title": "Accuracy",
-        "content": "Confirm the Accuracy bonuses here"
+        "content": "Confirm the Accuracy bonuses here. The default view focuses on targets, totals, and cover."
       },
       "difficulty": {
         "title": "Difficulty",
-        "content": "Confirm any Difficulty penalties here"
-      },
-      "template": {
-        "title": "Place a Measured Template",
-        "content": "If the attack is an AoE attack, this button will allow you to place a measured template. Scrollwheel rotates the template and left click confirms placement. Targets will be automatically selected when to template is placed."
+        "content": "Confirm any Difficulty penalties here."
       },
       "targeting": {
         "title": "Targets",
         "content": "Any targets, whether manually selected or automatically selected using a template will appear here allowing individual bonuses and penalties to be applied as necessary."
+      },
+      "advanced": {
+        "title": "Advanced section",
+        "content": "Weapon and target plugins, measured templates, and per-target fine modifiers live under <strong>Advanced</strong>. A client setting can remember whether Advanced stays open per weapon."
+      },
+      "template": {
+        "title": "Place a Measured Template",
+        "content": "If the attack is an AoE attack, this button will allow you to place a measured template. Scrollwheel rotates the template and left click confirms placement. Targets will be automatically selected when the template is placed."
       },
       "finish": {
         "title": "Finishing up",

--- a/public/tours/npc.json
+++ b/public/tours/npc.json
@@ -43,6 +43,18 @@
       "selector": ".tour-npc [data-npc-section='class-templates'] .npc-template-column",
       "title": "lancer.tour.npc.npcTemplates.title",
       "content": "lancer.tour.npc.npcTemplates.content"
+    },
+    {
+      "id": "featuresTab",
+      "selector": ".tour-npc nav.lancer-tabs [data-tab='features']",
+      "title": "lancer.tour.npc.featuresTab.title",
+      "content": "lancer.tour.npc.featuresTab.content"
+    },
+    {
+      "id": "featuresList",
+      "selector": ".tour-npc [data-npc-section='features']",
+      "title": "lancer.tour.npc.featuresList.title",
+      "content": "lancer.tour.npc.featuresList.content"
     }
   ],
   "suggestedNextTours": ["lancer.pilot-import"],
@@ -73,6 +85,14 @@
       "npcTemplates": {
         "title": "NPC Templates",
         "content": "NPC Templates can be added by dragging them to the sheet. All base features will be added and any desired optional features can be added by dragging them from the Template sheet, similar to Class features."
+      },
+      "featuresTab": {
+        "title": "Features tab",
+        "content": "The NPC sheet uses <strong>Stats | Features | Effects</strong> tabs. Feature drag-sort and recharge controls live on the Features tab."
+      },
+      "featuresList": {
+        "title": "Feature list",
+        "content": "Equipped features appear here. Drag to reorder; use the recharge button to reset limited-use features at the start of a turn."
       }
     }
   }

--- a/public/tours/pilot-import.json
+++ b/public/tours/pilot-import.json
@@ -33,6 +33,13 @@
       "sidebarTab": "actors"
     },
     {
+      "id": "clickToEquip",
+      "selector": "#LancerPilotSheet-Actor-TOUR0PILOT000000 div[data-tab='narrative'] .ref.slot.click-settable",
+      "title": "lancer.tour.pilot-import.clickToEquip.title",
+      "content": "lancer.tour.pilot-import.clickToEquip.content",
+      "sidebarTab": "actors"
+    },
+    {
       "id": "folders",
       "selector": "#sidebar #actors header button.create-folder",
       "title": "lancer.tour.pilot-import.folders.title",
@@ -66,7 +73,11 @@
       },
       "download": {
         "title": "Download",
-        "content": "One a share code has been entered or a pilot selected in the dropdown, this button will start the process of syncing."
+        "content": "Once a share code has been entered or a pilot selected in the dropdown, this button will start the process of syncing."
+      },
+      "clickToEquip": {
+        "title": "Click to equip",
+        "content": "Empty loadout slots show a drag-or-click hint. Click a slot to open a filtered compendium picker, or drag items from compendiums as before."
       },
       "folders": {
         "title": "Folders",

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -54,6 +54,7 @@ import { LancerActiveEffect } from "./module/effects/lancer-active-effect";
 import { EntryType } from "./module/enums";
 import { targetsFromTemplate } from "./module/flows/_template";
 import { registerHandlebarsHelpers } from "./module/helpers";
+import { showLancerHelp } from "./module/helpers/help";
 import { disableLancerInitiative, handleCombatUpdate } from "./module/helpers/automation/combat";
 import { gridDist } from "./module/helpers/automation/targeting";
 import { applyCollapseListeners, initializeCollapses } from "./module/helpers/collapse";
@@ -1068,26 +1069,6 @@ function addSettingsButtons(_app: foundry.applications.sidebar.tabs.Settings, ht
   });
 
   faqButton.on("click", async () => {
-    let helpContent = await foundry.applications.handlebars.renderTemplate(
-      `systems/${game.system.id}/templates/window/lancerHelp.hbs`,
-      {}
-    );
-
-    new foundry.applications.api.DialogV2({
-      window: {
-        title: `LANCER Help`,
-        icon: "fas fa-robot",
-      },
-      content: helpContent,
-      position: {
-        width: 600,
-      },
-      buttons: [
-        {
-          action: "close",
-          label: "Close",
-        },
-      ],
-    }).render(true);
+    await showLancerHelp();
   });
 }

--- a/src/module/actor/pilot-sheet.ts
+++ b/src/module/actor/pilot-sheet.ts
@@ -22,6 +22,7 @@ import type { ResolvedDropData } from "../helpers/dragdrop";
 import { EntryType } from "../enums";
 import type { PackedPilotData } from "../util/unpacking/packed-types";
 import { importCC, showImportResultDialog } from "./import";
+import { bindContextualHelpActions, renderContextualHelp } from "../helpers/help";
 
 const shareCodeMatcherV2 = /^[A-Z0-9]{6}$/;
 const shareCodeMatcherV3 = /^[A-Z0-9]{12}$/;
@@ -225,6 +226,8 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
         else ui.notifications!.warn(game.i18n.localize("lancer.pilot-sheet.cloud-wizard.tour-missing"));
       });
 
+    bindContextualHelpActions($el);
+
     $el.find<HTMLInputElement>("input#pilot-json-import").on("change", ev => this._onPilotJsonUpload(ev));
 
     $el.find(".activate-mech").on("click", async ev => {
@@ -309,11 +312,17 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
     options: Partial<foundry.applications.types.ApplicationRenderOptions>
   ): Promise<LancerActorSheetData<EntryType.PILOT>> {
     const data = (await super._prepareContext(options)) as LancerActorSheetData<EntryType.PILOT>;
+    const pilot = this.actor as LancerPILOT;
 
     data.compConLoggedIn = await isCompconLoggedIn();
     data.compConPilotCount = pilotCache().length;
     data.showSyncBanner =
       pilot.system.last_cloud_update === "never" && !(pilot.getFlag("lancer", "dismissSyncBanner") as boolean);
+    data.cloudHelpHtml = await renderContextualHelp({
+      topic: "cloud-import",
+      messageKey: "lancer.help.context.cloud-import",
+      tourKey: "pilot-import",
+    });
     data.compConPilotList = pilotCache()
       .sort((p1, p2) => {
         if (p1.callsign < p2.callsign) return -1;

--- a/src/module/apps/acc_diff/AccDiffHUD.svelte
+++ b/src/module/apps/acc_diff/AccDiffHUD.svelte
@@ -25,6 +25,7 @@
   import { LANCER } from "../../config";
   import { onMount } from "svelte";
   import { hudL, hudT } from "../../helpers/hud-i18n";
+  import { hasSeenAccdiffHelp, markAccdiffHelpSeen, showLancerHelp, startSystemTour } from "../../helpers/help";
   import { hudModal } from "../slidinghud/hud-modal";
 
   export let weapon: AccDiffHudWeapon;
@@ -56,6 +57,7 @@
   const dispatch = createEventDispatcher();
   let submitted = false;
   let showAdvanced = false;
+  let showFirstOpenHelp = false;
 
   $: hasAdvancedContent =
     kind === "attack" &&
@@ -96,7 +98,13 @@
 
   onMount(() => {
     loadAdvancedPreference();
+    showFirstOpenHelp = kind === "attack" && !hasSeenAccdiffHelp();
   });
+
+  async function dismissFirstOpenHelp() {
+    showFirstOpenHelp = false;
+    await markAccdiffHelpSeen();
+  }
 
   let rollerName = lancerActor ? ` -- ${lancerActor.token?.name || lancerActor.name}` : "";
 
@@ -258,6 +266,33 @@
     dispatch("submit");
   }}
 >
+  {#if showFirstOpenHelp}
+    <aside class="lancer-contextual-help" data-help-topic="accdiff">
+      <i class="fas fa-circle-info" aria-hidden="true"></i>
+      <p class="minor desc-text grow">{game.i18n.localize("lancer.help.context.accdiff")}</p>
+      <button
+        type="button"
+        class="lancer-button lancer-secondary"
+        on:click={() => showLancerHelp({ topic: "accdiff" })}
+      >
+        <i class="fas fa-book-open"></i>
+        {game.i18n.localize("lancer.help.open-help")}
+      </button>
+      <button type="button" class="lancer-button" on:click={() => startSystemTour("attack-dialog")}>
+        <i class="fas fa-route"></i>
+        {game.i18n.localize("lancer.help.start-tour")}
+      </button>
+      <button
+        type="button"
+        class="lancer-button lancer-contextual-help-dismiss"
+        on:click={dismissFirstOpenHelp}
+        aria-label={game.i18n.localize("lancer.help.dismiss")}
+        data-tooltip={game.i18n.localize("lancer.help.dismiss")}
+      >
+        <i class="fas fa-times"></i>
+      </button>
+    </aside>
+  {/if}
   {#if title != ""}
     <div class="lancer-header {isTech() ? 'lancer-tech' : 'lancer-weapon'} medium">
       {#if kind == "attack"}

--- a/src/module/apps/automation-settings.ts
+++ b/src/module/apps/automation-settings.ts
@@ -1,5 +1,6 @@
 import type { DeepPartial } from "fvtt-types/utils";
 import { LANCER } from "../config";
+import { bindContextualHelpActions, renderContextualHelp } from "../helpers/help";
 import { AutomationOptions } from "../settings";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
@@ -45,6 +46,11 @@ export class AutomationConfig extends HandlebarsApplicationMixin(ApplicationV2<{
     const ctx = {
       config: opts.loadDefault ? new AutomationOptions() : opts.loadEmpty ? blank : config,
       fields: config.schema.fields,
+      automationHelpHtml: await renderContextualHelp({
+        topic: "automation",
+        messageKey: "lancer.help.context.automation",
+        tourKey: "combat",
+      }),
       buttons: [
         { type: "submit", name: "submit", icon: "fas fa-save", label: "Save" },
         { type: "button", name: "reset", icon: "fas fa-undo", label: "SETTINGS.Reset", action: "onReset" },
@@ -67,5 +73,10 @@ export class AutomationConfig extends HandlebarsApplicationMixin(ApplicationV2<{
 
   static async #loadEmpty(this: AutomationConfig) {
     this.render(false, { loadEmpty: true });
+  }
+
+  protected override _onRender(context: object, options: Record<string, unknown>) {
+    super._onRender(context, options);
+    bindContextualHelpActions($(this.element));
   }
 }

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -63,6 +63,7 @@ export const LANCER = {
   setting_tag_config: "tagConfig",
   setting_accdiff_remember_advanced: "accdiffRememberAdvanced",
   setting_accdiff_advanced_expanded: "accdiffAdvancedExpanded",
+  setting_help_seen_accdiff: "helpSeenAccdiff",
   // setting_120: "warningFor120", // Old setting, currently unused.
   // setting_beta_warning: "warningForBeta", // Old setting, currently unused.
 } as const;

--- a/src/module/helpers/help.ts
+++ b/src/module/helpers/help.ts
@@ -1,0 +1,174 @@
+import changelogRaw from "../../../CHANGELOG.md?raw";
+import { LANCER } from "../config";
+
+export interface ChangelogSection {
+  title: string;
+  items: string[];
+}
+
+export interface ChangelogRelease {
+  version: string;
+  date: string;
+  sections: ChangelogSection[];
+}
+
+const HELP_WIKI = {
+  faq: "https://github.com/VacantFanatic/foundryvtt-lancer/wiki/FAQ",
+  resources: "https://github.com/VacantFanatic/foundryvtt-lancer/wiki/Recommended-Modules",
+  changelog: "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/CHANGELOG.md",
+} as const;
+
+export type HelpTopic = "cloud-import" | "automation" | "accdiff";
+
+function formatChangelogItem(text: string): string {
+  return text.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>").replace(/`([^`]+)`/g, "<code>$1</code>");
+}
+
+export function parseChangelogRecent(raw: string, maxReleases = 3): ChangelogRelease[] {
+  const releases: ChangelogRelease[] = [];
+  const lines = raw.split("\n");
+  let i = 0;
+
+  while (i < lines.length && releases.length < maxReleases) {
+    const header = lines[i].match(/^# (\d+\.\d+\.\d+) \(([^)]+)\)/);
+    if (!header) {
+      i++;
+      continue;
+    }
+
+    const release: ChangelogRelease = { version: header[1], date: header[2], sections: [] };
+    i++;
+
+    let currentSection: ChangelogSection | null = null;
+    while (i < lines.length && !lines[i].match(/^# \d+\.\d+\.\d+/)) {
+      const sectionMatch = lines[i].match(/^## (.+)/);
+      if (sectionMatch) {
+        currentSection = { title: sectionMatch[1], items: [] };
+        release.sections.push(currentSection);
+      } else if (lines[i].startsWith("- ") && currentSection) {
+        currentSection.items.push(formatChangelogItem(lines[i].slice(2)));
+      }
+      i++;
+    }
+
+    releases.push(release);
+  }
+
+  return releases;
+}
+
+export function getRecentChangelog(maxReleases = 3): ChangelogRelease[] {
+  return parseChangelogRecent(changelogRaw, maxReleases);
+}
+
+export async function showLancerHelp(options?: { topic?: HelpTopic }): Promise<void> {
+  const helpContent = await foundry.applications.handlebars.renderTemplate(
+    `systems/${game.system.id}/templates/window/lancerHelp.hbs`,
+    {
+      releases: getRecentChangelog(3),
+      wiki: HELP_WIKI,
+      focusTopic: options?.topic ?? null,
+    }
+  );
+
+  const dlg = new foundry.applications.api.DialogV2({
+    window: {
+      title: game.i18n.localize("lancer.help.dialog-title"),
+      icon: "fas fa-robot",
+    },
+    content: helpContent,
+    position: { width: 640 },
+    buttons: [{ action: "close", label: game.i18n.localize("Close") }],
+  });
+
+  await dlg.render(true);
+
+  if (options?.topic) {
+    requestAnimationFrame(() => {
+      dlg.element?.querySelector(`#help-topic-${options.topic}`)?.scrollIntoView({ block: "start" });
+    });
+  }
+}
+
+export async function startSystemTour(tourKey: string): Promise<void> {
+  const tour = game.tours.get(`${game.system.id}.${tourKey}`);
+  if (tour) await tour.start();
+  else ui.notifications!.warn(game.i18n.format("lancer.help.tour-missing", { tour: tourKey }));
+}
+
+export function hasSeenAccdiffHelp(): boolean {
+  return !!game.settings.get(game.system.id, LANCER.setting_help_seen_accdiff);
+}
+
+export async function markAccdiffHelpSeen(): Promise<void> {
+  await game.settings.set(game.system.id, LANCER.setting_help_seen_accdiff, true);
+}
+
+export function helpWikiUrl(topic: HelpTopic): string {
+  switch (topic) {
+    case "cloud-import":
+      return HELP_WIKI.faq;
+    case "automation":
+      return HELP_WIKI.faq;
+    case "accdiff":
+      return HELP_WIKI.faq;
+  }
+}
+
+export interface ContextualHelpOptions {
+  topic: HelpTopic;
+  messageKey: string;
+  showHelpButton?: boolean;
+  wikiUrl?: string;
+  tourKey?: string;
+  dismissible?: boolean;
+  dismissSetting?: string;
+}
+
+export async function renderContextualHelp(options: ContextualHelpOptions): Promise<string> {
+  return foundry.applications.handlebars.renderTemplate(
+    `systems/${game.system.id}/templates/window/contextual-help.hbs`,
+    {
+      topic: options.topic,
+      message: game.i18n.localize(options.messageKey),
+      showHelpButton: options.showHelpButton ?? true,
+      wikiUrl: options.wikiUrl ?? helpWikiUrl(options.topic),
+      tourKey: options.tourKey ?? null,
+      dismissible: options.dismissible ?? false,
+      dismissKey: options.dismissSetting ?? null,
+    }
+  );
+}
+
+export function bindContextualHelpActions(html: JQuery): void {
+  html
+    .find('[data-action="openLancerHelp"]')
+    .off("click.lancerHelp")
+    .on("click.lancerHelp", async ev => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      const topic = (ev.currentTarget as HTMLElement).dataset.helpTopic as HelpTopic | undefined;
+      await showLancerHelp(topic ? { topic } : undefined);
+    });
+
+  html
+    .find('[data-action="startSystemTour"]')
+    .off("click.lancerTour")
+    .on("click.lancerTour", async ev => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      const tourKey = (ev.currentTarget as HTMLElement).dataset.tourKey;
+      if (tourKey) await startSystemTour(tourKey);
+    });
+
+  html
+    .find('[data-action="dismissContextualHelp"]')
+    .off("click.lancerHelpDismiss")
+    .on("click.lancerHelpDismiss", async ev => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      const key = (ev.currentTarget as HTMLElement).dataset.helpDismiss;
+      if (key) await game.settings.set(game.system.id, key, true);
+      (ev.currentTarget as HTMLElement).closest(".lancer-contextual-help")?.remove();
+    });
+}

--- a/src/module/interfaces.ts
+++ b/src/module/interfaces.ts
@@ -54,6 +54,7 @@ export interface LancerActorSheetData<T extends LancerActorType> {
   compConLoggedIn?: boolean;
   compConPilotCount?: number;
   showSyncBanner?: boolean;
+  cloudHelpHtml?: string;
   cleanedOwnerID?: string;
   vaultID?: string;
   rawID?: string;

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -71,6 +71,13 @@ export const registerSettings = function () {
     default: {},
   });
 
+  game.settings.register(game.system.id, LANCER.setting_help_seen_accdiff, {
+    scope: "client",
+    config: false,
+    type: Boolean,
+    default: false,
+  });
+
   game.settings.register(game.system.id, LANCER.setting_autoanimations_enabled, {
     name: "lancer.autoAnimations.enabled.name",
     hint: "lancer.autoAnimations.enabled.hint",

--- a/src/module/tours/lancer-tour.ts
+++ b/src/module/tours/lancer-tour.ts
@@ -129,6 +129,9 @@ export class LancerPilotTour extends LancerTour {
       const settings = new foundry.applications.settings.SettingsConfig();
       await settings.render({ force: true });
       settings.changeTab("system", "categories");
+    } else if (this.currentStep?.id === "clickToEquip") {
+      await this.actor?.sheet?.["_render"](true);
+      this.actor?.sheet?.["activateTab"]("narrative");
     } else {
       await this.actor?.sheet?.["_render"](true);
       this.actor?.sheet?.["activateTab"]("cloud");
@@ -172,7 +175,11 @@ export class LancerNPCTour extends LancerTour {
     }
     const npcSheet = this.npc.sheet;
     await npcSheet?.["_render"](true);
-    npcSheet?.["changeTab"]?.("stats", "primary", { force: true });
+    if (["featuresTab", "featuresList"].includes(this.currentStep?.id!)) {
+      npcSheet?.["changeTab"]?.("features", "primary", { force: true });
+    } else {
+      npcSheet?.["changeTab"]?.("stats", "primary", { force: true });
+    }
     const el = npcSheet instanceof foundry.applications.api.ApplicationV2 ? npcSheet.element : npcSheet?.element[0];
     el?.classList.add("tour-npc");
     if (["baseFeatures", "optionalFeatures"].includes(this.currentStep?.id!)) {
@@ -234,6 +241,13 @@ export class LancerSlidingHudTour extends LancerTour {
     }
     this.npc?.itemTypes[EntryType.NPC_FEATURE][0].beginWeaponAttackFlow();
     await new Promise(resolve => setTimeout(resolve, 100));
+    if (["template", "advanced"].includes(this.currentStep?.id!)) {
+      const toggle = document.querySelector<HTMLElement>("#hudzone #accdiff .accdiff-advanced-toggle button");
+      if (toggle && !document.querySelector("#hudzone #accdiff .accdiff-advanced")) {
+        toggle.click();
+        await new Promise(resolve => setTimeout(resolve, 50));
+      }
+    }
   }
 
   protected async _tearDown() {

--- a/src/module/tours/register-tours.ts
+++ b/src/module/tours/register-tours.ts
@@ -1,4 +1,4 @@
-import { LancerCombatTour, LancerLcpTour, LancerNPCTour, LancerPilotTour } from "./lancer-tour";
+import { LancerCombatTour, LancerLcpTour, LancerNPCTour, LancerPilotTour, LancerSlidingHudTour } from "./lancer-tour";
 
 export async function registerTours() {
   game.tours.register(
@@ -20,5 +20,10 @@ export async function registerTours() {
     game.system.id,
     "combat",
     await LancerCombatTour.fromJSON(`./systems/${game.system.id}/tours/combat.json`)
+  );
+  game.tours.register(
+    game.system.id,
+    "attack-dialog",
+    await LancerSlidingHudTour.fromJSON(`./systems/${game.system.id}/tours/attack-dialog.json`)
   );
 }

--- a/src/styles/_applications.scss
+++ b/src/styles/_applications.scss
@@ -6,6 +6,7 @@
 @use "applications/item-sheet";
 @use "applications/stabilize";
 @use "applications/rich-editor";
+@use "applications/help";
 
 @layer lancer.applications {
   /* ===== RULES FOR LANCER APPLICATIONS ===== */

--- a/src/styles/applications/_help.scss
+++ b/src/styles/applications/_help.scss
@@ -1,0 +1,70 @@
+@layer lancer.applications {
+  .lancerHelpPage {
+    .lancer-help-whats-new {
+      margin-bottom: 1rem;
+      padding-bottom: 0.75rem;
+      border-bottom: 1px solid var(--color-border-light-tertiary);
+    }
+
+    .lancer-help-release {
+      margin-bottom: 0.75rem;
+
+      &-version {
+        margin: 0.25rem 0;
+        font-size: var(--font-size-16);
+      }
+
+      h4 {
+        margin: 0.35rem 0 0.15rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      ul {
+        margin: 0 0 0.5rem 1.25rem;
+        padding: 0;
+      }
+    }
+
+    .lancer-help-topic {
+      margin: 1rem 0;
+      padding: 0.5rem 0;
+      border-bottom: 1px solid var(--color-border-light-tertiary);
+    }
+  }
+
+  .lancer-contextual-help {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem 0.65rem;
+    border: 1px solid var(--color-border-light-tertiary);
+    border-radius: 3px;
+    background: var(--color-bg-option);
+
+    > i {
+      color: var(--color-text-hyperlink);
+      flex-shrink: 0;
+    }
+
+    p {
+      margin: 0;
+      flex: 1 1 12rem;
+    }
+
+    .lancer-contextual-help-dismiss {
+      margin-left: auto;
+      padding: 0.25rem 0.5rem;
+    }
+  }
+
+  #lancer-automation-settings .lancer-contextual-help {
+    margin-bottom: 0.75rem;
+  }
+
+  #accdiff .lancer-contextual-help {
+    margin: 0.35rem 0.5rem 0;
+  }
+}

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "compatibility": {
     "minimum": 13,
     "verified": 14,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md?raw" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sprint **F** release **v2.17.0** — bundles UX roadmap PRs **#22–#24** (milestone [#48](https://github.com/VacantFanatic/foundryvtt-lancer/issues/48)).

### Contextual help links (#22)
- Pilot **Cloud tab** banner with help, wiki, and pilot-import tour links
- **Automation settings** banner with help, wiki, and combat tour links
- **Acc/Diff HUD** first-open banner (dismissible via client setting `helpSeenAccdiff`)

### What's new in help dialog (#23)
- Help dialog parses bundled `CHANGELOG.md` and shows the **3 most recent releases**
- Topic sections for cloud import, automation, and Acc/Diff
- `showLancerHelp({ topic })` scrolls to the matching section

### Guided tour maintenance (#24)
- **Attack-dialog** tour registered (`LancerSlidingHudTour`); selectors updated for Acc/Diff Advanced layout
- **Pilot-import** tour: new **click-to-equip** step on narrative loadout slots
- **NPC** tour: **Features tab** steps for tabbed sheet layout
- Sliding HUD tour auto-expands Advanced before template step

## Other fixes

- Fixed undefined `pilot` reference in `LancerPilotSheet._prepareContext` (pre-existing bug)

## Version

- `2.17.0` in `package.json` and `system.json`
- CHANGELOG updated per Keep a Changelog

## Testing

- `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build` — pass
- `npm run test:e2e` — **7/7** passed (Firefox)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

