### PR TITLE
chore(ux-roadmap): close completed tracking issues

### DIFF
--- a/.github/workflows/ux-roadmap-close-issues.yml
+++ b/.github/workflows/ux-roadmap-close-issues.yml
@@ -1,0 +1,38 @@
+# Close completed UX Roadmap 2026 tracking issues (shipped in PRs #92–#102).
+#
+# Run manually after release PRs merge. Uses GITHUB_TOKEN (issues: write).
+# Optional: set UX_ROADMAP_GH_TOKEN if the default token lacks issue permissions.
+name: UX Roadmap close completed issues
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Dry run (list issues only, do not close)
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Close completed UX roadmap issues
+        env:
+          GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN || github.token }}
+        run: |
+          FLAGS=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            FLAGS="--dry-run"
+          fi
+          node scripts/ux-roadmap/close-completed-issues.mjs $FLAGS

--- a/scripts/ux-roadmap/README.md
+++ b/scripts/ux-roadmap/README.md
@@ -62,6 +62,17 @@ Enable **Status** field (built-in) for Todo / In Progress / Done.
 
 Re-run `bootstrap.mjs` as repo owner to create labels, milestones, the GitHub Project, and refresh epic/release bodies with cross-links.
 
+## Close completed tracking issues
+
+After release PRs merge, close stale roadmap issues with a comment linking the shipping PR:
+
+```bash
+node scripts/ux-roadmap/close-completed-issues.mjs --dry-run
+node scripts/ux-roadmap/close-completed-issues.mjs
+```
+
+**Cursor cloud / limited tokens:** run the **UX Roadmap close completed issues** workflow (`workflow_dispatch`) — it uses `GITHUB_TOKEN` with `issues: write`, or `UX_ROADMAP_GH_TOKEN` if set.
+
 ## Cursor cloud agents
 
 Implementation branches: `cursor/ux-<slug>-4b38`\

--- a/scripts/ux-roadmap/close-completed-issues.mjs
+++ b/scripts/ux-roadmap/close-completed-issues.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Close UX Roadmap 2026 tracking issues that shipped in merged release PRs.
+ * Idempotent: skips issues already closed.
+ *
+ *   node scripts/ux-roadmap/close-completed-issues.mjs
+ *   node scripts/ux-roadmap/close-completed-issues.mjs --dry-run
+ */
+import { execFileSync } from "node:child_process";
+
+const REPO = "VacantFanatic/foundryvtt-lancer";
+const dryRun = process.argv.includes("--dry-run");
+
+const MERGED = {
+  40: "Test issue — safe to close.",
+  41: "Test issue — safe to close.",
+  42: "Duplicate UX epic (#43 is canonical).",
+  43: "UX Roadmap 2026 complete through v3.0.0 (PRs #92–#102).",
+  44: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/92 (v2.12.11).",
+  45: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/93 (v2.13.0).",
+  46: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/97 (v2.14.0).",
+  47: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/98 (v2.15.0).",
+  48: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/99 (v2.16.0).",
+  49: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/100 (v2.17.0).",
+  50: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (v2.18.0, Sprint G).",
+  51: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (v2.19.0, Sprint G).",
+  52: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (v2.20.0, Sprint G).",
+  53: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/102 (v3.0.0).",
+  60: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/93 (PR7).",
+  61: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/93 (PR8).",
+  62: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/93 (PR9).",
+  64: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/97 (PR11).",
+  65: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/97 (PR12).",
+  67: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/98 (PR14).",
+  68: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/98 (PR15).",
+  69: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/99 (PR16).",
+  70: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/99 (PR17).",
+  71: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/99 (PR18).",
+  72: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/99 (PR19).",
+  73: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/99 (PR20).",
+  74: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/99 (PR21).",
+  75: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/100 (PR22).",
+  76: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/100 (PR23).",
+  77: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/100 (PR24).",
+  78: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (PR25).",
+  79: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (PR26).",
+  80: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (PR27).",
+  81: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (PR28).",
+  82: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (PR29).",
+  83: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (PR30).",
+  84: "Shipped in https://github.com/VacantFanatic/foundryvtt-lancer/pull/101 (PR31).",
+};
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8" }).trim();
+}
+
+function issueState(num) {
+  try {
+    const json = gh(["issue", "view", String(num), "-R", REPO, "--json", "state,title"]);
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+let closed = 0;
+let skipped = 0;
+
+for (const [num, reason] of Object.entries(MERGED).sort((a, b) => Number(a[0]) - Number(b[0]))) {
+  const n = Number(num);
+  const info = issueState(n);
+  if (!info) {
+    console.warn(`skip #${n}: not found`);
+    skipped++;
+    continue;
+  }
+  if (info.state === "CLOSED") {
+    console.log(`skip #${n} (already closed): ${info.title}`);
+    skipped++;
+    continue;
+  }
+
+  const body = `Closing as completed — implementation merged.\n\n${reason}\n\n_(Automated UX roadmap cleanup.)_`;
+  console.log(`${dryRun ? "[dry-run] close" : "close"} #${n}: ${info.title}`);
+
+  if (!dryRun) {
+    try {
+      gh(["issue", "comment", String(n), "-R", REPO, "--body", body]);
+    } catch (e) {
+      console.warn(`warn #${n}: comment failed (${e.message?.split("\n")[0] ?? e})`);
+    }
+    gh(["issue", "close", String(n), "-R", REPO, "--reason", "completed"]);
+    closed++;
+  }
+}
+
+console.log(`\nDone. closed=${closed} skipped=${skipped} dryRun=${dryRun}`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds automation to bulk-close UX Roadmap 2026 tracking issues that shipped in merged release PRs (#92–#102).

## Changes

- `scripts/ux-roadmap/close-completed-issues.mjs` — idempotent closer with PR links in comments (issues #40–#53, #60–#84)
- `.github/workflows/ux-roadmap-close-issues.yml` — manual `workflow_dispatch` runner using `GITHUB_TOKEN` (`issues: write`)
- `scripts/ux-roadmap/README.md` — documents local and CI usage

## Usage

After merge, run **UX Roadmap close completed issues** from Actions (or locally with `gh` + repo write access).

```bash
node scripts/ux-roadmap/close-completed-issues.mjs --dry-run
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

