### PR TITLE
feat(mech-sheet): abilities tab polish and effect badges (3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.0.2 (2026-06-07)
+
+## Added
+
+- **Compact weapon and system cards** on the mech Stats tab with FIRE and USE controls for in-combat gear access.
+
+## Changed
+
+- **Macros section** on the mech Stats tab is **collapsed by default** to reduce scroll during play.
+
 # 3.0.1 (2026-06-07)
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 3.1.1 (2026-06-07)
+
+## Added
+
+- **Abilities tab** merges frame details with pilot talents (replaces the Talents tab).
+- **Effects tab badge** shows active effect count when non-zero.
+- **Empty state** on the Abilities tab when no pilot is assigned.
+
 # 3.1.0 (2026-06-07)
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.0.1 (2026-06-07)
+
+## Added
+
+- **Persistent combat dock** on the mech sheet — HP, Heat, Structure, Stress, Overcharge, Core, action tracker, and attack utilities stay visible across all tabs.
+
+## Changed
+
+- **Attack utilities** (Melee/Ranged, Damage, Tech) moved from the Loadout tab into the combat dock.
+
 # 3.0.0 (2026-06-07)
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.1.0 (2026-06-07)
+
+## Added
+
+- **Gear tab play/edit toggle** — Play View shows compact gear cards; Edit Loadout exposes the full drag-and-drop editor.
+
+## Changed
+
+- Mech sheet tabs renamed for play intent: **COMBAT** (default), **GEAR**, **PILOT//TALENTS**, **EFFECTS//ACTIVE** (tab ids: `combat`, `gear`, `talents`, `effects`).
+
 # 3.0.2 (2026-06-07)
 
 ## Added

--- a/e2e/fixtures/lancer-dev-test/world.json
+++ b/e2e/fixtures/lancer-dev-test/world.json
@@ -7,7 +7,7 @@
     "minimum": "14",
     "verified": "14"
   },
-  "systemVersion": "3.1.0",
+  "systemVersion": "3.1.1",
   "description": "Minimal world for Lancer Playwright E2E regression tests.",
   "flags": {}
 }

--- a/e2e/fixtures/lancer-dev-test/world.json
+++ b/e2e/fixtures/lancer-dev-test/world.json
@@ -7,7 +7,7 @@
     "minimum": "14",
     "verified": "14"
   },
-  "systemVersion": "3.0.1",
+  "systemVersion": "3.0.2",
   "description": "Minimal world for Lancer Playwright E2E regression tests.",
   "flags": {}
 }

--- a/e2e/fixtures/lancer-dev-test/world.json
+++ b/e2e/fixtures/lancer-dev-test/world.json
@@ -2,11 +2,12 @@
   "title": "Lancer Dev Test",
   "system": "lancer",
   "id": "lancer-dev-test",
+  "coreVersion": "14.363",
   "compatibility": {
     "minimum": "14",
     "verified": "14"
   },
-  "systemVersion": "2.13.0",
+  "systemVersion": "3.0.1",
   "description": "Minimal world for Lancer Playwright E2E regression tests.",
   "flags": {}
 }

--- a/e2e/fixtures/lancer-dev-test/world.json
+++ b/e2e/fixtures/lancer-dev-test/world.json
@@ -7,7 +7,7 @@
     "minimum": "14",
     "verified": "14"
   },
-  "systemVersion": "3.0.2",
+  "systemVersion": "3.1.0",
   "description": "Minimal world for Lancer Playwright E2E regression tests.",
   "flags": {}
 }

--- a/e2e/helpers/foundry.ts
+++ b/e2e/helpers/foundry.ts
@@ -98,8 +98,9 @@ export async function completeFoundrySetup(page: Page, worldId = FOUNDRY_WORLD_I
   }
 
   if (page.url().includes("/setup")) {
-    await page.locator(`li.world[data-package-id="${worldId}"]`).waitFor({ state: "visible", timeout: 120_000 });
+    await dismissFoundryLaunchDialogs(page);
     await dismissFoundryTours(page);
+    await page.locator(`li.world[data-package-id="${worldId}"]`).waitFor({ state: "visible", timeout: 120_000 });
   }
 }
 

--- a/e2e/regression/mech-sheet-ux.spec.ts
+++ b/e2e/regression/mech-sheet-ux.spec.ts
@@ -38,7 +38,7 @@ test.describe("Mech sheet UX @regression", () => {
     const dockOnTalentsTab = await page.evaluate(async id => {
       const actor = game.actors.get(id);
       if (!actor?.sheet) return false;
-      actor.sheet.changeTab("talents", "primary", { force: true });
+      actor.sheet.changeTab("abilities", "primary", { force: true });
       const root = actor.sheet.element as HTMLElement;
       return !!root.querySelector(".mech-combat-dock");
     }, mechId);
@@ -132,5 +132,27 @@ test.describe("Mech sheet UX @regression", () => {
     }, mechId);
 
     expect(edited).toBe("edit");
+  });
+
+  test("abilities tab shows empty state without pilot and effects tab shows count badge", async ({ page }) => {
+    const { mechId } = await seedRegressionWorld(page);
+    await openActorSheet(page, mechId);
+
+    const emptyState = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return false;
+      actor.sheet.changeTab("abilities", "primary", { force: true });
+      const root = actor.sheet.element as HTMLElement;
+      return !!root.querySelector(".mech-abilities-empty");
+    }, mechId);
+    expect(emptyState).toBe(true);
+
+    const effectsLabel = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return "";
+      const nav = actor.sheet.element?.querySelector('a[data-tab="effects"]');
+      return nav?.textContent?.trim() ?? "";
+    }, mechId);
+    expect(effectsLabel).toContain("<EFFECTS//ACTIVE>");
   });
 });

--- a/e2e/regression/mech-sheet-ux.spec.ts
+++ b/e2e/regression/mech-sheet-ux.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { joinLancerWorld } from "../helpers/foundry";
+import { openActorSheet, seedRegressionWorld } from "../helpers/seed";
+
+test.describe("Mech sheet UX @regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await joinLancerWorld(page);
+  });
+
+  test("combat dock is visible on every tab and loadout no longer has attack utilities", async ({ page }) => {
+    const { mechId } = await seedRegressionWorld(page);
+    await openActorSheet(page, mechId);
+
+    const dockVisible = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return false;
+      const root = actor.sheet.element as HTMLElement;
+      return !!root.querySelector(".mech-combat-dock");
+    }, mechId);
+    expect(dockVisible).toBe(true);
+
+    const loadoutAttackUtilities = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return { onLoadout: true, onDock: false };
+      actor.sheet.changeTab("loadout", "primary", { force: true });
+      const root = actor.sheet.element as HTMLElement;
+      const loadoutTab = root.querySelector('.tab.loadout[data-tab="loadout"]');
+      const dock = root.querySelector(".mech-combat-dock");
+      const loadoutButtons = loadoutTab?.querySelectorAll('[data-flow-type="BasicAttack"]') ?? [];
+      const dockButtons = dock?.querySelectorAll('[data-flow-type="BasicAttack"]') ?? [];
+      return { onLoadout: loadoutButtons.length > 0, onDock: dockButtons.length > 0 };
+    }, mechId);
+
+    expect(loadoutAttackUtilities.onDock).toBe(true);
+    expect(loadoutAttackUtilities.onLoadout).toBe(false);
+
+    const dockOnTalentsTab = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return false;
+      actor.sheet.changeTab("talents", "primary", { force: true });
+      const root = actor.sheet.element as HTMLElement;
+      return !!root.querySelector(".mech-combat-dock");
+    }, mechId);
+    expect(dockOnTalentsTab).toBe(true);
+  });
+});

