### PR TITLE
fix: Acc/Diff HUD overlap on blast weapons (Missile Rack, etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.4 (2026-06-07)
+
+## Fixed
+
+- **Attack Acc/Diff HUD layout** — advanced toggle and Manual Adjust no longer overlap on blast/AoE weapons (e.g. Missile Rack). Each block now has its own section spacing, the advanced button wraps cleanly, and manual adjust controls render in a single row.
+
 # 3.1.3 (2026-06-07)
 
 ## Fixed

--- a/e2e/regression/accdiff-hud.spec.ts
+++ b/e2e/regression/accdiff-hud.spec.ts
@@ -8,6 +8,35 @@ test.describe("Acc/Diff HUD @regression", () => {
     await seedRegressionWorld(page);
   });
 
+  test("advanced toggle and manual adjust do not overlap", async ({ page }) => {
+    await page.evaluate(() => {
+      const npc = game.actors.find(a => a.name === "E2E Test NPC");
+      const weapon = npc?.items.find(i => i.name === "E2E Test Weapon");
+      if (!weapon) throw new Error("E2E weapon missing");
+      void weapon.beginWeaponAttackFlow();
+    });
+
+    await expect(page.locator("#hudzone #accdiff")).toBeVisible({ timeout: 30_000 });
+
+    const layout = await page.evaluate(() => {
+      const toggle = document.querySelector<HTMLElement>("#hudzone #accdiff .accdiff-advanced-toggle__button");
+      const manual = document.querySelector<HTMLElement>("#hudzone #accdiff .accdiff-manual-adjust-input");
+      if (!toggle || !manual) throw new Error("Acc/Diff layout controls missing");
+      const toggleBox = toggle.getBoundingClientRect();
+      const manualBox = manual.getBoundingClientRect();
+      return {
+        separated: toggleBox.bottom <= manualBox.top + 1,
+        toggleBottom: toggleBox.bottom,
+        manualTop: manualBox.top,
+      };
+    });
+
+    expect(layout.separated).toBe(true);
+
+    await page.locator("#hudzone #accdiff .lancer-hud-buttons .cancel").click();
+    await expect(page.locator("#hudzone #accdiff")).toBeHidden({ timeout: 10_000 });
+  });
+
   test("advanced section collapses plugins and template tools by default", async ({ page }) => {
     await page.evaluate(() => {
       const npc = game.actors.find(a => a.name === "E2E Test NPC");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/html-editor.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/html-editor.test.ts scripts/accdiff-hud-layout.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -567,7 +567,7 @@
         "hint": "When enabled, the expanded/collapsed state of the Advanced section in the attack Acc/Diff HUD is remembered per weapon."
       },
       "advanced": "Advanced",
-      "showAdvanced": "Show plugins, templates, and per-target modifiers",
+      "showAdvanced": "Show advanced options",
       "hideAdvanced": "Hide advanced options"
     },
     "actionTracker": {
@@ -647,6 +647,7 @@
         "prone": "Prone (+1)",
         "stunned": "Stunned (EVA=5)",
         "lock-on": "Lock On (+1)",
+        "manual-adjust": "Manual Adjust",
         "add-global-accuracy": "Add global accuracy",
         "global-accuracy-difficulty": "Global Accuracy/Difficulty Adjustment",
         "add-global-difficulty": "Add global difficulty",

--- a/scripts/accdiff-hud-layout.test.ts
+++ b/scripts/accdiff-hud-layout.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const hudSource = readFileSync("src/module/apps/acc_diff/AccDiffHUD.svelte", "utf8");
+const inputSource = readFileSync("src/module/apps/acc_diff/AccDiffInput.svelte", "utf8");
+
+describe("Acc/Diff HUD layout", () => {
+  it("uses dedicated section wrappers for advanced toggle and manual adjust", () => {
+    assert.match(hudSource, /class="accdiff-advanced-toggle accdiff-grid__section"/);
+    assert.match(hudSource, /class="accdiff-manual-adjust accdiff-grid__section"/);
+    assert.doesNotMatch(hudSource, /class="flexcol accdiff-grid"[\s\S]*AccDiffInput/);
+  });
+
+  it("styles the advanced toggle button for wrapped label text", () => {
+    assert.match(hudSource, /accdiff-advanced-toggle__button/);
+  });
+
+  it("wraps manual adjust controls in a single root element", () => {
+    assert.match(inputSource, /class="accdiff-manual-adjust-input/);
+  });
+});

--- a/src/module/apps/acc_diff/AccDiffHUD.svelte
+++ b/src/module/apps/acc_diff/AccDiffHUD.svelte
@@ -417,8 +417,13 @@
     {/if}
 
     {#if hasAdvancedContent}
-      <div class="accdiff-advanced-toggle flexrow flex-center">
-        <button class="lancer-button lancer-secondary" type="button" on:click={toggleAdvanced}>
+      <div class="accdiff-advanced-toggle accdiff-grid__section">
+        <button
+          class="lancer-button lancer-secondary accdiff-advanced-toggle__button"
+          type="button"
+          aria-expanded={showAdvanced}
+          on:click={toggleAdvanced}
+        >
           <i class="fas fa-{showAdvanced ? 'chevron-up' : 'chevron-down'}" />
           {
             showAdvanced ? game.i18n.localize("lancer.accdiff.hideAdvanced") : game.i18n.localize("lancer.accdiff.showAdvanced")
@@ -474,10 +479,8 @@
     {/if}
 
     <!-- Total accuracy / Targets -->
-    <div class="flexcol accdiff-grid">
-      <div class="flexrow accdiff-grid__section" style="justify-content: space-evenly">
-        <AccDiffInput bind:value={base.accuracy} id="accdiff-manual-adjust" />
-      </div>
+    <div class="accdiff-manual-adjust accdiff-grid__section">
+      <AccDiffInput bind:value={base.accuracy} id="accdiff-manual-adjust" />
     </div>
     <div class="flexcol accdiff-footer lancer-border-primary">
       <div class="accdiff-total">
@@ -608,6 +611,25 @@
       #accdiff :global(.accdiff-grid) {
         display: flex;
         justify-content: space-between;
+      }
+
+      .accdiff-advanced-toggle {
+        display: flex;
+        justify-content: center;
+
+        &__button {
+          width: 100%;
+          max-width: 100%;
+          white-space: normal;
+          text-align: center;
+          line-height: 1.35;
+          padding: 0.45em 0.6em;
+        }
+      }
+
+      .accdiff-manual-adjust {
+        display: block;
+        width: 100%;
       }
 
       .accdiff-flat-bonus {

--- a/src/module/apps/acc_diff/AccDiffInput.svelte
+++ b/src/module/apps/acc_diff/AccDiffInput.svelte
@@ -5,45 +5,53 @@
   export let id: string;
 </script>
 
-<button
-  class="lancer-button dec-set"
-  type="button"
-  data-tooltip={hudL("accdiff.add-global-accuracy")}
-  aria-label={hudL("accdiff.add-global-accuracy")}
-  on:click={() => (value = value + 1)}
->
-  <i class="cci cci-accuracy i--3" />
-</button>
-<label for={id} class="flexcol" data-tooltip={hudL("accdiff.global-accuracy-difficulty")}>
-  <strong style="text-wrap: nowrap">Manual Adjust</strong>
-  <strong class="accdiff-value">
-    <span>{Math.abs(value)}</span>
-    <i class="i--3 cci" class:cci-accuracy={value >= 0} class:cci-difficulty={value < 0} />
-  </strong>
-</label>
-<input {id} class="difficulty lancer-invisible-input dec-set" style="display: none" type="number" bind:value />
-<button
-  class="lancer-button dec-set"
-  type="button"
-  data-tooltip={hudL("accdiff.add-global-difficulty")}
-  aria-label={hudL("accdiff.add-global-difficulty")}
-  on:click={() => (value = value - 1)}
->
-  <i class="cci cci-difficulty i--3" />
-</button>
+<div class="accdiff-manual-adjust-input flexrow flex-center">
+  <button
+    class="lancer-button dec-set"
+    type="button"
+    data-tooltip={hudL("accdiff.add-global-accuracy")}
+    aria-label={hudL("accdiff.add-global-accuracy")}
+    on:click={() => (value = value + 1)}
+  >
+    <i class="cci cci-accuracy i--3" />
+  </button>
+  <label for={id} class="flexcol" data-tooltip={hudL("accdiff.global-accuracy-difficulty")}>
+    <strong style="text-wrap: nowrap">{hudL("accdiff.manual-adjust")}</strong>
+    <strong class="accdiff-value">
+      <span>{Math.abs(value)}</span>
+      <i class="i--3 cci" class:cci-accuracy={value >= 0} class:cci-difficulty={value < 0} />
+    </strong>
+  </label>
+  <input {id} class="difficulty lancer-invisible-input dec-set" style="display: none" type="number" bind:value />
+  <button
+    class="lancer-button dec-set"
+    type="button"
+    data-tooltip={hudL("accdiff.add-global-difficulty")}
+    aria-label={hudL("accdiff.add-global-difficulty")}
+    on:click={() => (value = value - 1)}
+  >
+    <i class="cci cci-difficulty i--3" />
+  </button>
+</div>
 
 <style lang="scss">
   @layer lancer {
     @layer components {
+      .accdiff-manual-adjust-input {
+        width: 100%;
+        justify-content: space-evenly;
+      }
+
       .lancer-button {
         width: 5em;
         align-self: center;
+        flex-shrink: 0;
       }
 
       label {
         text-align: center;
         margin: 0 0.5em;
-        height: 3em;
+        min-height: 3em;
       }
 
       .accdiff-value {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.3/lancer-v3.1.3.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.4/lancer-v3.1.4.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes overlapping UI in the attack Acc/Diff HUD on weapons with blast/AoE templates (e.g. **Missile Rack**), where the **Show advanced options** toggle and **Manual Adjust** row were rendering on top of each other.

## Changes

- Give the advanced toggle and Manual Adjust each their own `accdiff-grid__section` block with clear vertical spacing
- Style the advanced toggle button to wrap its label at full width instead of overflowing into the next row
- Wrap Manual Adjust controls (`AccDiffInput`) in a single flex row container so the +/- buttons and label stay aligned
- Shorten the advanced toggle label to **Show advanced options** (matches **Hide advanced options**)
- Add layout regression tests (unit + Playwright bounding-box check)

## Version

Bumps to **3.1.4**.

## Test plan

- [x] `npm run test` (includes new `scripts/accdiff-hud-layout.test.ts`)
- [x] `npx dprint check` on touched Svelte/TS sources
- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`
- [ ] E2E: `npm run test:e2e` — new overlap check in `accdiff-hud.spec.ts` (requires Foundry)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c504d947-00a2-45b4-9f1d-a81fb6a958e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c504d947-00a2-45b4-9f1d-a81fb6a958e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

