### PR TITLE
Polish mech sheet portraits and combat buttons (v3.1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 3.1.8 (2026-06-08)
+
+## Changed
+
+- **Mech sheet header portrait** — pilot thumbnail enlarged with a visible frame, brightness boost, and a lighter license badge overlay so portraits read clearly on dark headers.
+- **Mech header controls** — GRIT/HASE roll chips and the View Inventory button use gradient fills, accent borders, and hover glow for clearer affordance.
+- **Combat gear cards** — compact weapon and system rows show item thumbnails plus polished FIRE (weapon accent) and USE (system accent) action buttons.
+
 # 3.1.7 (2026-06-07)
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/html-editor.test.ts scripts/accdiff-hud-layout.test.ts scripts/mech-pilot-row.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/mech-sheet-visual-polish.test.ts scripts/html-editor.test.ts scripts/accdiff-hud-layout.test.ts scripts/mech-pilot-row.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/scripts/mech-sheet-visual-polish.test.ts
+++ b/scripts/mech-sheet-visual-polish.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import {
+  buildCompactSystemCardHtml,
+  buildCompactWeaponCardHtml,
+  COMBAT_GEAR_SYSTEM_IMG_FALLBACK,
+  COMBAT_GEAR_WEAPON_IMG_FALLBACK,
+  combatGearItemImgSrc,
+} from "../src/module/helpers/mech-combat-gear-core.ts";
+import { buildInventoryButtonHtml } from "../src/module/helpers/mech-pilot-row-core.ts";
+
+describe("mech sheet visual polish", () => {
+  it("combatGearItemImgSrc falls back when img is empty", () => {
+    assert.equal(combatGearItemImgSrc("", COMBAT_GEAR_WEAPON_IMG_FALLBACK), COMBAT_GEAR_WEAPON_IMG_FALLBACK);
+    assert.equal(combatGearItemImgSrc("  ", COMBAT_GEAR_SYSTEM_IMG_FALLBACK), COMBAT_GEAR_SYSTEM_IMG_FALLBACK);
+    assert.equal(combatGearItemImgSrc("icons/weapon.png", COMBAT_GEAR_WEAPON_IMG_FALLBACK), "icons/weapon.png");
+  });
+
+  it("buildCompactWeaponCardHtml renders a visible item thumbnail", () => {
+    const html = buildCompactWeaponCardHtml("Assault Rifle", "path.weapon", "icons/rifle.png");
+    assert.match(html, /mech-combat-gear-thumb/);
+    assert.match(html, /src="icons\/rifle\.png"/);
+    assert.match(html, /mech-combat-action-button/);
+  });
+
+  it("buildCompactSystemCardHtml renders a visible item thumbnail", () => {
+    const html = buildCompactSystemCardHtml("ECM Suite", "path.system", null);
+    assert.match(html, /mech-combat-gear-thumb/);
+    assert.match(html, new RegExp(`src="${COMBAT_GEAR_SYSTEM_IMG_FALLBACK.replace(/\//g, "\\/")}"`));
+    assert.match(html, /mech-combat-action-button/);
+  });
+
+  it("buildInventoryButtonHtml uses secondary polish classes and icon", () => {
+    const html = buildInventoryButtonHtml("View Inventory");
+    assert.match(html, /mech-inventory-button/);
+    assert.match(html, /lancer-secondary/);
+    assert.match(html, /fa-box-open/);
+    assert.match(html, /View Inventory/);
+  });
+
+  it("styles pilot portrait, chips, and combat gear action buttons", () => {
+    const styles = readFileSync("src/styles/applications/_actor-sheet.scss", "utf8");
+    assert.match(styles, /\.mech-header-pilot-row[\s\S]*\.pilot-summary[\s\S]*box-shadow/);
+    assert.match(styles, /\.mech-header-pilot-row[\s\S]*filter:\s*brightness/);
+    assert.match(styles, /\.mech-pilot-roll-chip[\s\S]*border-top/);
+    assert.match(styles, /\.mech-combat-gear-thumb/);
+    assert.match(styles, /\.mech-combat-gear-card[\s\S]*\.roll-attack/);
+    assert.match(styles, /\.mech-combat-gear-card[\s\S]*\.chat-flow-button/);
+    assert.match(styles, /\.mech-inventory-button/);
+  });
+});

--- a/src/module/helpers/mech-combat-gear-core.ts
+++ b/src/module/helpers/mech-combat-gear-core.ts
@@ -1,6 +1,19 @@
 import type { LancerMECH } from "../actor/lancer-actor";
 import type { LancerMECH_SYSTEM, LancerMECH_WEAPON } from "../item/lancer-item";
 
+export const COMBAT_GEAR_WEAPON_IMG_FALLBACK = "systems/lancer/assets/icons/mech_weapon.svg";
+export const COMBAT_GEAR_SYSTEM_IMG_FALLBACK = "systems/lancer/assets/icons/mech_system.svg";
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+/** Resolve item art for compact combat cards, with type-specific fallbacks. */
+export function combatGearItemImgSrc(img: string | undefined | null, fallback: string): string {
+  const trimmed = img?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
 export interface CombatGearCounts {
   weaponCount: number;
   systemCount: number;
@@ -37,22 +50,26 @@ export function collectCombatSystems(loadout: LancerMECH["system"]["loadout"]): 
   return loadout.systems.map(s => s.value).filter((s): s is LancerMECH_SYSTEM => !!s);
 }
 
-export function buildCompactWeaponCardHtml(weaponName: string, weaponPath: string): string {
+export function buildCompactWeaponCardHtml(weaponName: string, weaponPath: string, weaponImg?: string | null): string {
+  const imgSrc = escapeAttr(combatGearItemImgSrc(weaponImg, COMBAT_GEAR_WEAPON_IMG_FALLBACK));
   return `
     <div class="mech-combat-gear-card card clipped" data-item-id="${weaponPath}">
+      <img class="mech-combat-gear-thumb" src="${imgSrc}" alt="" width="32" height="32" />
       <span class="mech-combat-gear-name minor">${weaponName}</span>
-      <button type="button" class="roll-attack lancer-button lancer-secondary" data-tooltip="Roll attack">
+      <button type="button" class="roll-attack lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Roll attack">
         <i class="fas fa-dice-d20 i--4 i--dark" aria-hidden="true"></i>
         <span>FIRE</span>
       </button>
     </div>`;
 }
 
-export function buildCompactSystemCardHtml(systemName: string, systemPath: string): string {
+export function buildCompactSystemCardHtml(systemName: string, systemPath: string, systemImg?: string | null): string {
+  const imgSrc = escapeAttr(combatGearItemImgSrc(systemImg, COMBAT_GEAR_SYSTEM_IMG_FALLBACK));
   return `
     <div class="mech-combat-gear-card card clipped" data-item-id="${systemPath}">
+      <img class="mech-combat-gear-thumb" src="${imgSrc}" alt="" width="32" height="32" />
       <span class="mech-combat-gear-name minor">${systemName}</span>
-      <a class="chat-flow-button lancer-button lancer-secondary" data-tooltip="Use system">
+      <a class="chat-flow-button lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Use system">
         <i class="mdi mdi-message i--4" aria-hidden="true"></i>
         <span>USE</span>
       </a>

--- a/src/module/helpers/mech-combat-gear.ts
+++ b/src/module/helpers/mech-combat-gear.ts
@@ -29,8 +29,9 @@ function renderWeaponCards(mech: LancerMECH, options: HelperOptions): string {
       const weaponPath = `system.loadout.weapon_mounts.${mountIndex}.slots.${slotIndex}.weapon.value`;
       cards.push(`
         <div class="mech-combat-gear-card card clipped ref set" ${ref_params(weapon, weaponPath)}>
+          <img class="mech-combat-gear-thumb" src="${weapon.img || "systems/lancer/assets/icons/mech_weapon.svg"}" alt="" width="32" height="32" />
           <span class="mech-combat-gear-name minor">${weapon.name}</span>
-          <button type="button" class="roll-attack lancer-button lancer-secondary" data-tooltip="Roll attack">
+          <button type="button" class="roll-attack lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Roll attack">
             <i class="fas fa-dice-d20 i--4 i--dark" aria-hidden="true"></i>
             <span>FIRE</span>
           </button>
@@ -48,8 +49,9 @@ function renderSystemCards(mech: LancerMECH): string {
     const systemPath = `system.loadout.systems.${index}.value`;
     cards.push(`
       <div class="mech-combat-gear-card card clipped ref set" ${ref_params(system, systemPath)}>
+        <img class="mech-combat-gear-thumb" src="${system.img || "systems/lancer/assets/icons/mech_system.svg"}" alt="" width="32" height="32" />
         <span class="mech-combat-gear-name minor">${system.name}</span>
-        <a class="chat-flow-button lancer-button lancer-secondary" data-tooltip="Use system">
+        <a class="chat-flow-button lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Use system">
           <i class="mdi mdi-message i--4" aria-hidden="true"></i>
           <span>USE</span>
         </a>

--- a/src/module/helpers/mech-pilot-row-core.ts
+++ b/src/module/helpers/mech-pilot-row-core.ts
@@ -35,3 +35,8 @@ export function buildRollStatChipHtml(spec: RollStatChipSpec): string {
 export function buildMechPilotRowStatsHtml(chips: string[]): string {
   return `<div class="mech-pilot-roll-chips flexrow">${chips.join("")}</div>`;
 }
+
+/** Polished inventory opener for the mech header pilot row. */
+export function buildInventoryButtonHtml(label: string): string {
+  return `<button class="lancer-button lancer-secondary mech-inventory-button" type="button"><i class="fas fa-box-open i--2" aria-hidden="true"></i><span>${label}</span></button>`;
+}

--- a/src/module/helpers/mech-pilot-row.ts
+++ b/src/module/helpers/mech-pilot-row.ts
@@ -3,9 +3,15 @@ import type { LancerMECH, LancerPILOT } from "../actor/lancer-actor";
 import { basicAttackButton, getActorUUID, rollStatButton } from "./actor";
 import { resolveHelperDotpath } from "./commons";
 import { pilotSlot } from "./loadout";
-import { buildMechPilotRowStatsHtml, buildRollStatChipHtml, MECH_PILOT_HASE_PATHS } from "./mech-pilot-row-core";
+import {
+  buildInventoryButtonHtml,
+  buildMechPilotRowStatsHtml,
+  buildRollStatChipHtml,
+  MECH_PILOT_HASE_PATHS,
+} from "./mech-pilot-row-core";
 
 export {
+  buildInventoryButtonHtml,
   buildMechPilotRowStatsHtml,
   buildRollStatChipHtml,
   MECH_PILOT_HASE_PATHS,
@@ -52,13 +58,14 @@ export function mechCombatPilotRow(options: HelperOptions): string {
 
   const stats = buildMechPilotRowStatsHtml([gritChip, ...haseChips]);
   const inventoryLabel = game.i18n.localize("lancer.mech-sheet.inventory.label");
+  const inventoryButton = buildInventoryButtonHtml(inventoryLabel);
 
   return `
     <div class="mech-header-pilot-row flexrow">
       ${portrait}
       ${stats}
       <div class="inventory card clipped">
-        <button class="lancer-button" type="button">${inventoryLabel}</button>
+        ${inventoryButton}
       </div>
     </div>`;
 }

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -359,6 +359,57 @@
     padding: 0.25rem 0.45rem;
     min-width: 8rem;
     flex: 1 1 10rem;
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--darken-1), #fff 6%),
+      var(--darken-1)
+    );
+    border-top: 1px solid color-mix(in srgb, var(--light-text), transparent 82%);
+
+    .mech-combat-gear-thumb {
+      flex: 0 0 2rem;
+      width: 2rem;
+      height: 2rem;
+      object-fit: cover;
+      border: 1px solid color-mix(in srgb, var(--light-text), transparent 68%);
+      border-radius: 3px;
+      background-color: var(--background-color);
+      filter: brightness(1.12) contrast(1.08);
+      box-shadow: 0 0 4px color-mix(in srgb, var(--light-text), transparent 80%);
+    }
+
+    .mech-combat-action-button.lancer-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.2rem;
+      min-width: 3.25rem;
+      height: 2.25rem;
+      margin: 0;
+      padding: 0.15rem 0.45rem;
+      background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--light-gray-color), #fff 10%),
+        var(--light-gray-color)
+      );
+      box-shadow:
+        var(--button-shadow),
+        inset 0 1px 0 color-mix(in srgb, #fff, transparent 88%);
+
+      &:hover {
+        box-shadow:
+          var(--button-shadow),
+          var(--hover-bright),
+          0 0 6px color-mix(in srgb, var(--primary-highlight), transparent 55%);
+      }
+    }
+
+    .roll-attack.mech-combat-action-button {
+      border-left: 3px solid var(--primary-color);
+    }
+
+    .chat-flow-button.mech-combat-action-button {
+      border-left: 3px solid var(--system-color);
+    }
   }
 
   .mech-combat-gear-name {
@@ -398,21 +449,30 @@
     flex-wrap: wrap;
 
     .pilot-summary {
-      flex: 0 0 3rem;
-      width: 3rem;
-      height: 3rem;
+      flex: 0 0 4.5rem;
+      width: 4.5rem;
+      height: 4.5rem;
       margin: 0;
       min-height: 0;
-      padding: 0;
+      padding: 2px;
+      background-color: var(--background-color);
+      border: 2px solid var(--secondary-highlight);
+      border-radius: 4px;
+      box-shadow:
+        0 0 8px color-mix(in srgb, var(--secondary-color), transparent 45%),
+        inset 0 0 0 1px color-mix(in srgb, var(--light-text), transparent 88%);
 
       img {
         width: 100%;
         height: 100%;
         object-fit: cover;
+        border-radius: 2px;
+        filter: brightness(1.15) contrast(1.1);
       }
 
       .license-level {
-        font-size: 0.85rem;
+        font-size: 0.7rem;
+        background-color: color-mix(in srgb, var(--primary-color), transparent 20%);
       }
     }
 
@@ -433,6 +493,13 @@
       margin: 0;
       min-width: 4.75rem;
       flex: 0 1 auto;
+      background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--darken-1), #fff 5%),
+        var(--darken-1)
+      );
+      border-top: 2px solid var(--secondary-color);
+      box-shadow: inset 0 1px 0 color-mix(in srgb, #fff, transparent 90%);
     }
 
     .mech-pilot-roll-chip-label {
@@ -454,7 +521,22 @@
       align-items: center;
 
       .lancer-button {
-        padding: 0.1rem 0.2rem;
+        padding: 0.12rem 0.28rem;
+        background: linear-gradient(
+          180deg,
+          color-mix(in srgb, var(--light-gray-color), #fff 12%),
+          var(--light-gray-color)
+        );
+        box-shadow:
+          var(--button-shadow),
+          inset 0 1px 0 color-mix(in srgb, #fff, transparent 86%);
+
+        &:hover {
+          box-shadow:
+            var(--button-shadow),
+            var(--hover-bright),
+            0 0 5px color-mix(in srgb, var(--secondary-highlight), transparent 50%);
+        }
       }
     }
 
@@ -465,6 +547,30 @@
       flex: 0 0 auto;
       margin: 0;
       padding: 0.2rem 0.5rem;
+    }
+
+    .mech-inventory-button.lancer-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.65rem;
+      background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--secondary-color), #fff 12%),
+        var(--secondary-color)
+      );
+      color: var(--secondary-text);
+      border: 1px solid color-mix(in srgb, var(--secondary-highlight), #000 25%);
+      box-shadow:
+        var(--button-shadow),
+        inset 0 1px 0 color-mix(in srgb, #fff, transparent 82%);
+
+      &:hover {
+        box-shadow:
+          var(--button-shadow),
+          var(--hover-bright),
+          0 0 8px color-mix(in srgb, var(--secondary-highlight), transparent 45%);
+      }
     }
   }
 

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.7/lancer-v3.1.7.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.8/lancer-v3.1.8.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the mech sheet visual polish mockup: clearer pilot portraits, polished header controls, and combat gear cards with visible item thumbnails and accent-styled FIRE/USE buttons.

## Changes

- **Pilot portrait** — enlarged to 4.5rem with framed border, glow, and brightness/contrast boost; license badge overlay is lighter
- **GRIT/HASE chips** — gradient fill, secondary accent top border, polished roll/attack buttons
- **View Inventory** — secondary gradient button with box icon
- **Combat gear cards** — 32px item thumbnails with fallbacks; FIRE (primary accent) and USE (system green accent) action buttons with gradient polish
- **Tests** — `scripts/mech-sheet-visual-polish.test.ts` covers helpers and SCSS contract
- **Version** — 3.1.8 with CHANGELOG entry

## Test plan

- [x] `npm test` (31 tests pass)
- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`
- [ ] Visual check in Foundry: open mech sheet, confirm portrait visibility and button styling on header + combat/gear play tabs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddb27bd5-e237-4a83-bb7a-f0b1a85c14d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddb27bd5-e237-4a83-bb7a-f0b1a85c14d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

