### PR TITLE
fix(mech-sheet): core checkbox validation error on toggle (3.1.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1.9 (2026-06-08)
+
+## Fixed
+
+- **Combat dock core toggle** — the CORE checkbox now submits `0`/`1` for `system.core_energy` (NumberField) instead of boolean values, which caused a validation error when toggling core power on the mech sheet. Fixes [#117](https://github.com/VacantFanatic/foundryvtt-lancer/issues/117).
+
 # 3.1.8 (2026-06-08)
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/scripts/mech-combat-dock.test.ts
+++ b/scripts/mech-combat-dock.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  buildCombatDockCoreToggleHtml,
   buildCombatDockStatChipsHtml,
   COMBAT_DOCK_ATTACK_FLOW_TYPES,
+  normalizeCoreEnergyFormValue,
 } from "../src/module/helpers/mech-combat-dock-core.ts";
 
 describe("mech combat dock helpers", () => {
@@ -22,5 +24,28 @@ describe("mech combat dock helpers", () => {
 
   it("combat dock attack utilities include all three flow types", () => {
     assert.deepEqual(COMBAT_DOCK_ATTACK_FLOW_TYPES, ["BasicAttack", "Damage", "TechAttack"]);
+  });
+
+  it("buildCombatDockCoreToggleHtml uses Number dtype for core_energy schema", () => {
+    const html = buildCombatDockCoreToggleHtml(1);
+    assert.match(html, /name="system\.core_energy"/);
+    assert.match(html, /data-dtype="Number"/);
+    assert.match(html, /value="1"/);
+    assert.doesNotMatch(html, /data-dtype="Boolean"/);
+    assert.match(html, /checked/);
+  });
+
+  it("buildCombatDockCoreToggleHtml omits checked when core energy is spent", () => {
+    const html = buildCombatDockCoreToggleHtml(0);
+    assert.doesNotMatch(html, /checked/);
+  });
+
+  it("normalizeCoreEnergyFormValue coerces legacy boolean form values to 0 or 1", () => {
+    assert.equal(normalizeCoreEnergyFormValue(true), 1);
+    assert.equal(normalizeCoreEnergyFormValue(false), 0);
+    assert.equal(normalizeCoreEnergyFormValue(1), 1);
+    assert.equal(normalizeCoreEnergyFormValue(0), 0);
+    assert.equal(normalizeCoreEnergyFormValue("1"), 1);
+    assert.equal(normalizeCoreEnergyFormValue("0"), 0);
   });
 });

--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -31,6 +31,7 @@ import {
   handleUsesInteraction,
 } from "../helpers/refs";
 import { LancerItem } from "../item/lancer-item";
+import { normalizeCoreEnergyFormValue } from "../helpers/mech-combat-dock-core";
 import { lookupOwnedDeployables } from "../util/lid";
 import type { LancerActorSheetData } from "../interfaces";
 import { LancerActor, type LancerActorType } from "./lancer-actor";
@@ -107,6 +108,9 @@ export class LancerActorSheet<T extends LancerActorType> extends HandlebarsAppli
   ): Promise<void> {
     event.preventDefault();
     const updateData = { ...formData.object };
+    if ("system.core_energy" in updateData) {
+      updateData["system.core_energy"] = normalizeCoreEnergyFormValue(updateData["system.core_energy"]);
+    }
     this._propagateData(updateData);
     await this.actor.update(updateData);
   }

--- a/src/module/helpers/mech-combat-dock-core.ts
+++ b/src/module/helpers/mech-combat-dock-core.ts
@@ -7,6 +7,24 @@ export interface CombatDockStatSnapshot {
 
 export const COMBAT_DOCK_ATTACK_FLOW_TYPES = ["BasicAttack", "Damage", "TechAttack"] as const;
 
+/** Coerce form values for `system.core_energy` (NumberField 0|1). */
+export function normalizeCoreEnergyFormValue(value: unknown): number {
+  if (value === true || value === 1 || value === "1") return 1;
+  return 0;
+}
+
+/** Core power checkbox for the combat dock; must use Number dtype to match MechModel. */
+export function buildCombatDockCoreToggleHtml(coreEnergy: number): string {
+  const checked = coreEnergy > 0;
+  return `
+    <div class="mech-combat-dock-core card clipped" data-tooltip="Core power">
+      <span class="minor">CORE</span>
+      <div class="stat-container core-power-stat-container">
+        <input name="system.core_energy" class="core-power-toggle" type="checkbox" data-dtype="Number" value="1" ${checked ? "checked" : ""} />
+      </div>
+    </div>`;
+}
+
 /** Pure stat chip markup for unit tests and sheet render. */
 export function buildCombatDockStatChipsHtml(stats: CombatDockStatSnapshot): string {
   const chip = (label: string, value: number, max: number, valuePath: string, icon: string) =>

--- a/src/module/helpers/mech-combat-dock.ts
+++ b/src/module/helpers/mech-combat-dock.ts
@@ -3,9 +3,18 @@ import type { LancerMECH } from "../actor/lancer-actor";
 import { LancerFlowState } from "../flows/interfaces";
 import { resolveHelperDotpath } from "./commons";
 import { action_button, actor_flow_button, is_combatant } from "./actor";
-import { buildCombatDockStatChipsHtml, COMBAT_DOCK_ATTACK_FLOW_TYPES } from "./mech-combat-dock-core";
+import {
+  buildCombatDockCoreToggleHtml,
+  buildCombatDockStatChipsHtml,
+  COMBAT_DOCK_ATTACK_FLOW_TYPES,
+} from "./mech-combat-dock-core";
 
-export { buildCombatDockStatChipsHtml, COMBAT_DOCK_ATTACK_FLOW_TYPES } from "./mech-combat-dock-core";
+export {
+  buildCombatDockCoreToggleHtml,
+  buildCombatDockStatChipsHtml,
+  COMBAT_DOCK_ATTACK_FLOW_TYPES,
+  normalizeCoreEnergyFormValue,
+} from "./mech-combat-dock-core";
 export type { CombatDockStatSnapshot } from "./mech-combat-dock-core";
 
 /** Attack utility buttons rendered in the persistent combat dock. */
@@ -30,16 +39,6 @@ function compactOverchargeDock(actor: LancerMECH, overchargeLevel: number): stri
       </button>
       <button type="button" class="overcharge-text lancer-button lancer-secondary">${value}</button>
       <button type="button" class="overcharge-reset mdi mdi-restore" aria-label="Reset overcharge"></button>
-    </div>`;
-}
-
-function compactCoreToggle(checked: boolean): string {
-  return `
-    <div class="mech-combat-dock-core card clipped" data-tooltip="Core power">
-      <span class="minor">CORE</span>
-      <div class="stat-container core-power-stat-container">
-        <input name="system.core_energy" class="core-power-toggle" type="checkbox" data-dtype="Boolean" ${checked ? "checked" : ""} />
-      </div>
     </div>`;
 }
 
@@ -68,7 +67,7 @@ export function mechCombatDock(options: HelperOptions): string {
     stress: system.stress,
   });
   const overcharge = compactOverchargeDock(actor, system.overcharge);
-  const core = compactCoreToggle(system.core_energy);
+  const core = buildCombatDockCoreToggleHtml(system.core_energy);
   const actions = compactActionTracker(actor, options);
   const attacks = buildCombatDockAttackUtilitiesHtml();
 

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.8/lancer-v3.1.8.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.9/lancer-v3.1.9.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#117](https://github.com/VacantFanatic/foundryvtt-lancer/issues/117) — toggling the CORE checkbox in the mech combat dock showed a validation error because the input used `data-dtype="Boolean"` while `system.core_energy` is a `NumberField` (0 or 1).

## Changes

- Combat dock CORE checkbox now uses `data-dtype="Number"` with `value="1"`.
- Actor sheet form submit normalizes any legacy boolean values to `0`/`1` before `actor.update`.
- Unit tests cover toggle HTML and form value coercion.

## Version

Patch release **3.1.9** (CHANGELOG and `system.json` updated).

## Test plan

- [x] `npm test` — all 34 unit tests pass
- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build` — production build succeeds
- [ ] Manual: open mech sheet, toggle CORE — no error notification, value persists
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dad3f33e-96e0-40b9-8163-81986e03a42f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dad3f33e-96e0-40b9-8163-81986e03a42f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

