### PR TITLE
fix: compact GRIT/HASE stat cards in mech combat pilot row (v3.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.5 (2026-06-07)
+
+## Fixed
+
+- **Mech combat pilot row** — GRIT and HASE stat cards no longer stretch to match the pilot portrait height. The row uses compact fixed grid tracks, smaller labels, and a constrained portrait slot.
+
 # 3.1.4 (2026-06-07)
 
 ## Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/html-editor.test.ts scripts/accdiff-hud-layout.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/html-editor.test.ts scripts/accdiff-hud-layout.test.ts scripts/mech-pilot-row-compact.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/scripts/mech-pilot-row-compact.test.ts
+++ b/scripts/mech-pilot-row-compact.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const actorSheetStyles = readFileSync("src/styles/applications/_actor-sheet.scss", "utf8");
+
+describe("mech combat pilot row compact layout", () => {
+  it("does not stretch stat cards to the pilot portrait height", () => {
+    const block = actorSheetStyles.match(/\.mech-combat-pilot-row\s*\{[\s\S]*?\n  \}/);
+    assert.ok(block, "expected .mech-combat-pilot-row styles");
+    assert.match(block[0], /align-items:\s*flex-start/);
+  });
+
+  it("uses fixed grid tracks for grit and hase stat cards", () => {
+    assert.match(actorSheetStyles, /\.mech-combat-pilot-row[\s\S]*grid-template:\s*minmax\(/);
+  });
+
+  it("constrains the pilot portrait slot", () => {
+    assert.match(actorSheetStyles, /\.mech-combat-pilot-row[\s\S]*\.pilot-summary[\s\S]*flex:\s*0\s+0/);
+  });
+});

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -394,11 +394,46 @@
 
   .mech-combat-pilot-row {
     gap: 0.5rem;
-    align-items: stretch;
+    align-items: flex-start;
     margin-bottom: 0.75rem;
 
+    .pilot-summary {
+      flex: 0 0 4.75rem;
+      width: 4.75rem;
+      margin: 0;
+      align-self: center;
+    }
+
+    > .stat-card,
+    .hase > .stat-card {
+      grid-template: minmax(1.4em, auto) minmax(1.6em, auto) / 1fr;
+      margin: 0;
+    }
+
+    > .stat-card {
+      flex: 0 0 4.75rem;
+    }
+
+    .stat-card .lancer-header {
+      flex: unset;
+      min-height: 0;
+      padding-top: 0.1em;
+      padding-bottom: 0.1em;
+
+      .major {
+        font-size: 0.8rem;
+        line-height: 1.1;
+      }
+    }
+
+    .stat-card .lancer-stat.major {
+      font-size: 1rem;
+      line-height: 1.2;
+    }
+
     .hase {
-      flex: 1 1 12rem;
+      flex: 1 1 9.5rem;
+      max-width: 13rem;
       margin: 0;
     }
 
@@ -408,6 +443,8 @@
       justify-content: center;
       min-width: 6rem;
       padding: 0.35rem;
+      margin: 0;
+      align-self: center;
     }
   }
 

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.4/lancer-v3.1.4.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.5/lancer-v3.1.5.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The bottom combat-tab row (pilot portrait, GRIT, HUL/SYS/AGI/ENG, inventory) had stat cards that stretched vertically to match the pilot portrait. Orange header blocks ended up much taller than needed.

## Changes

- Switch `.mech-combat-pilot-row` from `align-items: stretch` to `flex-start` so stat cards keep their natural height
- Use fixed `minmax` grid tracks on GRIT/HASE `.stat-card` elements (matching the approach used in `.lancer-mech-stat-grid`)
- Constrain the pilot portrait slot to a compact fixed width
- Reduce label and stat font sizes within this row
- Add regression tests in `scripts/mech-pilot-row-compact.test.ts`
- Bump version to **3.1.5**

## Testing

- [x] `npm test` (24 tests pass)
- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`
- [ ] Foundry visual check (Docker unavailable in cloud VM)

After merge, push tag `v3.1.5` to trigger the release workflow.

---

## Superseded — do not merge

**Closed without merge.** The problem this PR addressed is already fixed on `master` via a different approach:

| PR | Version | Resolution |
|----|---------|------------|
| #114 | 3.1.6 | Replaced tall stat cards with inline roll chips |
| #115 | 3.1.7 | Moved pilot row into the mech sheet header (`.mech-header-pilot-row`) |
| #116 | 3.1.8 | Portrait frame and chip/button visual polish |

This branch still compacts `.mech-combat-pilot-row` stat cards, but `master` no longer uses that layout or those stat cards. The Handlebars helper name `mech-combat-pilot-row` remains, but it renders compact roll chips in the header. No code from this PR needs to land on `master`.

Reviewed 2026-06-08 by Cursor Cloud Agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b820b55-092f-451a-805b-76a940ca55ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b820b55-092f-451a-805b-76a940ca55ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

