### PR TITLE
ci(ux-roadmap): auto-run issue closer on workflow update

### DIFF
--- a/.github/workflows/ux-roadmap-close-issues.yml
+++ b/.github/workflows/ux-roadmap-close-issues.yml
@@ -12,6 +12,10 @@ on:
         required: false
         default: false
         type: boolean
+  push:
+    branches: [master]
+    paths:
+      - .github/workflows/ux-roadmap-close-issues.yml
 
 permissions:
   issues: write
@@ -32,7 +36,7 @@ jobs:
           GH_TOKEN: ${{ secrets.UX_ROADMAP_GH_TOKEN || github.token }}
         run: |
           FLAGS=""
-          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
             FLAGS="--dry-run"
           fi
           node scripts/ux-roadmap/close-completed-issues.mjs $FLAGS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Triggers **UX Roadmap close completed issues** when the workflow file is pushed to `master`, so the bulk close runs without manual `workflow_dispatch` (Cursor integration tokens cannot dispatch workflows).

Manual dry-run remains available via `workflow_dispatch` with `dry_run: true`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5743953b-0e0f-45f4-96e9-d91577f44b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

