### PR TITLE
feat: move pilot roll chips into mech sheet header (v3.1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.7 (2026-06-07)
+
+## Changed
+
+- **Mech sheet header** — pilot portrait, GRIT/HASE roll chips, and inventory moved from the combat tab into the sheet header so they stay visible on every tab.
+
 # 3.1.6 (2026-06-07)
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -21,6 +21,7 @@
             {{itemTypes.frame.0.name}}</span>
         {{/if}}
       </div>
+      {{{mech-combat-pilot-row pilot=pilot}}}
     </header>
 
     {{{mech-combat-dock}}}
@@ -106,8 +107,6 @@
           {{{stat-edit-max-card "REPAIRS" "cci cci-repair" "system.repairs.value" "system.repairs.max"}}}
         </div>
       </section>
-
-      {{{mech-combat-pilot-row pilot=pilot}}}
     </div>
 
     <div class="tab gear {{tabs.primary.gear.cssClass}}" data-group="primary" data-tab="gear" data-gear-mode="play">

--- a/scripts/mech-pilot-row.test.ts
+++ b/scripts/mech-pilot-row.test.ts
@@ -42,9 +42,19 @@ describe("mech pilot row roll chips", () => {
 
   it("styles the pilot row as inline chips instead of stat-cards", () => {
     const styles = readFileSync("src/styles/applications/_actor-sheet.scss", "utf8");
-    const block = styles.match(/\.mech-combat-pilot-row\s*\{[\s\S]*?\n  \}/);
-    assert.ok(block, "expected .mech-combat-pilot-row styles");
+    const block = styles.match(/\.mech-header-pilot-row\s*\{[\s\S]*?\n  \}/);
+    assert.ok(block, "expected .mech-header-pilot-row styles");
     assert.match(block[0], /\.mech-pilot-roll-chip/);
     assert.doesNotMatch(block[0], /\.stat-card/);
+  });
+
+  it("renders pilot row in the mech sheet header, not the combat tab body", () => {
+    const template = readFileSync("public/templates/actor/mech.hbs", "utf8");
+    const headerBlock = template.match(/<header[\s\S]*?<\/header>/);
+    assert.ok(headerBlock, "expected mech sheet header");
+    assert.match(headerBlock[0], /mech-combat-pilot-row/);
+    const combatTab = template.match(/tab combat[\s\S]*?<\/div>\s*<div class="tab gear/);
+    assert.ok(combatTab, "expected combat tab");
+    assert.doesNotMatch(combatTab[0], /mech-combat-pilot-row/);
   });
 });

--- a/src/module/helpers/mech-pilot-row.ts
+++ b/src/module/helpers/mech-pilot-row.ts
@@ -54,7 +54,7 @@ export function mechCombatPilotRow(options: HelperOptions): string {
   const inventoryLabel = game.i18n.localize("lancer.mech-sheet.inventory.label");
 
   return `
-    <div class="mech-combat-pilot-row flexrow">
+    <div class="mech-header-pilot-row flexrow">
       ${portrait}
       ${stats}
       <div class="inventory card clipped">

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -392,10 +392,9 @@
     display: none;
   }
 
-  .mech-combat-pilot-row {
+  .mech-header-pilot-row {
     gap: 0.35rem;
     align-items: center;
-    margin-bottom: 0.75rem;
     flex-wrap: wrap;
 
     .pilot-summary {
@@ -640,12 +639,30 @@
   .lancer.sheet header.sheet-header.lancer-mech-sheet-header {
     min-height: 5.9rem;
     padding: 0.35em 0.5em 0.35em 0.75em;
-    grid-template-rows: minmax(3.25rem, auto) auto;
+    grid-template-rows: minmax(3.25rem, auto) auto auto;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(112px, 170px);
+    grid-template-areas:
+      "name name name img"
+      "details details details img"
+      "pilot pilot pilot img";
 
     .header-details {
+      grid-area: details;
       min-width: 0;
       flex-wrap: wrap;
+    }
+
+    .mech-header-pilot-row {
+      grid-area: pilot;
+      margin: 0;
+      padding-top: 0.2rem;
+      width: 100%;
+      min-width: 0;
+    }
+
+    .portrait-img-container {
+      grid-area: img;
+      align-self: stretch;
     }
 
     h1.name {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.6/lancer-v3.1.6.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.7/lancer-v3.1.7.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the pilot portrait, GRIT/HASE roll chips, and inventory button from the bottom of the combat tab into the **mech sheet header**, so they stay visible on every tab alongside the combat dock.

## Changes

- `mech.hbs`: pilot row helper call relocated into `<header>`
- Header grid extended with a third row (`pilot` area) spanning columns 1–3; mech portrait spans all rows
- Renamed row class to `mech-header-pilot-row`
- Version **3.1.7**

## Testing

- [x] `npm test` (26 tests)
- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b820b55-092f-451a-805b-76a940ca55ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b820b55-092f-451a-805b-76a940ca55ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

