### PR TITLE
feat(mech-sheet): persistent combat dock (3.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.0.1 (2026-06-07)
+
+## Added
+
+- **Persistent combat dock** on the mech sheet — HP, Heat, Structure, Stress, Overcharge, Core, action tracker, and attack utilities stay visible across all tabs.
+
+## Changed
+
+- **Attack utilities** (Melee/Ranged, Damage, Tech) moved from the Loadout tab into the combat dock.
+
 # 3.0.0 (2026-06-07)
 
 ## Added

--- a/e2e/fixtures/lancer-dev-test/world.json
+++ b/e2e/fixtures/lancer-dev-test/world.json
@@ -2,11 +2,12 @@
   "title": "Lancer Dev Test",
   "system": "lancer",
   "id": "lancer-dev-test",
+  "coreVersion": "14.363",
   "compatibility": {
     "minimum": "14",
     "verified": "14"
   },
-  "systemVersion": "2.13.0",
+  "systemVersion": "3.0.1",
   "description": "Minimal world for Lancer Playwright E2E regression tests.",
   "flags": {}
 }

--- a/e2e/helpers/foundry.ts
+++ b/e2e/helpers/foundry.ts
@@ -98,8 +98,9 @@ export async function completeFoundrySetup(page: Page, worldId = FOUNDRY_WORLD_I
   }
 
   if (page.url().includes("/setup")) {
-    await page.locator(`li.world[data-package-id="${worldId}"]`).waitFor({ state: "visible", timeout: 120_000 });
+    await dismissFoundryLaunchDialogs(page);
     await dismissFoundryTours(page);
+    await page.locator(`li.world[data-package-id="${worldId}"]`).waitFor({ state: "visible", timeout: 120_000 });
   }
 }
 

--- a/e2e/regression/mech-sheet-ux.spec.ts
+++ b/e2e/regression/mech-sheet-ux.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { joinLancerWorld } from "../helpers/foundry";
+import { openActorSheet, seedRegressionWorld } from "../helpers/seed";
+
+test.describe("Mech sheet UX @regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await joinLancerWorld(page);
+  });
+
+  test("combat dock is visible on every tab and loadout no longer has attack utilities", async ({ page }) => {
+    const { mechId } = await seedRegressionWorld(page);
+    await openActorSheet(page, mechId);
+
+    const dockVisible = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return false;
+      const root = actor.sheet.element as HTMLElement;
+      return !!root.querySelector(".mech-combat-dock");
+    }, mechId);
+    expect(dockVisible).toBe(true);
+
+    const loadoutAttackUtilities = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return { onLoadout: true, onDock: false };
+      actor.sheet.changeTab("loadout", "primary", { force: true });
+      const root = actor.sheet.element as HTMLElement;
+      const loadoutTab = root.querySelector('.tab.loadout[data-tab="loadout"]');
+      const dock = root.querySelector(".mech-combat-dock");
+      const loadoutButtons = loadoutTab?.querySelectorAll('[data-flow-type="BasicAttack"]') ?? [];
+      const dockButtons = dock?.querySelectorAll('[data-flow-type="BasicAttack"]') ?? [];
+      return { onLoadout: loadoutButtons.length > 0, onDock: dockButtons.length > 0 };
+    }, mechId);
+
+    expect(loadoutAttackUtilities.onDock).toBe(true);
+    expect(loadoutAttackUtilities.onLoadout).toBe(false);
+
+    const dockOnTalentsTab = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return false;
+      actor.sheet.changeTab("talents", "primary", { force: true });
+      const root = actor.sheet.element as HTMLElement;
+      return !!root.querySelector(".mech-combat-dock");
+    }, mechId);
+    expect(dockOnTalentsTab).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -132,6 +132,9 @@
         "combat": "COMBAT",
         "systems": "SYSTEMS"
       },
+      "combat-dock": {
+        "label": "Combat quick controls"
+      },
       "inventory": {
         "label": "View Inventory"
       },

