### PR TITLE
feat: inline roll chips for mech combat pilot row (v3.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.6 (2026-06-07)
+
+## Changed
+
+- **Mech combat pilot row** — GRIT and HASE stats now use inline roll chips (matching the combat dock style) instead of tall stat cards. Portrait, rolls, and inventory fit on one compact horizontal row.
+
 # 3.1.4 (2026-06-07)
 
 ## Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.4",
+  "version": "3.1.6",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/html-editor.test.ts scripts/accdiff-hud-layout.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/html-editor.test.ts scripts/accdiff-hud-layout.test.ts scripts/mech-pilot-row.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -107,19 +107,7 @@
         </div>
       </section>
 
-      <div class="mech-combat-pilot-row flexrow wraprow">
-        {{{pilot-slot "system.pilot" value=pilot}}}
-        {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit"}}}
-        <div class="wraprow double hase card clipped">
-          {{{stat-rollable-card "HUL" "" "system.hull"}}}
-          {{{stat-rollable-card "AGI" "" "system.agi"}}}
-          {{{stat-rollable-card "SYS" "" "system.sys"}}}
-          {{{stat-rollable-card "ENG" "" "system.eng"}}}
-        </div>
-        <div class="inventory card clipped">
-          <button class="lancer-button" type="button">{{localize "lancer.mech-sheet.inventory.label"}}</button>
-        </div>
-      </div>
+      {{{mech-combat-pilot-row pilot=pilot}}}
     </div>
 
     <div class="tab gear {{tabs.primary.gear.cssClass}}" data-group="primary" data-tab="gear" data-gear-mode="play">

--- a/public/templates/actor/pilot.hbs
+++ b/public/templates/actor/pilot.hbs
@@ -24,26 +24,14 @@
     </div>
     {{{ref-portrait-img actor.img "img" actor}}}
     <div class="header-details pilot-stats flexrow">
-      {{
-        {compact-stat-edit "mdi mdi-heart-outline" "system.hp.value" "system.hp.max" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.hp")}
-      }}
-      {{
-        {compact-stat-edit "mdi mdi-shield-star-outline" "system.overshield.value" "" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.overshield")}
-      }}
-      {{
-        {compact-stat-view "mdi mdi-shield-outline" "system.armor" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.armor")}
-      }}
-      {{
-        {compact-stat-view "cci cci-evasion" "system.evasion" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.evasion")}
-      }}
+      {{{compact-stat-edit "mdi mdi-heart-outline" "system.hp.value" "system.hp.max" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.hp")}}}
+      {{{compact-stat-edit "mdi mdi-shield-star-outline" "system.overshield.value" "" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.overshield")}}}
+      {{{compact-stat-view "mdi mdi-shield-outline" "system.armor" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.armor")}}}
+      {{{compact-stat-view "cci cci-evasion" "system.evasion" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.evasion")}}}
       {{{compact-stat-view "cci cci-edef" "system.edef" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.edef")}}}
-      {{
-        {compact-stat-view "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.speed")}
-      }}
+      {{{compact-stat-view "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.speed")}}}
       {{{compact-stat-view "cci cci-save" "system.save" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.save")}}}
-      {{
-        {compact-stat-view "cci cci-sensor" "system.sensor_range" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.sensor_range")}
-      }}
+      {{{compact-stat-view "cci cci-sensor" "system.sensor_range" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.sensor_range")}}}
     </div>
   </header>
 
@@ -120,12 +108,8 @@
     <div class="tab pilot flexcol {{tabs.primary.narrative.cssClass}}" data-group="primary" data-tab="narrative">
       <div class="card clipped">
         <div class="flexrow">
-          {{
-            {clicker-stat-card "LICENSE LEVEL" "mdi mdi-shield-outline" "system.level" false tooltip=(localize "lancer.pilot-sheet.stat-tooltip.license_level")}
-          }}
-          {{
-            {stat-rollable-card "GRIT" "cci cci-armor" "system.grit" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.grit")}
-          }}
+          {{{clicker-stat-card "LICENSE LEVEL" "mdi mdi-shield-outline" "system.level" false tooltip=(localize "lancer.pilot-sheet.stat-tooltip.license_level")}}}
+          {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.grit")}}}
         </div>
       </div>
 

--- a/public/templates/actor/pilot.hbs
+++ b/public/templates/actor/pilot.hbs
@@ -24,14 +24,26 @@
     </div>
     {{{ref-portrait-img actor.img "img" actor}}}
     <div class="header-details pilot-stats flexrow">
-      {{{compact-stat-edit "mdi mdi-heart-outline" "system.hp.value" "system.hp.max" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.hp")}}}
-      {{{compact-stat-edit "mdi mdi-shield-star-outline" "system.overshield.value" "" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.overshield")}}}
-      {{{compact-stat-view "mdi mdi-shield-outline" "system.armor" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.armor")}}}
-      {{{compact-stat-view "cci cci-evasion" "system.evasion" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.evasion")}}}
+      {{
+        {compact-stat-edit "mdi mdi-heart-outline" "system.hp.value" "system.hp.max" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.hp")}
+      }}
+      {{
+        {compact-stat-edit "mdi mdi-shield-star-outline" "system.overshield.value" "" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.overshield")}
+      }}
+      {{
+        {compact-stat-view "mdi mdi-shield-outline" "system.armor" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.armor")}
+      }}
+      {{
+        {compact-stat-view "cci cci-evasion" "system.evasion" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.evasion")}
+      }}
       {{{compact-stat-view "cci cci-edef" "system.edef" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.edef")}}}
-      {{{compact-stat-view "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.speed")}}}
+      {{
+        {compact-stat-view "mdi mdi-arrow-right-bold-hexagon-outline" "system.speed" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.speed")}
+      }}
       {{{compact-stat-view "cci cci-save" "system.save" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.save")}}}
-      {{{compact-stat-view "cci cci-sensor" "system.sensor_range" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.sensor_range")}}}
+      {{
+        {compact-stat-view "cci cci-sensor" "system.sensor_range" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.sensor_range")}
+      }}
     </div>
   </header>
 
@@ -108,8 +120,12 @@
     <div class="tab pilot flexcol {{tabs.primary.narrative.cssClass}}" data-group="primary" data-tab="narrative">
       <div class="card clipped">
         <div class="flexrow">
-          {{{clicker-stat-card "LICENSE LEVEL" "mdi mdi-shield-outline" "system.level" false tooltip=(localize "lancer.pilot-sheet.stat-tooltip.license_level")}}}
-          {{{stat-rollable-card "GRIT" "cci cci-armor" "system.grit" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.grit")}}}
+          {{
+            {clicker-stat-card "LICENSE LEVEL" "mdi mdi-shield-outline" "system.level" false tooltip=(localize "lancer.pilot-sheet.stat-tooltip.license_level")}
+          }}
+          {{
+            {stat-rollable-card "GRIT" "cci cci-armor" "system.grit" tooltip=(localize "lancer.pilot-sheet.stat-tooltip.grit")}
+          }}
         </div>
       </div>
 

--- a/scripts/mech-pilot-row.test.ts
+++ b/scripts/mech-pilot-row.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import {
+  buildMechPilotRowStatsHtml,
+  buildRollStatChipHtml,
+  MECH_PILOT_HASE_PATHS,
+} from "../src/module/helpers/mech-pilot-row-core.ts";
+
+describe("mech pilot row roll chips", () => {
+  it("buildRollStatChipHtml renders inline label, value, and roll control", () => {
+    const html = buildRollStatChipHtml({
+      label: "GRIT",
+      value: 0,
+      dataPath: "system.grit",
+      tooltip: "Roll Grit",
+      rollButtonHtml: '<a class="roll-stat lancer-button" data-path="system.grit"></a>',
+      extraActionHtml: '<a class="lancer-flow-button lancer-button" data-flow-type="BasicAttack"></a>',
+    });
+
+    assert.match(html, /mech-pilot-roll-chip/);
+    assert.match(html, /mech-pilot-roll-chip-label">GRIT</);
+    assert.match(html, /data-path="system\.grit">0</);
+    assert.match(html, /roll-stat/);
+    assert.match(html, /data-flow-type="BasicAttack"/);
+    assert.match(html, /data-tooltip="Roll Grit"/);
+  });
+
+  it("buildMechPilotRowStatsHtml wraps chips in a horizontal flex row", () => {
+    const html = buildMechPilotRowStatsHtml(['<div class="mech-pilot-roll-chip"></div>']);
+    assert.match(html, /mech-pilot-roll-chips flexrow/);
+  });
+
+  it("orders HASE stats HUL, SYS, AGI, ENG", () => {
+    assert.deepEqual(MECH_PILOT_HASE_PATHS, [
+      { label: "HUL", path: "system.hull" },
+      { label: "SYS", path: "system.sys" },
+      { label: "AGI", path: "system.agi" },
+      { label: "ENG", path: "system.eng" },
+    ]);
+  });
+
+  it("styles the pilot row as inline chips instead of stat-cards", () => {
+    const styles = readFileSync("src/styles/applications/_actor-sheet.scss", "utf8");
+    const block = styles.match(/\.mech-combat-pilot-row\s*\{[\s\S]*?\n  \}/);
+    assert.ok(block, "expected .mech-combat-pilot-row styles");
+    assert.match(block[0], /\.mech-pilot-roll-chip/);
+    assert.doesNotMatch(block[0], /\.stat-card/);
+  });
+});

--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -49,6 +49,16 @@ function _basicFlowButton(uuid: string, type = "BasicAttack", overrides: ButtonO
   return _flowButton("lancer-flow-button", data, overrides);
 }
 
+/** Roll-stat control for inline pilot-row chips and stat cards. */
+export function rollStatButton(uuid: string, path: string, overrides: ButtonOverrides = {}): string {
+  return _statFlowButton(uuid, path, overrides);
+}
+
+/** Basic-attack flow control (e.g. on grit chip). */
+export function basicAttackButton(uuid: string, overrides: ButtonOverrides = {}): string {
+  return _basicFlowButton(uuid, "BasicAttack", overrides);
+}
+
 export function getActorUUID(options: HelperOptions): string | null {
   // Determine whether this is an unlinked token, so we can encode the correct id for the macro.
   const rActor = options.data.root.actor as LancerActor | undefined;

--- a/src/module/helpers/index.ts
+++ b/src/module/helpers/index.ts
@@ -74,6 +74,7 @@ import {
 } from "./refs";
 import { mechLoadout, pilotSlot, frameView } from "./loadout";
 import { mechCombatDock } from "./mech-combat-dock";
+import { mechCombatPilotRow } from "./mech-pilot-row";
 import { mechCombatSystems, mechCombatWeapons } from "./mech-combat-gear";
 import {
   item_edit_arrayed_actions,
@@ -360,6 +361,7 @@ export function registerHandlebarsHelpers() {
   Handlebars.registerHelper("mech-loadout", mechLoadout);
   Handlebars.registerHelper("mech-frame", frameView);
   Handlebars.registerHelper("mech-combat-dock", mechCombatDock);
+  Handlebars.registerHelper("mech-combat-pilot-row", mechCombatPilotRow);
   Handlebars.registerHelper("mech-combat-weapons", mechCombatWeapons);
   Handlebars.registerHelper("mech-combat-systems", mechCombatSystems);
 

--- a/src/module/helpers/mech-pilot-row-core.ts
+++ b/src/module/helpers/mech-pilot-row-core.ts
@@ -1,0 +1,37 @@
+export interface RollStatChipSpec {
+  label: string;
+  value: string | number;
+  dataPath: string;
+  tooltip?: string;
+  rollButtonHtml: string;
+  extraActionHtml?: string;
+}
+
+/** HASE display order on the mech combat pilot row (matches Lancer mnemonic). */
+export const MECH_PILOT_HASE_PATHS = [
+  { label: "HUL", path: "system.hull" },
+  { label: "SYS", path: "system.sys" },
+  { label: "AGI", path: "system.agi" },
+  { label: "ENG", path: "system.eng" },
+] as const;
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+/** Inline roll chip markup (dock-style) for grit and HASE stats. */
+export function buildRollStatChipHtml(spec: RollStatChipSpec): string {
+  const tooltip = spec.tooltip ? ` data-tooltip="${escapeAttr(spec.tooltip)}"` : "";
+  const extra = spec.extraActionHtml ?? "";
+  return `
+    <div class="mech-pilot-roll-chip card clipped"${tooltip}>
+      <span class="mech-pilot-roll-chip-label">${spec.label}</span>
+      <span class="mech-pilot-roll-chip-value lancer-stat minor" data-path="${spec.dataPath}">${spec.value}</span>
+      <span class="mech-pilot-roll-chip-actions flexrow">${spec.rollButtonHtml}${extra}</span>
+    </div>`;
+}
+
+/** Horizontal strip of roll chips between portrait and inventory. */
+export function buildMechPilotRowStatsHtml(chips: string[]): string {
+  return `<div class="mech-pilot-roll-chips flexrow">${chips.join("")}</div>`;
+}

--- a/src/module/helpers/mech-pilot-row.ts
+++ b/src/module/helpers/mech-pilot-row.ts
@@ -1,0 +1,64 @@
+import type { HelperOptions } from "handlebars";
+import type { LancerMECH, LancerPILOT } from "../actor/lancer-actor";
+import { basicAttackButton, getActorUUID, rollStatButton } from "./actor";
+import { resolveHelperDotpath } from "./commons";
+import { pilotSlot } from "./loadout";
+import { buildMechPilotRowStatsHtml, buildRollStatChipHtml, MECH_PILOT_HASE_PATHS } from "./mech-pilot-row-core";
+
+export {
+  buildMechPilotRowStatsHtml,
+  buildRollStatChipHtml,
+  MECH_PILOT_HASE_PATHS,
+} from "./mech-pilot-row-core";
+export type { RollStatChipSpec } from "./mech-pilot-row-core";
+
+function pilotStatTooltip(key: string): string {
+  return game.i18n.localize(`lancer.pilot-sheet.stat-tooltip.${key}`);
+}
+
+/** Handlebars helper: compact pilot portrait + grit/HASE roll chips + inventory. */
+export function mechCombatPilotRow(options: HelperOptions): string {
+  const actor = options.data?.root?.actor as LancerMECH | undefined;
+  if (!actor?.is_mech()) return "";
+
+  const uuid = getActorUUID(options);
+  if (!uuid) return "";
+
+  const pilot = options.hash.pilot as LancerPILOT | undefined;
+  const portrait = pilotSlot("system.pilot", { ...options, hash: { ...options.hash, value: pilot } });
+
+  const gritChip = buildRollStatChipHtml({
+    label: "GRIT",
+    value: resolveHelperDotpath(options, "system.grit", 0),
+    dataPath: "system.grit",
+    tooltip: pilotStatTooltip("grit"),
+    rollButtonHtml: rollStatButton(uuid, "system.grit"),
+    extraActionHtml: basicAttackButton(uuid, {
+      icon: "cci cci-weapon",
+      tooltip: "Roll a basic attack",
+    }),
+  });
+
+  const haseChips = MECH_PILOT_HASE_PATHS.map(({ label, path }) => {
+    const tooltipKey = path.replace("system.", "");
+    return buildRollStatChipHtml({
+      label,
+      value: resolveHelperDotpath(options, path, 0),
+      dataPath: path,
+      tooltip: pilotStatTooltip(tooltipKey),
+      rollButtonHtml: rollStatButton(uuid, path),
+    });
+  });
+
+  const stats = buildMechPilotRowStatsHtml([gritChip, ...haseChips]);
+  const inventoryLabel = game.i18n.localize("lancer.mech-sheet.inventory.label");
+
+  return `
+    <div class="mech-combat-pilot-row flexrow">
+      ${portrait}
+      ${stats}
+      <div class="inventory card clipped">
+        <button class="lancer-button" type="button">${inventoryLabel}</button>
+      </div>
+    </div>`;
+}

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -393,21 +393,79 @@
   }
 
   .mech-combat-pilot-row {
-    gap: 0.5rem;
-    align-items: stretch;
+    gap: 0.35rem;
+    align-items: center;
     margin-bottom: 0.75rem;
+    flex-wrap: wrap;
 
-    .hase {
-      flex: 1 1 12rem;
+    .pilot-summary {
+      flex: 0 0 3rem;
+      width: 3rem;
+      height: 3rem;
       margin: 0;
+      min-height: 0;
+      padding: 0;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .license-level {
+        font-size: 0.85rem;
+      }
+    }
+
+    .mech-pilot-roll-chips {
+      flex: 1 1 auto;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+      align-items: center;
+      min-width: 0;
+    }
+
+    .mech-pilot-roll-chip {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.2rem 0.45rem;
+      margin: 0;
+      min-width: 4.75rem;
+      flex: 0 1 auto;
+    }
+
+    .mech-pilot-roll-chip-label {
+      font-size: 0.65rem;
+      opacity: 0.85;
+      min-width: 2rem;
+      text-transform: uppercase;
+    }
+
+    .mech-pilot-roll-chip-value {
+      font-size: 0.85rem;
+      min-width: 1rem;
+      text-align: center;
+    }
+
+    .mech-pilot-roll-chip-actions {
+      gap: 0.15rem;
+      margin-left: auto;
+      align-items: center;
+
+      .lancer-button {
+        padding: 0.1rem 0.2rem;
+      }
     }
 
     .inventory {
       display: flex;
       align-items: center;
       justify-content: center;
-      min-width: 6rem;
-      padding: 0.35rem;
+      flex: 0 0 auto;
+      margin: 0;
+      padding: 0.2rem 0.5rem;
     }
   }
 

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.4",
+  "version": "3.1.6",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.4/lancer-v3.1.4.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.6/lancer-v3.1.6.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the tall GRIT/HASE stat cards in the mech combat pilot row with **inline roll chips** matching the combat dock pattern.

## Changes

- New `mech-combat-pilot-row` Handlebars helper rendering portrait + horizontal roll chips + inventory
- Chips show `LABEL · value · roll` (GRIT also includes basic attack)
- HASE order: HUL, SYS, AGI, ENG
- Compact SCSS aligned with `.mech-combat-dock-stat` density (~3rem row height)
- Regression tests in `scripts/mech-pilot-row.test.ts`
- Version **3.1.6**

## Testing

- [x] `npm test` (25 tests)
- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`

Supersedes the reverted v3.1.5 stat-card shrink approach.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b820b55-092f-451a-805b-76a940ca55ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b820b55-092f-451a-805b-76a940ca55ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

