### PR TITLE
fix(mech-sheet): reorder combat tab layout (3.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changed
 
 - **Combat tab layout** — Weapons, mounted systems, and macros moved to the top; full stat grid directly below. Removed the redundant Systems utilities panel (overcharge, core, and size already live in the combat dock). Pilot link, GRIT/HASE rolls, and inventory kept in a compact row at the bottom of the tab.
+- **Combat dock core toggle** — Core checkbox matches the full-size sheet control (30px) instead of rendering as a tiny native checkbox.
 
 # 3.1.1 (2026-06-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.2 (2026-06-07)
+
+## Changed
+
+- **Combat tab layout** — Weapons, mounted systems, and macros moved to the top; full stat grid directly below. Removed the redundant Systems utilities panel (overcharge, core, and size already live in the combat dock). Pilot link, GRIT/HASE rolls, and inventory kept in a compact row at the bottom of the tab.
+
 # 3.1.1 (2026-06-07)
 
 ## Added

--- a/e2e/regression/mech-sheet-ux.spec.ts
+++ b/e2e/regression/mech-sheet-ux.spec.ts
@@ -45,6 +45,33 @@ test.describe("Mech sheet UX @regression", () => {
     expect(dockOnTalentsTab).toBe(true);
   });
 
+  test("combat tab orders gear before stats and omits redundant systems panel", async ({ page }) => {
+    const { mechId } = await seedRegressionWorld(page);
+    await openActorSheet(page, mechId);
+
+    const layout = await page.evaluate(async id => {
+      const actor = game.actors.get(id);
+      if (!actor?.sheet) return null;
+      actor.sheet.changeTab("combat", "primary", { force: true });
+      const tab = actor.sheet.element?.querySelector('.tab.combat[data-tab="combat"]') as HTMLElement | null;
+      if (!tab) return null;
+      const sections = [...tab.querySelectorAll("[data-mech-section]")].map(el =>
+        el.getAttribute("data-mech-section")
+      );
+      const weaponsIndex = sections.indexOf("combat-weapons");
+      const combatIndex = sections.indexOf("combat");
+      return {
+        hasSystemsPanel: !!tab.querySelector('[data-mech-section="systems"]'),
+        gearBeforeCombat: weaponsIndex >= 0 && combatIndex > weaponsIndex,
+        sections,
+      };
+    }, mechId);
+
+    expect(layout?.hasSystemsPanel).toBe(false);
+    expect(layout?.gearBeforeCombat).toBe(true);
+    expect(layout?.sections?.at(-1)).toBe("combat");
+  });
+
   test("combat gear cards and collapsed macros on stats tab", async ({ page }) => {
     const { mechId } = await seedRegressionWorld(page);
     await page.evaluate(async id => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -57,79 +57,6 @@
   {{!-- Sheet Body --}}
   <section class="sheet-body scroll-body">
     <div class="tab combat {{tabs.primary.combat.cssClass}}" data-group="primary" data-tab="combat">
-      <section class="mech-stat-section" data-mech-section="combat">
-        <div class="lancer-header lancer-primary sheet-section-header sticky">
-          <i
-            class="mdi mdi-unfold-less-horizontal collapse-trigger collapse-icon"
-            data-collapse-id="mech-stats-combat"
-          ></i>
-          <span class="major">{{localize "lancer.mech-sheet.sections.combat"}}</span>
-        </div>
-        <div class="collapse lancer-mech-stat-grid mech-combat-stat-grid" data-collapse-id="mech-stats-combat">
-          {{{stat-edit-max-card "HP" "mdi mdi-heart-outline" "system.hp.value" "system.hp.max"}}}
-          {{{stat-edit-max-card "HEAT" "cci cci-heat" "system.heat.value" "system.heat.max"}}}
-          {{{stat-view-card "EVASION" "cci cci-evasion" "system.evasion"}}}
-          {{{stat-view-card "ARMOR" "mdi mdi-shield-outline" "system.armor"}}}
-          {{{stat-edit-max-card "STRUCTURE" "cci cci-structure" "system.structure.value" "system.structure.max"}}}
-          {{{stat-edit-max-card "STRESS" "cci cci-reactor" "system.stress.value" "system.stress.max"}}}
-          {{{stat-view-card "E-DEF" "cci cci-edef" "system.edef"}}}
-          {{{stat-view-card "SPEED" "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed"}}}
-          {{{stat-view-card "SAVE" "cci cci-save" "system.save"}}}
-          {{{stat-view-card "SENSORS" "cci cci-sensor" "system.sensor_range"}}}
-          {{{tech-flow-card "TECH ATK" "cci cci-tech-full" "system.tech_attack"}}}
-          {{{stat-edit-rollable-card "BURN" "cci cci-burn" "system.burn"}}}
-          {{{stat-edit-card "O.SHIELD" "mdi mdi-shield-star-outline" "system.overshield.value"}}}
-          {{{stat-edit-max-card "REPAIRS" "cci cci-repair" "system.repairs.value" "system.repairs.max"}}}
-        </div>
-      </section>
-
-      <section class="mech-stat-section" data-mech-section="systems">
-        <div class="lancer-header lancer-primary sheet-section-header sticky">
-          <i
-            class="mdi mdi-unfold-less-horizontal collapse-trigger collapse-icon"
-            data-collapse-id="mech-stats-systems"
-          ></i>
-          <span class="major">{{localize "lancer.mech-sheet.sections.systems"}}</span>
-        </div>
-        <div class="collapse mech-systems-panel" data-collapse-id="mech-stats-systems">
-          <div class="mech-systems-utilities flexrow wraprow">
-            <div class="size-card card clipped">
-              {{#if (eq system.size 0.5)}}
-                <i class="cci cci-size-half size-icon theme--main"></i>
-              {{else}}
-                <i class="cci cci-size-{{system.size}} size-icon theme--main"></i>
-              {{/if}}
-            </div>
-            {{{overcharge-button actor "system.overcharge"}}}
-            <div class="flexcol card clipped">
-              <div class="lancer-header lancer-primary">
-                <span class="major">{{localize "lancer.mech-sheet.core.label"}}</span>
-              </div>
-              <div class="flexrow stat-container core-power-stat-container">
-                <input
-                  name="system.core_energy"
-                  class="core-power-toggle"
-                  type="checkbox"
-                  data-dtype="Boolean"
-                  {{checked system.core_energy}}
-                />
-              </div>
-            </div>
-            {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit"}}}
-            {{{pilot-slot "system.pilot" value=pilot}}}
-            <div class="wraprow double hase card clipped">
-              {{{stat-rollable-card "HUL" "" "system.hull"}}}
-              {{{stat-rollable-card "AGI" "" "system.agi"}}}
-              {{{stat-rollable-card "SYS" "" "system.sys"}}}
-              {{{stat-rollable-card "ENG" "" "system.eng"}}}
-            </div>
-            <div class="inventory card clipped">
-              <button class="lancer-button" type="button">{{localize "lancer.mech-sheet.inventory.label"}}</button>
-            </div>
-          </div>
-        </div>
-      </section>
-
       {{{mech-combat-weapons}}}
       {{{mech-combat-systems}}}
 
@@ -153,6 +80,46 @@
           </div>
         </div>
       </section>
+
+      <section class="mech-stat-section" data-mech-section="combat">
+        <div class="lancer-header lancer-primary sheet-section-header sticky">
+          <i
+            class="mdi mdi-unfold-less-horizontal collapse-trigger collapse-icon"
+            data-collapse-id="mech-stats-combat"
+          ></i>
+          <span class="major">{{localize "lancer.mech-sheet.sections.combat"}}</span>
+        </div>
+        <div class="collapse lancer-mech-stat-grid mech-combat-stat-grid" data-collapse-id="mech-stats-combat">
+          {{{stat-edit-max-card "HP" "mdi mdi-heart-outline" "system.hp.value" "system.hp.max"}}}
+          {{{stat-edit-max-card "HEAT" "cci cci-heat" "system.heat.value" "system.heat.max"}}}
+          {{{stat-view-card "EVASION" "cci cci-evasion" "system.evasion"}}}
+          {{{stat-view-card "ARMOR" "mdi mdi-shield-outline" "system.armor"}}}
+          {{{stat-edit-max-card "STRUCTURE" "cci cci-structure" "system.structure.value" "system.structure.max"}}}
+          {{{stat-edit-max-card "STRESS" "cci cci-reactor" "system.stress.value" "system.stress.max"}}}
+          {{{stat-view-card "E-DEF" "cci cci-edef" "system.edef"}}}
+          {{{stat-view-card "SPEED" "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed"}}}
+          {{{stat-view-card "SAVE" "cci cci-save" "system.save"}}}
+          {{{stat-view-card "SENSORS" "cci cci-sensor" "system.sensor_range"}}}
+          {{{tech-flow-card "TECH ATK" "cci cci-tech-full" "system.tech_attack"}}}
+          {{{stat-rollable-card "BURN" "cci cci-burn" "system.burn"}}}
+          {{{stat-edit-card "O.SHIELD" "mdi mdi-shield-star-outline" "system.overshield.value"}}}
+          {{{stat-edit-max-card "REPAIRS" "cci cci-repair" "system.repairs.value" "system.repairs.max"}}}
+        </div>
+      </section>
+
+      <div class="mech-combat-pilot-row flexrow wraprow">
+        {{{pilot-slot "system.pilot" value=pilot}}}
+        {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit"}}}
+        <div class="wraprow double hase card clipped">
+          {{{stat-rollable-card "HUL" "" "system.hull"}}}
+          {{{stat-rollable-card "AGI" "" "system.agi"}}}
+          {{{stat-rollable-card "SYS" "" "system.sys"}}}
+          {{{stat-rollable-card "ENG" "" "system.eng"}}}
+        </div>
+        <div class="inventory card clipped">
+          <button class="lancer-button" type="button">{{localize "lancer.mech-sheet.inventory.label"}}</button>
+        </div>
+      </div>
     </div>
 
     <div class="tab gear {{tabs.primary.gear.cssClass}}" data-group="primary" data-tab="gear" data-gear-mode="play">

--- a/src/module/helpers/mech-combat-dock.ts
+++ b/src/module/helpers/mech-combat-dock.ts
@@ -37,7 +37,9 @@ function compactCoreToggle(checked: boolean): string {
   return `
     <div class="mech-combat-dock-core card clipped" data-tooltip="Core power">
       <span class="minor">CORE</span>
-      <input name="system.core_energy" class="core-power-toggle" type="checkbox" data-dtype="Boolean" ${checked ? "checked" : ""} />
+      <div class="stat-container core-power-stat-container">
+        <input name="system.core_energy" class="core-power-toggle" type="checkbox" data-dtype="Boolean" ${checked ? "checked" : ""} />
+      </div>
     </div>`;
 }
 

--- a/src/module/helpers/mech-combat-gear.ts
+++ b/src/module/helpers/mech-combat-gear.ts
@@ -64,16 +64,15 @@ export function mechCombatWeapons(options: HelperOptions): string {
   if (!actor?.is_mech()) return "";
 
   const cards = renderWeaponCards(actor, options);
-  if (!cards) {
-    return `<p class="mech-combat-gear-empty note">${game.i18n.localize("lancer.mech-sheet.combat-gear.no-weapons")}</p>`;
-  }
+  const body = cards
+    || `<p class="mech-combat-gear-empty note">${game.i18n.localize("lancer.mech-sheet.combat-gear.no-weapons")}</p>`;
 
   return `
     <section class="mech-combat-gear-section" data-mech-section="combat-weapons">
       <div class="lancer-header lancer-primary sheet-section-header">
         <span class="major">${game.i18n.localize("lancer.mech-sheet.combat-gear.weapons")}</span>
       </div>
-      <div class="mech-combat-gear-grid flexrow wraprow">${cards}</div>
+      <div class="mech-combat-gear-grid flexrow wraprow">${body}</div>
     </section>`;
 }
 
@@ -83,15 +82,14 @@ export function mechCombatSystems(options: HelperOptions): string {
   if (!actor?.is_mech()) return "";
 
   const cards = renderSystemCards(actor);
-  if (!cards) {
-    return `<p class="mech-combat-gear-empty note">${game.i18n.localize("lancer.mech-sheet.combat-gear.no-systems")}</p>`;
-  }
+  const body = cards
+    || `<p class="mech-combat-gear-empty note">${game.i18n.localize("lancer.mech-sheet.combat-gear.no-systems")}</p>`;
 
   return `
     <section class="mech-combat-gear-section" data-mech-section="combat-systems">
       <div class="lancer-header lancer-primary sheet-section-header">
         <span class="major">${game.i18n.localize("lancer.mech-sheet.combat-gear.systems")}</span>
       </div>
-      <div class="mech-combat-gear-grid flexrow wraprow">${cards}</div>
+      <div class="mech-combat-gear-grid flexrow wraprow">${body}</div>
     </section>`;
 }

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -348,6 +348,25 @@
     display: none;
   }
 
+  .mech-combat-pilot-row {
+    gap: 0.5rem;
+    align-items: stretch;
+    margin-bottom: 0.75rem;
+
+    .hase {
+      flex: 1 1 12rem;
+      margin: 0;
+    }
+
+    .inventory {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 6rem;
+      padding: 0.35rem;
+    }
+  }
+
   .mech-abilities-empty {
     padding: 0.75rem 1rem;
 

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -284,6 +284,50 @@
     padding: 0.2rem 0.35rem;
   }
 
+  .mech-combat-dock-core {
+    .core-power-stat-container {
+      justify-content: center;
+    }
+
+    input.core-power-toggle {
+      -webkit-appearance: none;
+      appearance: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
+      width: 30px;
+      height: 30px;
+      min-width: 30px;
+      max-width: 30px;
+      flex: 0 0 auto;
+      margin: 0;
+      padding: 0;
+      cursor: pointer;
+      outline: 0;
+      border: none;
+      background: transparent;
+      font: normal normal normal 24px/1 "Material Design Icons";
+      -webkit-filter: none !important;
+      filter: none !important;
+
+      &::before {
+        display: block;
+        line-height: 1;
+      }
+
+      &:checked::before {
+        content: "\F0079";
+        color: var(--primary-color, #e67e22);
+      }
+
+      &:not(:checked)::before {
+        content: "\F007A";
+        color: grey;
+      }
+    }
+  }
+
   .mech-combat-dock-actions,
   .mech-combat-dock-attacks {
     flex-wrap: wrap;

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.1/lancer-v3.1.1.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.2/lancer-v3.1.2.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorganizes the **Combat** tab for play-first flow:

1. **WEAPONS** (compact FIRE cards)
2. **SYSTEMS** (compact USE cards)
3. **MACROS** (collapsed by default)
4. **COMBAT** (full stat grid)
5. Compact **pilot / GRIT / HASE / inventory** row at the bottom

Removes the redundant **Systems** utilities panel — overcharge, core, and frame size are already in the persistent combat dock.

## Test plan

- [x] E2E: `npx playwright test e2e/regression/mech-sheet-ux.spec.ts --grep "combat tab orders"`
- [x] Build: `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc8e7591-7e4a-45de-9901-f987b75433f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc8e7591-7e4a-45de-9901-f987b75433f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