--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -23,6 +23,8 @@
       </div>
     </header>
 
+    {{{mech-combat-dock}}}
+
     {{!-- Sheet Tab Navigation --}}
     <nav class="tabs lancer-tabs" data-group="primary">
       <a
@@ -160,14 +162,6 @@
 
     <div class="tab loadout {{tabs.primary.loadout.cssClass}}" data-group="primary" data-tab="loadout">
       {{{mech-frame "system.loadout.frame.value" system.core_energy}}}
-      <div class="card clipped">
-        <span class="lancer-header lancer-primary submajor">ATTACK UTILITIES</span>
-        <div class="lancer-flow-button-grid">
-          {{{flow-button "MELEE/RANGED" "BasicAttack"}}}
-          {{{flow-button "DAMAGE" "Damage"}}}
-          {{{flow-button "TECH" "TechAttack"}}}
-        </div>
-      </div>
       <div class="card">
         <div class="lancer-header lancer-primary major">
           <span>

--- a/scripts/mech-combat-dock.test.ts
+++ b/scripts/mech-combat-dock.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildCombatDockStatChipsHtml,
+  COMBAT_DOCK_ATTACK_FLOW_TYPES,
+} from "../src/module/helpers/mech-combat-dock-core.ts";
+
+describe("mech combat dock helpers", () => {
+  it("buildCombatDockStatChipsHtml renders HP, heat, structure, and stress", () => {
+    const html = buildCombatDockStatChipsHtml({
+      hp: { value: 1, max: 12 },
+      heat: { value: 0, max: 6 },
+      structure: { value: 4, max: 4 },
+      stress: { value: 4, max: 4 },
+    });
+    assert.match(html, /mech-combat-dock-stat/);
+    assert.match(html, /system\.hp\.value/);
+    assert.match(html, /system\.heat\.value/);
+    assert.match(html, /system\.structure\.value/);
+    assert.match(html, /system\.stress\.value/);
+  });
+
+  it("combat dock attack utilities include all three flow types", () => {
+    assert.deepEqual(COMBAT_DOCK_ATTACK_FLOW_TYPES, ["BasicAttack", "Damage", "TechAttack"]);
+  });
+});

--- a/src/module/helpers/index.ts
+++ b/src/module/helpers/index.ts
@@ -73,6 +73,7 @@ import {
   loadingIndicator,
 } from "./refs";
 import { mechLoadout, pilotSlot, frameView } from "./loadout";