--- a/e2e/regression/mech-sheet-ux.spec.ts
+++ b/e2e/regression/mech-sheet-ux.spec.ts
@@ -22,9 +22,10 @@ test.describe("Mech sheet UX @regression", () => {
     const loadoutAttackUtilities = await page.evaluate(async id => {
       const actor = game.actors.get(id);
       if (!actor?.sheet) return { onLoadout: true, onDock: false };
-      actor.sheet.changeTab("loadout", "primary", { force: true });
+      actor.sheet.changeTab("gear", "primary", { force: true });
       const root = actor.sheet.element as HTMLElement;
-      const loadoutTab = root.querySelector('.tab.loadout[data-tab="loadout"]');
+      const gearTab = root.querySelector('.tab.gear[data-tab="gear"]');
+      const loadoutTab = root.querySelector('.tab.gear[data-tab="gear"] .gear-edit-panel');
       const dock = root.querySelector(".mech-combat-dock");
       const loadoutButtons = loadoutTab?.querySelectorAll('[data-flow-type="BasicAttack"]') ?? [];
       const dockButtons = dock?.querySelectorAll('[data-flow-type="BasicAttack"]') ?? [];
@@ -82,14 +83,14 @@ test.describe("Mech sheet UX @regression", () => {
       mounts[0].slots[0].weapon = weapon.id;
       await actor.update({ "system.loadout.weapon_mounts": mounts });
       await actor.sheet.render(true);
-      actor.sheet.changeTab("stats", "primary", { force: true });
+      actor.sheet.changeTab("combat", "primary", { force: true });
     }, mechId);
 
     const result = await page.evaluate(async id => {
       const actor = game.actors.get(id);
       if (!actor?.sheet) return null;
       const root = actor.sheet.element as HTMLElement;
-      const statsTab = root.querySelector('.tab.stats[data-tab="stats"]');
+      const statsTab = root.querySelector('.tab.combat[data-tab="combat"]');
       return {
         hasWeaponCard: !!statsTab?.querySelector(".mech-combat-gear-card .roll-attack"),
         macrosCollapsed: !!statsTab?.querySelector('[data-collapse-id="mech-stats-macros"].collapsed'),
@@ -98,5 +99,38 @@ test.describe("Mech sheet UX @regression", () => {
 
     expect(result?.hasWeaponCard).toBe(true);
     expect(result?.macrosCollapsed).toBe(true);
+  });
+
+  test("gear tab defaults to play view and can switch to edit loadout", async ({ page }) => {
+    const { mechId } = await seedRegressionWorld(page);
+    await openActorSheet(page, mechId);
+
+    const initial = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return null;
+      actor.sheet.changeTab("gear", "primary", { force: true });
+      const gearTab = actor.sheet.element?.querySelector('.tab.gear[data-tab="gear"]') as HTMLElement | null;
+      return {
+        mode: gearTab?.getAttribute("data-gear-mode"),
+        playVisible: gearTab?.querySelector(".gear-play-panel")?.checkVisibility?.() ?? true,
+        editHidden: gearTab?.querySelector(".gear-edit-panel")?.checkVisibility?.() === false,
+      };
+    }, mechId);
+
+    expect(initial?.mode).toBe("play");
+
+    await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      const gearTab = actor?.sheet?.element?.querySelector('.tab.gear[data-tab="gear"]');
+      gearTab?.querySelector<HTMLButtonElement>('.gear-mode-button[data-gear-mode="edit"]')?.click();
+    }, mechId);
+
+    const edited = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      const gearTab = actor?.sheet?.element?.querySelector('.tab.gear[data-tab="gear"]') as HTMLElement | null;
+      return gearTab?.getAttribute("data-gear-mode");
+    }, mechId);
+
+    expect(edited).toBe("edit");
   });
 });

--- a/e2e/regression/mech-sheet-ux.spec.ts
+++ b/e2e/regression/mech-sheet-ux.spec.ts
@@ -43,4 +43,60 @@ test.describe("Mech sheet UX @regression", () => {
     }, mechId);
     expect(dockOnTalentsTab).toBe(true);
   });
+
+  test("combat gear cards and collapsed macros on stats tab", async ({ page }) => {
+    const { mechId } = await seedRegressionWorld(page);
+    await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor) throw new Error("mech missing");
+      const weapon = await Item.create(
+        {
+          name: "E2E Test Rifle",
+          type: "mech_weapon",
+          img: `systems/${game.system.id}/assets/icons/mech_weapon.svg`,
+          system: {
+            size: "Main",
+            sp: 0,
+            profiles: [
+              {
+                name: "Standard",
+                type: "Rifle",
+                range: [{ type: "Range", val: 10 }],
+                damage: [{ type: "Kinetic", val: "1d6" }],
+                actions: [],
+                tags: [],
+                effect: "",
+                on_attack: "",
+                on_hit: "",
+                on_crit: "",
+              },
+            ],
+            selected_profile_index: 0,
+            tags: [],
+            actions: [],
+          },
+        },
+        { parent: actor }
+      );
+      const mounts = foundry.utils.deepClone(actor.system.loadout.weapon_mounts);
+      mounts[0].slots[0].weapon = weapon.id;
+      await actor.update({ "system.loadout.weapon_mounts": mounts });
+      await actor.sheet.render(true);
+      actor.sheet.changeTab("stats", "primary", { force: true });
+    }, mechId);
+
+    const result = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return null;
+      const root = actor.sheet.element as HTMLElement;
+      const statsTab = root.querySelector('.tab.stats[data-tab="stats"]');
+      return {
+        hasWeaponCard: !!statsTab?.querySelector(".mech-combat-gear-card .roll-attack"),
+        macrosCollapsed: !!statsTab?.querySelector('[data-collapse-id="mech-stats-macros"].collapsed'),
+      };
+    }, mechId);
+
+    expect(result?.hasWeaponCard).toBe(true);
+    expect(result?.macrosCollapsed).toBe(true);
+  });
 });