+import { mechCombatDock } from "./mech-combat-dock";
 import {
   item_edit_arrayed_actions,
   item_edit_arrayed_damage,
@@ -357,6 +358,7 @@ export function registerHandlebarsHelpers() {
   // Mech components
   Handlebars.registerHelper("mech-loadout", mechLoadout);
   Handlebars.registerHelper("mech-frame", frameView);
+  Handlebars.registerHelper("mech-combat-dock", mechCombatDock);
 
   // ------------------------------------------------------------------------
   // NPC components

--- a/src/module/helpers/mech-combat-dock-core.ts
+++ b/src/module/helpers/mech-combat-dock-core.ts
@@ -1,0 +1,30 @@
+export interface CombatDockStatSnapshot {
+  hp: { value: number; max: number };
+  heat: { value: number; max: number };
+  structure: { value: number; max: number };
+  stress: { value: number; max: number };
+}
+
+export const COMBAT_DOCK_ATTACK_FLOW_TYPES = ["BasicAttack", "Damage", "TechAttack"] as const;
+
+/** Pure stat chip markup for unit tests and sheet render. */
+export function buildCombatDockStatChipsHtml(stats: CombatDockStatSnapshot): string {
+  const chip = (label: string, value: number, max: number, valuePath: string, icon: string) =>
+    `
+    <div class="mech-combat-dock-stat card clipped" data-tooltip="${label}">
+      <i class="${icon} i--3" aria-hidden="true"></i>
+      <span class="mech-combat-dock-stat-label">${label}</span>
+      <span class="mech-combat-dock-stat-value">
+        <input class="lancer-stat minor" type="number" name="${valuePath}" value="${value}" data-dtype="Number" />
+        /
+        <span class="lancer-stat minor">${max}</span>
+      </span>
+    </div>`;
+
+  return `<div class="mech-combat-dock-stats flexrow">
+    ${chip("HP", stats.hp.value, stats.hp.max, "system.hp.value", "mdi mdi-heart-outline")}
+    ${chip("HEAT", stats.heat.value, stats.heat.max, "system.heat.value", "cci cci-heat")}
+    ${chip("STRUCT", stats.structure.value, stats.structure.max, "system.structure.value", "cci cci-structure")}
+    ${chip("STRESS", stats.stress.value, stats.stress.max, "system.stress.value", "cci cci-reactor")}
+  </div>`;
+}

--- a/src/module/helpers/mech-combat-dock.ts
+++ b/src/module/helpers/mech-combat-dock.ts
@@ -1,0 +1,83 @@
+import type { HelperOptions } from "handlebars";
+import type { LancerMECH } from "../actor/lancer-actor";
+import { LancerFlowState } from "../flows/interfaces";
+import { resolveHelperDotpath } from "./commons";
+import { action_button, actor_flow_button, is_combatant } from "./actor";
+import { buildCombatDockStatChipsHtml, COMBAT_DOCK_ATTACK_FLOW_TYPES } from "./mech-combat-dock-core";
+
+export { buildCombatDockStatChipsHtml, COMBAT_DOCK_ATTACK_FLOW_TYPES } from "./mech-combat-dock-core";
+export type { CombatDockStatSnapshot } from "./mech-combat-dock-core";
+
+/** Attack utility buttons rendered in the persistent combat dock. */
+export function buildCombatDockAttackUtilitiesHtml(): string {
+  const BasicFlowType = LancerFlowState.BasicFlowType;
+  const buttons = [
+    actor_flow_button("M/R", BasicFlowType.BasicAttack, {} as HelperOptions),
+    actor_flow_button("DMG", BasicFlowType.Damage, {} as HelperOptions),
+    actor_flow_button("TECH", BasicFlowType.TechAttack, {} as HelperOptions),
+  ];
+  return `<div class="mech-combat-dock-attacks flexrow">${buttons.join("")}</div>`;
+}
+
+function compactOverchargeDock(actor: LancerMECH, overchargeLevel: number): string {
+  const sequence = actor.system.overcharge_sequence.split(",");
+  const index = Math.max(0, Math.min(sequence.length - 1, overchargeLevel));
+  const value = sequence[index];
+  return `
+    <div class="mech-combat-dock-overcharge card clipped" data-tooltip="Overcharge">
+      <button type="button" class="lancer-flow-button lancer-button lancer-secondary" data-flow-type="Overcharge" data-flow-args="{}" aria-label="Roll overcharge">
+        <i class="fas fa-dice-d20 i--dark i--2" aria-hidden="true"></i>
+      </button>
+      <button type="button" class="overcharge-text lancer-button lancer-secondary">${value}</button>
+      <button type="button" class="overcharge-reset mdi mdi-restore" aria-label="Reset overcharge"></button>
+    </div>`;
+}
+
+function compactCoreToggle(checked: boolean): string {
+  return `
+    <div class="mech-combat-dock-core card clipped" data-tooltip="Core power">
+      <span class="minor">CORE</span>
+      <input name="system.core_energy" class="core-power-toggle" type="checkbox" data-dtype="Boolean" ${checked ? "checked" : ""} />
+    </div>`;
+}
+
+function compactActionTracker(actor: LancerMECH, options: HelperOptions): string {
+  if (!is_combatant(actor)) return "";
+  const buttons = [
+    action_button("P", "system.action_tracker.protocol", "protocol", options),
+    action_button("M", "system.action_tracker.move", "move", options),
+    action_button("F", "system.action_tracker.full", "full", options),
+    action_button("Q", "system.action_tracker.quick", "quick", options),
+    action_button("R", "system.action_tracker.reaction", "reaction", options),
+  ];
+  return `<div class="mech-combat-dock-actions flexrow">${buttons.join("")}</div>`;
+}
+
+/** Handlebars helper: persistent combat dock visible on every mech sheet tab. */
+export function mechCombatDock(options: HelperOptions): string {
+  const actor = (options.data?.root?.actor ?? resolveHelperDotpath(options, "actor")) as LancerMECH | undefined;
+  if (!actor?.is_mech()) return "";
+
+  const system = actor.system;
+  const statChips = buildCombatDockStatChipsHtml({
+    hp: system.hp,
+    heat: system.heat,
+    structure: system.structure,
+    stress: system.stress,
+  });
+  const overcharge = compactOverchargeDock(actor, system.overcharge);
+  const core = compactCoreToggle(system.core_energy);
+  const actions = compactActionTracker(actor, options);
+  const attacks = buildCombatDockAttackUtilitiesHtml();
+
+  return `
+    <aside class="mech-combat-dock card clipped" aria-label="${game.i18n.localize("lancer.mech-sheet.combat-dock.label")}">
+      ${statChips}
+      <div class="mech-combat-dock-controls flexrow">
+        ${overcharge}
+        ${core}
+        ${actions}
+        ${attacks}
+      </div>
+    </aside>`;
+}

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -221,6 +221,83 @@
     margin-bottom: 0.75rem;
   }
 
+  .mech-combat-dock {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin: 0.35rem 0 0.5rem;
+    padding: 0.35rem 0.5rem;
+    background-color: var(--darken-2, #1a1a1a);
+    position: sticky;
+    top: 0;
+    z-index: 3;
+  }
+
+  .mech-combat-dock-stats {
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: stretch;
+  }
+
+  .mech-combat-dock-stat {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.45rem;
+    min-width: 5.5rem;
+    flex: 1 1 auto;
+  }
+
+  .mech-combat-dock-stat-label {
+    font-size: 0.65rem;
+    opacity: 0.85;
+    min-width: 2.75rem;
+  }
+
+  .mech-combat-dock-stat-value {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.1rem;
+    font-size: 0.8rem;
+
+    input.lancer-stat {
+      width: 2.25rem;
+      min-width: 2rem;
+      padding: 0 0.15rem;
+      text-align: center;
+    }
+  }
+
+  .mech-combat-dock-controls {
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+  }
+
+  .mech-combat-dock-overcharge,
+  .mech-combat-dock-core {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.35rem;
+  }
+
+  .mech-combat-dock-actions,
+  .mech-combat-dock-attacks {
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+
+    .lancer-action-button,
+    .lancer-flow-button {
+      min-width: 2.25rem;
+      padding: 0.2rem 0.4rem;
+      font-size: 0.7rem;
+    }
+  }
+
   .sheet-section-header.sticky {
     position: sticky;
     top: 0;

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "compatibility": {
     "minimum": 13,
     "verified": 14,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a **persistent combat dock** below the mech sheet header with HP, Heat, Structure, Stress, Overcharge, Core, action tracker, and attack utilities.
- Moves **Attack utilities** (Melee/Ranged, Damage, Tech) out of the Loadout tab so combat controls stay visible on every tab.

## Test plan

- [x] Unit tests: `npm test` (`scripts/mech-combat-dock.test.ts`)
- [x] E2E: `npx playwright test e2e/regression/mech-sheet-ux.spec.ts` (Foundry Docker)
- [x] Production build: `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`

## Also fixes

- E2E world fixture: add required `coreVersion` for Foundry 14.363
- E2E setup: dismiss usage-data dialog before waiting for world list
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc8e7591-7e4a-45de-9901-f987b75433f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc8e7591-7e4a-45de-9901-f987b75433f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