--- a/e2e/regression/sprint-g-features.spec.ts
+++ b/e2e/regression/sprint-g-features.spec.ts
@@ -41,7 +41,7 @@ test.describe("Sprint G features @regression", () => {
       const actor = game.actors.get(id);
       if (!actor) throw new Error("mech missing");
       await actor.sheet.render(true);
-      actor.sheet.changeTab("loadout", "primary", { force: true });
+      actor.sheet.changeTab("gear", "primary", { force: true });
     }, mechId);
 
     expect(await waitForSheetSelector(page, mechId, "[data-loadout-editor-mount] .loadout-editor")).toBe(true);
@@ -49,6 +49,9 @@ test.describe("Sprint G features @regression", () => {
     const controls = await page.evaluate(async id => {
       const actor = game.actors.get(id);
       if (!actor) throw new Error("mech missing");
+      actor.sheet.changeTab("gear", "primary", { force: true });
+      actor.sheet.element?.querySelector('.tab.gear[data-tab="gear"]')?.setAttribute("data-gear-mode", "edit");
+      await actor.sheet.render(false);
       const root = actor.sheet.element as HTMLElement;
       return {
         all: !!root.querySelector(".reset-all-weapon-mounts-button"),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -111,9 +111,13 @@
         "inactive-warning": "Warning: Inactive Mech - Pilot bonuses not tracked"
       },
       "tabs": {
-        "stats": "<MECH//STATS>",
-        "loadout": "<MECH//LOADOUT>",
+        "combat": "<COMBAT//PRIMARY>",
+        "gear": "<MECH//GEAR>",
         "talents": "<PILOT//TALENTS>"
+      },
+      "gear-mode": {
+        "play": "PLAY VIEW",
+        "edit": "EDIT LOADOUT"
       },
       "core": {
         "label": "CORE"

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -113,7 +113,11 @@
       "tabs": {
         "combat": "<COMBAT//PRIMARY>",
         "gear": "<MECH//GEAR>",
-        "talents": "<PILOT//TALENTS>"
+        "abilities": "<ABILITIES//ALL>",
+        "effects": "<EFFECTS//ACTIVE>"
+      },
+      "abilities": {
+        "no-pilot": "No pilot is assigned to this mech. Assign a pilot on the Combat tab to view talents and frame bonuses."
       },
       "gear-mode": {
         "play": "PLAY VIEW",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -132,6 +132,9 @@
         "combat": "COMBAT",
         "systems": "SYSTEMS"
       },
+      "combat-dock": {
+        "label": "Combat quick controls"
+      },
       "inventory": {
         "label": "View Inventory"
       },

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -135,6 +135,12 @@
       "combat-dock": {
         "label": "Combat quick controls"
       },
+      "combat-gear": {
+        "weapons": "WEAPONS",
+        "systems": "SYSTEMS",
+        "no-weapons": "No weapons mounted.",
+        "no-systems": "No systems mounted."
+      },
       "inventory": {
         "label": "View Inventory"
       },

--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -40,17 +40,17 @@
         data-tab="gear"
       >{{localize "lancer.mech-sheet.tabs.gear"}}</a>
       <a
-        class="item lancer-tab medium {{tabs.primary.talents.cssClass}}"
+        class="item lancer-tab medium {{tabs.primary.abilities.cssClass}}"
         data-action="tab"
         data-group="primary"
-        data-tab="talents"
-      >{{localize "lancer.mech-sheet.tabs.talents"}}</a>
+        data-tab="abilities"
+      >{{localize "lancer.mech-sheet.tabs.abilities"}}</a>
       <a
         class="item lancer-tab medium {{tabs.primary.effects.cssClass}}"
         data-action="tab"
         data-group="primary"
         data-tab="effects"
-      >{{localize "lancer.common-sheet.tabs.effects"}}</a>
+      >{{localize "lancer.mech-sheet.tabs.effects"}}{{#if effect_count}} ({{effect_count}}){{/if}}</a>
     </nav>
   </div>
 
@@ -193,8 +193,8 @@
       </div>
     </div>
 
-    <div class="tab talents {{tabs.primary.talents.cssClass}}" data-group="primary" data-tab="talents">
-      {{!-- Talents --}}
+    <div class="tab abilities {{tabs.primary.abilities.cssClass}}" data-group="primary" data-tab="abilities">
+      {{{mech-frame "system.loadout.frame.value" system.core_energy}}}
       {{#if system.pilot.value}}
         <div class="card clipped">
           <h2 class="lancer-header lancer-primary major clipped">
@@ -203,6 +203,10 @@
           {{#each system.pilot.value.itemTypes.talent as |talent index|}}
             {{{item-preview (concat "system.pilot.value.itemTypes.talent." index) null}}}
           {{/each}}
+        </div>
+      {{else}}
+        <div class="card clipped mech-abilities-empty">
+          <p class="note">{{localize "lancer.mech-sheet.abilities.no-pilot"}}</p>
         </div>
       {{/if}}
     </div>

--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -23,6 +23,8 @@
       </div>
     </header>
 
+    {{{mech-combat-dock}}}
+
     {{!-- Sheet Tab Navigation --}}
     <nav class="tabs lancer-tabs" data-group="primary">
       <a
@@ -160,14 +162,6 @@
 
     <div class="tab loadout {{tabs.primary.loadout.cssClass}}" data-group="primary" data-tab="loadout">
       {{{mech-frame "system.loadout.frame.value" system.core_energy}}}
-      <div class="card clipped">
-        <span class="lancer-header lancer-primary submajor">ATTACK UTILITIES</span>
-        <div class="lancer-flow-button-grid">
-          {{{flow-button "MELEE/RANGED" "BasicAttack"}}}
-          {{{flow-button "DAMAGE" "Damage"}}}
-          {{{flow-button "TECH" "TechAttack"}}}
-        </div>
-      </div>
       <div class="card">
         <div class="lancer-header lancer-primary major">
           <span>

--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -28,17 +28,17 @@
     {{!-- Sheet Tab Navigation --}}
     <nav class="tabs lancer-tabs" data-group="primary">
       <a
-        class="item lancer-tab medium {{tabs.primary.stats.cssClass}}"
+        class="item lancer-tab medium {{tabs.primary.combat.cssClass}}"
         data-action="tab"
         data-group="primary"
-        data-tab="stats"
-      >{{localize "lancer.mech-sheet.tabs.stats"}}</a>
+        data-tab="combat"
+      >{{localize "lancer.mech-sheet.tabs.combat"}}</a>
       <a
-        class="item lancer-tab medium {{tabs.primary.loadout.cssClass}}"
+        class="item lancer-tab medium {{tabs.primary.gear.cssClass}}"
         data-action="tab"
         data-group="primary"
-        data-tab="loadout"
-      >{{localize "lancer.mech-sheet.tabs.loadout"}}</a>
+        data-tab="gear"
+      >{{localize "lancer.mech-sheet.tabs.gear"}}</a>
       <a
         class="item lancer-tab medium {{tabs.primary.talents.cssClass}}"
         data-action="tab"
@@ -56,7 +56,7 @@
 
   {{!-- Sheet Body --}}
   <section class="sheet-body scroll-body">
-    <div class="tab stats {{tabs.primary.stats.cssClass}}" data-group="primary" data-tab="stats">
+    <div class="tab combat {{tabs.primary.combat.cssClass}}" data-group="primary" data-tab="combat">
       <section class="mech-stat-section" data-mech-section="combat">
         <div class="lancer-header lancer-primary sheet-section-header sticky">
           <i
@@ -155,21 +155,41 @@
       </section>
     </div>
 
-    <div class="tab loadout {{tabs.primary.loadout.cssClass}}" data-group="primary" data-tab="loadout">
+    <div class="tab gear {{tabs.primary.gear.cssClass}}" data-group="primary" data-tab="gear" data-gear-mode="play">
       {{{mech-frame "system.loadout.frame.value" system.core_energy}}}
-      <div class="card">
-        <div class="lancer-header lancer-primary major">
-          <span>
-            {{{localize "lancer.mech-sheet.system.label"}}}
-          </span>
-          <span class="mech-sp-counter">
-            <i class="cci cci-system-point i--4"></i>
-            {{system.loadout.sp.value}} / {{system.loadout.sp.max}}
-            {{localize "lancer.mech-sheet.system.sp-used"}}
-          </span>
+      <div class="gear-mode-toggle card clipped flexrow">
+        <button
+          type="button"
+          class="lancer-button gear-mode-button active"
+          data-gear-mode="play"
+        >
+          {{localize "lancer.mech-sheet.gear-mode.play"}}
+        </button>
+        <button
+          type="button"
+          class="lancer-button gear-mode-button"
+          data-gear-mode="edit"
+        >
+          {{localize "lancer.mech-sheet.gear-mode.edit"}}
+        </button>
+      </div>
+      <div class="gear-play-panel">
+        {{{mech-combat-weapons}}}
+        {{{mech-combat-systems}}}
+      </div>
+      <div class="gear-edit-panel">
+        <div class="card">
+          <div class="lancer-header lancer-primary major">
+            <span>{{localize "lancer.mech-sheet.system.label"}}</span>
+            <span class="mech-sp-counter">
+              <i class="cci cci-system-point i--4"></i>
+              {{system.loadout.sp.value}} / {{system.loadout.sp.max}}
+              {{localize "lancer.mech-sheet.system.sp-used"}}
+            </span>
+          </div>
+          <div class="loadout-editor-mount" data-loadout-editor-mount></div>
+          {{{mech-loadout}}}
         </div>
-        <div class="loadout-editor-mount" data-loadout-editor-mount></div>
-        {{{mech-loadout}}}
       </div>
     </div>
 

--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -127,34 +127,29 @@
               <button class="lancer-button" type="button">{{localize "lancer.mech-sheet.inventory.label"}}</button>
             </div>
           </div>
+        </div>
+      </section>
 
-          <div class="pilot-frame-wrapper flexrow">
-            <div class="card">
-              <span class="lancer-header lancer-primary submajor clipped-top">
-                {{localize "lancer.mech-sheet.macros.label"}}
-              </span>
-              <div class="lancer-flow-button-grid">
-                {{{flow-button "STABILIZE" "Stabilize"}}}
-                {{{flow-button "FULL REPAIR" "FullRepair"}}}
-                <div class="flow-button-sep"></div>
-                {{{flow-button "STRUCTURE" "Structure"}}}
-                {{{flow-button "OVERHEAT" "Overheat"}}}
-              </div>
+      {{{mech-combat-weapons}}}
+      {{{mech-combat-systems}}}
+
+      <section class="mech-stat-section" data-mech-section="macros">
+        <div class="lancer-header lancer-primary sheet-section-header sticky">
+          <i
+            class="mdi mdi-unfold-more-horizontal collapse-trigger collapse-icon"
+            data-collapse-id="mech-stats-macros"
+          ></i>
+          <span class="major">{{localize "lancer.mech-sheet.macros.label"}}</span>
+        </div>
+        <div class="collapse collapsed pilot-frame-wrapper flexrow" data-collapse-id="mech-stats-macros">
+          <div class="card">
+            <div class="lancer-flow-button-grid">
+              {{{flow-button "STABILIZE" "Stabilize"}}}
+              {{{flow-button "FULL REPAIR" "FullRepair"}}}
+              <div class="flow-button-sep"></div>
+              {{{flow-button "STRUCTURE" "Structure"}}}
+              {{{flow-button "OVERHEAT" "Overheat"}}}
             </div>
-            {{#if (is-combatant actor)}}
-              <div class="card mech-combat-actions">
-                <span class="lancer-header lancer-primary submajor clipped-top">
-                  {{localize "lancer.mech-sheet.actions.label"}}
-                </span>
-                <div class="lancer-flow-button-grid">
-                  {{{action-button "Protocol" "system.action_tracker.protocol" "protocol"}}}
-                  {{{action-button "Movement" "system.action_tracker.move" "move"}}}
-                  {{{action-button "Full Action" "system.action_tracker.full" "full"}}}
-                  {{{action-button "Quick Action" "system.action_tracker.quick" "quick"}}}
-                  {{{action-button "Reaction" "system.action_tracker.reaction" "reaction"}}}
-                </div>
-              </div>
-            {{/if}}
           </div>
         </div>
       </section>

--- a/scripts/mech-combat-dock.test.ts
+++ b/scripts/mech-combat-dock.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildCombatDockStatChipsHtml,
+  COMBAT_DOCK_ATTACK_FLOW_TYPES,
+} from "../src/module/helpers/mech-combat-dock-core.ts";
+
+describe("mech combat dock helpers", () => {
+  it("buildCombatDockStatChipsHtml renders HP, heat, structure, and stress", () => {
+    const html = buildCombatDockStatChipsHtml({
+      hp: { value: 1, max: 12 },
+      heat: { value: 0, max: 6 },
+      structure: { value: 4, max: 4 },
+      stress: { value: 4, max: 4 },
+    });
+    assert.match(html, /mech-combat-dock-stat/);
+    assert.match(html, /system\.hp\.value/);
+    assert.match(html, /system\.heat\.value/);
+    assert.match(html, /system\.structure\.value/);
+    assert.match(html, /system\.stress\.value/);
+  });
+
+  it("combat dock attack utilities include all three flow types", () => {
+    assert.deepEqual(COMBAT_DOCK_ATTACK_FLOW_TYPES, ["BasicAttack", "Damage", "TechAttack"]);
+  });
+});

--- a/scripts/mech-combat-gear.test.ts
+++ b/scripts/mech-combat-gear.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildCompactSystemCardHtml,
+  buildCompactWeaponCardHtml,
+  collectCombatSystems,
+  collectCombatWeapons,
+  countCombatGear,
+} from "../src/module/helpers/mech-combat-gear-core.ts";
+
+describe("mech combat gear helpers", () => {
+  const loadout = {
+    weapon_mounts: [
+      {
+        type: "Main",
+        bracing: false,
+        slots: [
+          { size: "Main", weapon: { value: { name: "Assault Rifle" } }, mod: null },
+          { size: "Aux", weapon: null, mod: null },
+        ],
+      },
+    ],
+    systems: [{ value: { name: "Grenade Launcher" } }, { value: null }],
+    sp: { value: 1, max: 4 },
+    frame: null,
+  } as never;
+
+  it("countCombatGear counts weapons and systems", () => {
+    assert.deepEqual(countCombatGear(loadout), { weaponCount: 1, systemCount: 1 });
+  });
+
+  it("collectCombatWeapons returns equipped weapons", () => {
+    assert.equal(collectCombatWeapons(loadout).length, 1);
+    assert.equal(collectCombatWeapons(loadout)[0]?.name, "Assault Rifle");
+  });
+
+  it("collectCombatSystems returns mounted systems", () => {
+    assert.equal(collectCombatSystems(loadout).length, 1);
+    assert.equal(collectCombatSystems(loadout)[0]?.name, "Grenade Launcher");
+  });
+
+  it("buildCompactWeaponCardHtml includes roll-attack control", () => {
+    const html = buildCompactWeaponCardHtml("Assault Rifle", "path.weapon");
+    assert.match(html, /roll-attack/);
+    assert.match(html, /Assault Rifle/);
+  });
+
+  it("buildCompactSystemCardHtml includes chat-flow-button control", () => {
+    const html = buildCompactSystemCardHtml("ECM Suite", "path.system");
+    assert.match(html, /chat-flow-button/);
+    assert.match(html, /ECM Suite/);
+  });
+});

--- a/scripts/mech-gear-mode.test.ts
+++ b/scripts/mech-gear-mode.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveGearTabMode, shouldShowLoadoutEditor } from "../src/module/helpers/mech-gear-mode-core.ts";
+
+describe("mech gear mode helpers", () => {
+  it("resolveGearTabMode defaults to play", () => {
+    assert.equal(resolveGearTabMode(undefined), "play");
+    assert.equal(resolveGearTabMode("play"), "play");
+    assert.equal(resolveGearTabMode("edit"), "edit");
+  });
+
+  it("shouldShowLoadoutEditor is true only in edit mode", () => {
+    assert.equal(shouldShowLoadoutEditor("play"), false);
+    assert.equal(shouldShowLoadoutEditor("edit"), true);
+  });
+});

--- a/scripts/mech-sheet-ux-polish.test.ts
+++ b/scripts/mech-sheet-ux-polish.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { countActiveEffects, formatEffectsTabLabel } from "../src/module/helpers/mech-sheet-ux-core.ts";
+
+describe("mech sheet UX polish helpers", () => {
+  it("countActiveEffects sums effects in all categories", () => {
+    const total = countActiveEffects([{ effects: [1, 2] }, { effects: [3] }, { effects: [] }]);
+    assert.equal(total, 3);
+  });
+
+  it("formatEffectsTabLabel appends count when non-zero", () => {
+    assert.equal(formatEffectsTabLabel("<EFFECTS//ACTIVE>", 0), "<EFFECTS//ACTIVE>");
+    assert.equal(formatEffectsTabLabel("<EFFECTS//ACTIVE>", 3), "<EFFECTS//ACTIVE> (3)");
+  });
+});

--- a/src/module/actor/mech-sheet.ts
+++ b/src/module/actor/mech-sheet.ts
@@ -6,7 +6,7 @@ import type { ResolvedDropData } from "../helpers/dragdrop";
 import { EntryType, fittingsForMount, MountType } from "../enums";
 import type { SourceData } from "../source-template";
 import { LANCER } from "../config";
-import { mountLoadoutEditor } from "../apps/loadout/mount";
+import { countActiveEffects } from "../helpers/mech-sheet-ux-core";
 import { unmount } from "svelte";
 
 import ContextMenu = foundry.applications.ux.ContextMenu;
@@ -32,7 +32,7 @@ export class LancerMechSheet extends LancerActorSheet<EntryType.MECH> {
       tabs: [
         { id: "combat", group: "primary" },
         { id: "gear", group: "primary" },
-        { id: "talents", group: "primary" },
+        { id: "abilities", group: "primary" },
         { id: "effects", group: "primary" },
       ],
     },
@@ -367,6 +367,7 @@ export class LancerMechSheet extends LancerActorSheet<EntryType.MECH> {
     (data as Record<string, unknown>).pilot = this.actor.system.pilot?.value;
     (data as Record<string, unknown>).is_active =
       this.actor.system.pilot?.value?.system.active_mech?.value == this.actor;
+    (data as Record<string, unknown>).effect_count = countActiveEffects(data.effect_categories);
     return data;
   }
 }

--- a/src/module/actor/mech-sheet.ts
+++ b/src/module/actor/mech-sheet.ts
@@ -28,10 +28,10 @@ export class LancerMechSheet extends LancerActorSheet<EntryType.MECH> {
 
   static override TABS = {
     primary: {
-      initial: "stats",
+      initial: "combat",
       tabs: [
-        { id: "stats", group: "primary" },
-        { id: "loadout", group: "primary" },
+        { id: "combat", group: "primary" },
+        { id: "gear", group: "primary" },
         { id: "talents", group: "primary" },
         { id: "effects", group: "primary" },
       ],
@@ -51,6 +51,7 @@ export class LancerMechSheet extends LancerActorSheet<EntryType.MECH> {
     this._activateOverchargeControls($html);
     this._activateLoadoutControls($html);
     this._activateMountContextMenus($html);
+    this._activateGearModeToggle($html);
   }
 
   override activateListeners(html: HTMLElement): void {
@@ -167,6 +168,22 @@ export class LancerMechSheet extends LancerActorSheet<EntryType.MECH> {
     if (this.isEditable && !is_new && drop.type === "Item" && drop.document.is_mech_system()) {
       this._onSortItem(event, drop.document.toObject());
     }
+  }
+
+  /**
+   * Toggle play vs edit mode on the Gear tab.
+   */
+  _activateGearModeToggle(html: JQuery<HTMLElement>) {
+    html.off("click.lancerGearMode");
+    html.on("click.lancerGearMode", ".gear-mode-button", ev => {
+      ev.preventDefault();
+      const mode = ev.currentTarget?.dataset?.gearMode;
+      if (!mode) return;
+      const tab = html.find('.tab.gear[data-tab="gear"]');
+      tab.attr("data-gear-mode", mode);
+      tab.find(".gear-mode-button").removeClass("active");
+      $(ev.currentTarget).addClass("active");
+    });
   }
 
   /**

--- a/src/module/helpers/index.ts
+++ b/src/module/helpers/index.ts
@@ -73,6 +73,7 @@ import {
   loadingIndicator,
 } from "./refs";
 import { mechLoadout, pilotSlot, frameView } from "./loadout";
+import { mechCombatDock } from "./mech-combat-dock";
 import {
   item_edit_arrayed_actions,
   item_edit_arrayed_damage,
@@ -357,6 +358,7 @@ export function registerHandlebarsHelpers() {
   // Mech components
   Handlebars.registerHelper("mech-loadout", mechLoadout);
   Handlebars.registerHelper("mech-frame", frameView);
+  Handlebars.registerHelper("mech-combat-dock", mechCombatDock);
 
   // ------------------------------------------------------------------------
   // NPC components

--- a/src/module/helpers/index.ts
+++ b/src/module/helpers/index.ts
@@ -74,6 +74,7 @@ import {
 } from "./refs";
 import { mechLoadout, pilotSlot, frameView } from "./loadout";
 import { mechCombatDock } from "./mech-combat-dock";
+import { mechCombatSystems, mechCombatWeapons } from "./mech-combat-gear";
 import {
   item_edit_arrayed_actions,
   item_edit_arrayed_damage,
@@ -359,6 +360,8 @@ export function registerHandlebarsHelpers() {
   Handlebars.registerHelper("mech-loadout", mechLoadout);
   Handlebars.registerHelper("mech-frame", frameView);
   Handlebars.registerHelper("mech-combat-dock", mechCombatDock);
+  Handlebars.registerHelper("mech-combat-weapons", mechCombatWeapons);
+  Handlebars.registerHelper("mech-combat-systems", mechCombatSystems);
 
   // ------------------------------------------------------------------------
   // NPC components

--- a/src/module/helpers/mech-combat-dock-core.ts
+++ b/src/module/helpers/mech-combat-dock-core.ts
@@ -1,0 +1,30 @@
+export interface CombatDockStatSnapshot {
+  hp: { value: number; max: number };
+  heat: { value: number; max: number };
+  structure: { value: number; max: number };
+  stress: { value: number; max: number };
+}
+
+export const COMBAT_DOCK_ATTACK_FLOW_TYPES = ["BasicAttack", "Damage", "TechAttack"] as const;
+
+/** Pure stat chip markup for unit tests and sheet render. */
+export function buildCombatDockStatChipsHtml(stats: CombatDockStatSnapshot): string {
+  const chip = (label: string, value: number, max: number, valuePath: string, icon: string) =>
+    `
+    <div class="mech-combat-dock-stat card clipped" data-tooltip="${label}">
+      <i class="${icon} i--3" aria-hidden="true"></i>
+      <span class="mech-combat-dock-stat-label">${label}</span>
+      <span class="mech-combat-dock-stat-value">
+        <input class="lancer-stat minor" type="number" name="${valuePath}" value="${value}" data-dtype="Number" />
+        /
+        <span class="lancer-stat minor">${max}</span>
+      </span>
+    </div>`;
+
+  return `<div class="mech-combat-dock-stats flexrow">
+    ${chip("HP", stats.hp.value, stats.hp.max, "system.hp.value", "mdi mdi-heart-outline")}
+    ${chip("HEAT", stats.heat.value, stats.heat.max, "system.heat.value", "cci cci-heat")}
+    ${chip("STRUCT", stats.structure.value, stats.structure.max, "system.structure.value", "cci cci-structure")}
+    ${chip("STRESS", stats.stress.value, stats.stress.max, "system.stress.value", "cci cci-reactor")}
+  </div>`;
+}

--- a/src/module/helpers/mech-combat-dock.ts
+++ b/src/module/helpers/mech-combat-dock.ts
@@ -1,0 +1,83 @@
+import type { HelperOptions } from "handlebars";
+import type { LancerMECH } from "../actor/lancer-actor";
+import { LancerFlowState } from "../flows/interfaces";
+import { resolveHelperDotpath } from "./commons";
+import { action_button, actor_flow_button, is_combatant } from "./actor";
+import { buildCombatDockStatChipsHtml, COMBAT_DOCK_ATTACK_FLOW_TYPES } from "./mech-combat-dock-core";
+
+export { buildCombatDockStatChipsHtml, COMBAT_DOCK_ATTACK_FLOW_TYPES } from "./mech-combat-dock-core";
+export type { CombatDockStatSnapshot } from "./mech-combat-dock-core";
+
+/** Attack utility buttons rendered in the persistent combat dock. */
+export function buildCombatDockAttackUtilitiesHtml(): string {
+  const BasicFlowType = LancerFlowState.BasicFlowType;
+  const buttons = [
+    actor_flow_button("M/R", BasicFlowType.BasicAttack, {} as HelperOptions),
+    actor_flow_button("DMG", BasicFlowType.Damage, {} as HelperOptions),
+    actor_flow_button("TECH", BasicFlowType.TechAttack, {} as HelperOptions),
+  ];
+  return `<div class="mech-combat-dock-attacks flexrow">${buttons.join("")}</div>`;
+}
+
+function compactOverchargeDock(actor: LancerMECH, overchargeLevel: number): string {
+  const sequence = actor.system.overcharge_sequence.split(",");
+  const index = Math.max(0, Math.min(sequence.length - 1, overchargeLevel));
+  const value = sequence[index];
+  return `
+    <div class="mech-combat-dock-overcharge card clipped" data-tooltip="Overcharge">
+      <button type="button" class="lancer-flow-button lancer-button lancer-secondary" data-flow-type="Overcharge" data-flow-args="{}" aria-label="Roll overcharge">
+        <i class="fas fa-dice-d20 i--dark i--2" aria-hidden="true"></i>
+      </button>
+      <button type="button" class="overcharge-text lancer-button lancer-secondary">${value}</button>
+      <button type="button" class="overcharge-reset mdi mdi-restore" aria-label="Reset overcharge"></button>
+    </div>`;
+}
+
+function compactCoreToggle(checked: boolean): string {
+  return `
+    <div class="mech-combat-dock-core card clipped" data-tooltip="Core power">
+      <span class="minor">CORE</span>
+      <input name="system.core_energy" class="core-power-toggle" type="checkbox" data-dtype="Boolean" ${checked ? "checked" : ""} />
+    </div>`;
+}
+
+function compactActionTracker(actor: LancerMECH, options: HelperOptions): string {
+  if (!is_combatant(actor)) return "";
+  const buttons = [
+    action_button("P", "system.action_tracker.protocol", "protocol", options),
+    action_button("M", "system.action_tracker.move", "move", options),
+    action_button("F", "system.action_tracker.full", "full", options),
+    action_button("Q", "system.action_tracker.quick", "quick", options),
+    action_button("R", "system.action_tracker.reaction", "reaction", options),
+  ];
+  return `<div class="mech-combat-dock-actions flexrow">${buttons.join("")}</div>`;
+}
+
+/** Handlebars helper: persistent combat dock visible on every mech sheet tab. */
+export function mechCombatDock(options: HelperOptions): string {
+  const actor = (options.data?.root?.actor ?? resolveHelperDotpath(options, "actor")) as LancerMECH | undefined;
+  if (!actor?.is_mech()) return "";
+
+  const system = actor.system;
+  const statChips = buildCombatDockStatChipsHtml({
+    hp: system.hp,
+    heat: system.heat,
+    structure: system.structure,
+    stress: system.stress,
+  });
+  const overcharge = compactOverchargeDock(actor, system.overcharge);
+  const core = compactCoreToggle(system.core_energy);
+  const actions = compactActionTracker(actor, options);
+  const attacks = buildCombatDockAttackUtilitiesHtml();
+
+  return `
+    <aside class="mech-combat-dock card clipped" aria-label="${game.i18n.localize("lancer.mech-sheet.combat-dock.label")}">
+      ${statChips}
+      <div class="mech-combat-dock-controls flexrow">
+        ${overcharge}
+        ${core}
+        ${actions}
+        ${attacks}
+      </div>
+    </aside>`;
+}

--- a/src/module/helpers/mech-combat-gear-core.ts
+++ b/src/module/helpers/mech-combat-gear-core.ts
@@ -1,0 +1,60 @@
+import type { LancerMECH } from "../actor/lancer-actor";
+import type { LancerMECH_SYSTEM, LancerMECH_WEAPON } from "../item/lancer-item";
+
+export interface CombatGearCounts {
+  weaponCount: number;
+  systemCount: number;
+}
+
+/** Count equipped weapons and mounted systems for compact combat strips. */
+export function countCombatGear(loadout: LancerMECH["system"]["loadout"]): CombatGearCounts {
+  let weaponCount = 0;
+  for (const mount of loadout.weapon_mounts) {
+    for (const slot of mount.slots) {
+      if (slot.weapon?.value) weaponCount++;
+    }
+  }
+  return {
+    weaponCount,
+    systemCount: loadout.systems.filter(s => !!s.value).length,
+  };
+}
+
+/** Collect equipped weapons from all mount slots. */
+export function collectCombatWeapons(loadout: LancerMECH["system"]["loadout"]): LancerMECH_WEAPON[] {
+  const weapons: LancerMECH_WEAPON[] = [];
+  for (const mount of loadout.weapon_mounts) {
+    for (const slot of mount.slots) {
+      const weapon = slot.weapon?.value;
+      if (weapon) weapons.push(weapon);
+    }
+  }
+  return weapons;
+}
+
+/** Collect mounted systems. */
+export function collectCombatSystems(loadout: LancerMECH["system"]["loadout"]): LancerMECH_SYSTEM[] {
+  return loadout.systems.map(s => s.value).filter((s): s is LancerMECH_SYSTEM => !!s);
+}
+
+export function buildCompactWeaponCardHtml(weaponName: string, weaponPath: string): string {
+  return `
+    <div class="mech-combat-gear-card card clipped" data-item-id="${weaponPath}">
+      <span class="mech-combat-gear-name minor">${weaponName}</span>
+      <button type="button" class="roll-attack lancer-button lancer-secondary" data-tooltip="Roll attack">
+        <i class="fas fa-dice-d20 i--4 i--dark" aria-hidden="true"></i>
+        <span>FIRE</span>
+      </button>
+    </div>`;
+}
+
+export function buildCompactSystemCardHtml(systemName: string, systemPath: string): string {
+  return `
+    <div class="mech-combat-gear-card card clipped" data-item-id="${systemPath}">
+      <span class="mech-combat-gear-name minor">${systemName}</span>
+      <a class="chat-flow-button lancer-button lancer-secondary" data-tooltip="Use system">
+        <i class="mdi mdi-message i--4" aria-hidden="true"></i>
+        <span>USE</span>
+      </a>
+    </div>`;
+}

--- a/src/module/helpers/mech-combat-gear.ts
+++ b/src/module/helpers/mech-combat-gear.ts
@@ -1,0 +1,97 @@
+import type { HelperOptions } from "handlebars";
+import type { LancerMECH } from "../actor/lancer-actor";
+import { resolveHelperDotpath } from "./commons";
+import {
+  buildCompactSystemCardHtml,
+  buildCompactWeaponCardHtml,
+  collectCombatSystems,
+  collectCombatWeapons,
+  countCombatGear,
+} from "./mech-combat-gear-core";
+import { ref_params } from "./refs";
+
+export {
+  buildCompactSystemCardHtml,
+  buildCompactWeaponCardHtml,
+  collectCombatSystems,
+  collectCombatWeapons,
+  countCombatGear,
+} from "./mech-combat-gear-core";
+export type { CombatGearCounts } from "./mech-combat-gear-core";
+
+function renderWeaponCards(mech: LancerMECH, options: HelperOptions): string {
+  const cards: string[] = [];
+  const loadout = mech.system.loadout;
+  loadout.weapon_mounts.forEach((mount, mountIndex) => {
+    mount.slots.forEach((slot, slotIndex) => {
+      const weapon = slot.weapon?.value;
+      if (!weapon) return;
+      const weaponPath = `system.loadout.weapon_mounts.${mountIndex}.slots.${slotIndex}.weapon.value`;
+      cards.push(`
+        <div class="mech-combat-gear-card card clipped ref set" ${ref_params(weapon, weaponPath)}>
+          <span class="mech-combat-gear-name minor">${weapon.name}</span>
+          <button type="button" class="roll-attack lancer-button lancer-secondary" data-tooltip="Roll attack">
+            <i class="fas fa-dice-d20 i--4 i--dark" aria-hidden="true"></i>
+            <span>FIRE</span>
+          </button>
+        </div>`);
+    });
+  });
+  return cards.join("");
+}
+
+function renderSystemCards(mech: LancerMECH): string {
+  const cards: string[] = [];
+  mech.system.loadout.systems.forEach((sysRef, index) => {
+    const system = sysRef.value;
+    if (!system) return;
+    const systemPath = `system.loadout.systems.${index}.value`;
+    cards.push(`
+      <div class="mech-combat-gear-card card clipped ref set" ${ref_params(system, systemPath)}>
+        <span class="mech-combat-gear-name minor">${system.name}</span>
+        <a class="chat-flow-button lancer-button lancer-secondary" data-tooltip="Use system">
+          <i class="mdi mdi-message i--4" aria-hidden="true"></i>
+          <span>USE</span>
+        </a>
+      </div>`);
+  });
+  return cards.join("");
+}
+
+/** Compact weapon fire cards for the Stats/Combat tab. */
+export function mechCombatWeapons(options: HelperOptions): string {
+  const actor = (options.data?.root?.actor ?? resolveHelperDotpath(options, "actor")) as LancerMECH | undefined;
+  if (!actor?.is_mech()) return "";
+
+  const cards = renderWeaponCards(actor, options);
+  if (!cards) {
+    return `<p class="mech-combat-gear-empty note">${game.i18n.localize("lancer.mech-sheet.combat-gear.no-weapons")}</p>`;
+  }
+
+  return `
+    <section class="mech-combat-gear-section" data-mech-section="combat-weapons">
+      <div class="lancer-header lancer-primary sheet-section-header">
+        <span class="major">${game.i18n.localize("lancer.mech-sheet.combat-gear.weapons")}</span>
+      </div>
+      <div class="mech-combat-gear-grid flexrow wraprow">${cards}</div>
+    </section>`;
+}
+
+/** Compact system use cards for the Stats/Combat tab. */
+export function mechCombatSystems(options: HelperOptions): string {
+  const actor = (options.data?.root?.actor ?? resolveHelperDotpath(options, "actor")) as LancerMECH | undefined;
+  if (!actor?.is_mech()) return "";
+
+  const cards = renderSystemCards(actor);
+  if (!cards) {
+    return `<p class="mech-combat-gear-empty note">${game.i18n.localize("lancer.mech-sheet.combat-gear.no-systems")}</p>`;
+  }
+
+  return `
+    <section class="mech-combat-gear-section" data-mech-section="combat-systems">
+      <div class="lancer-header lancer-primary sheet-section-header">
+        <span class="major">${game.i18n.localize("lancer.mech-sheet.combat-gear.systems")}</span>
+      </div>
+      <div class="mech-combat-gear-grid flexrow wraprow">${cards}</div>
+    </section>`;
+}

--- a/src/module/helpers/mech-gear-mode-core.ts
+++ b/src/module/helpers/mech-gear-mode-core.ts
@@ -1,0 +1,11 @@
+export type GearTabMode = "play" | "edit";
+
+/** Resolve gear tab display mode from a data attribute value. */
+export function resolveGearTabMode(value: string | null | undefined): GearTabMode {
+  return value === "edit" ? "edit" : "play";
+}
+
+/** Whether the full loadout editor should render for the current gear mode. */
+export function shouldShowLoadoutEditor(mode: GearTabMode): boolean {
+  return mode === "edit";
+}

--- a/src/module/helpers/mech-sheet-ux-core.ts
+++ b/src/module/helpers/mech-sheet-ux-core.ts
@@ -1,0 +1,14 @@
+export interface EffectCategoryLike {
+  effects: unknown[];
+}
+
+/** Count total active effects across all categories for tab badge display. */
+export function countActiveEffects(categories: EffectCategoryLike[]): number {
+  return categories.reduce((sum, category) => sum + category.effects.length, 0);
+}
+
+/** Format the effects tab label with an optional count badge. */
+export function formatEffectsTabLabel(baseLabel: string, count: number): string {
+  if (count <= 0) return baseLabel;
+  return `${baseLabel} (${count})`;
+}

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -221,6 +221,83 @@
     margin-bottom: 0.75rem;
   }
 
+  .mech-combat-dock {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin: 0.35rem 0 0.5rem;
+    padding: 0.35rem 0.5rem;
+    background-color: var(--darken-2, #1a1a1a);
+    position: sticky;
+    top: 0;
+    z-index: 3;
+  }
+
+  .mech-combat-dock-stats {
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: stretch;
+  }
+
+  .mech-combat-dock-stat {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.45rem;
+    min-width: 5.5rem;
+    flex: 1 1 auto;
+  }
+
+  .mech-combat-dock-stat-label {
+    font-size: 0.65rem;
+    opacity: 0.85;
+    min-width: 2.75rem;
+  }
+
+  .mech-combat-dock-stat-value {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.1rem;
+    font-size: 0.8rem;
+
+    input.lancer-stat {
+      width: 2.25rem;
+      min-width: 2rem;
+      padding: 0 0.15rem;
+      text-align: center;
+    }
+  }
+
+  .mech-combat-dock-controls {
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+  }
+
+  .mech-combat-dock-overcharge,
+  .mech-combat-dock-core {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.2rem 0.35rem;
+  }
+
+  .mech-combat-dock-actions,
+  .mech-combat-dock-attacks {
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+
+    .lancer-action-button,
+    .lancer-flow-button {
+      min-width: 2.25rem;
+      padding: 0.2rem 0.4rem;
+      font-size: 0.7rem;
+    }
+  }
+
   .sheet-section-header.sticky {
     position: sticky;
     top: 0;

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -298,6 +298,38 @@
     }
   }
 
+  .mech-combat-gear-section {
+    margin-bottom: 0.75rem;
+  }
+
+  .mech-combat-gear-grid {
+    gap: 0.35rem;
+    align-items: stretch;
+  }
+
+  .mech-combat-gear-card {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.45rem;
+    min-width: 8rem;
+    flex: 1 1 10rem;
+  }
+
+  .mech-combat-gear-name {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mech-combat-gear-empty {
+    margin: 0.25rem 0 0.75rem;
+    opacity: 0.75;
+    font-size: 0.85rem;
+  }
+
   .sheet-section-header.sticky {
     position: sticky;
     top: 0;

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -348,6 +348,15 @@
     display: none;
   }
 
+  .mech-abilities-empty {
+    padding: 0.75rem 1rem;
+
+    .note {
+      margin: 0;
+      opacity: 0.85;
+    }
+  }
+
   .sheet-section-header.sticky {
     position: sticky;
     top: 0;

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -330,6 +330,24 @@
     font-size: 0.85rem;
   }
 
+  .gear-mode-toggle {
+    gap: 0.35rem;
+    padding: 0.35rem;
+    margin: 0.5rem 0;
+
+    .gear-mode-button.active {
+      background-color: var(--primary-highlight, fuchsia);
+    }
+  }
+
+  .tab.gear[data-gear-mode="play"] .gear-edit-panel {
+    display: none;
+  }
+
+  .tab.gear[data-gear-mode="edit"] .gear-play-panel {
+    display: none;
+  }
+
   .sheet-section-header.sticky {
     position: sticky;
     top: 0;

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "compatibility": {
     "minimum": 13,
     "verified": 14,

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "compatibility": {
     "minimum": 13,
     "verified": 14,

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "compatibility": {
     "minimum": 13,
     "verified": 14,

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "compatibility": {
     "minimum": 13,
     "verified": 14,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replaces the **Talents** tab with **Abilities** — frame details plus pilot talents in one place.
- Adds an **empty state** when no pilot is assigned to the mech.
- Shows an **active effect count badge** on the Effects tab when effects are present.

Stacks on #106, #107, and #108.

## Test plan

- [x] Unit tests: `npm test` (`scripts/mech-sheet-ux-polish.test.ts`)
- [x] E2E: `npx playwright test e2e/regression/mech-sheet-ux.spec.ts`
- [x] Production build: `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc8e7591-7e4a-45de-9901-f987b75433f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc8e7591-7e4a-45de-9901-f987b75433f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

