### PR TITLE
fix: restore combat tracker and action tracker on Foundry v14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.1.11 (2026-06-09)
+
+## Fixed
+
+- **Combat tracker** — return tracker render context from `_prepareTrackerContext` so combatants populate in the Application V2 combat sidebar on Foundry v14. Fixes [#121](https://github.com/VacantFanatic/foundryvtt-lancer/issues/121).
+- **Action tracker HUD** — fix invalid `height: autopx` inline styling, refresh the HUD when combat round/turn state changes, and resolve controlled tokens via `combatant` as well as `inCombat` so the floating action bar appears during combat.
+
 # 3.1.10 (2026-06-09)
 
 ## Changed

--- a/e2e/regression/a11y-regression.spec.ts
+++ b/e2e/regression/a11y-regression.spec.ts
@@ -37,6 +37,8 @@ test.describe("Accessibility regression @regression", () => {
         {
           showTextLabels: false,
           clickable: true,
+          showSurface: true,
+          positionWidth: 300,
           name: "E2E",
           actions: { protocol: true, move: true, full: false, quick: false },
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",
@@ -19,7 +19,7 @@
     "prepare": "husky install",
     "verify:git-remote": "sh ./scripts/assert-safe-git-remote.sh",
     "verify:doc-links": "sh ./scripts/assert-no-eranziel-doc-links.sh",
-    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/mech-sheet-visual-polish.test.ts scripts/html-editor.test.ts scripts/accdiff-hud-layout.test.ts scripts/mech-pilot-row.test.ts scripts/mech-header-layout.test.ts scripts/inventory-dialog.test.ts",
+    "test": "node --import tsx --test scripts/import-routing.test.ts scripts/mech-combat-dock.test.ts scripts/mech-combat-gear.test.ts scripts/mech-gear-mode.test.ts scripts/mech-sheet-ux-polish.test.ts scripts/mech-sheet-visual-polish.test.ts scripts/html-editor.test.ts scripts/accdiff-hud-layout.test.ts scripts/mech-pilot-row.test.ts scripts/mech-header-layout.test.ts scripts/inventory-dialog.test.ts scripts/combat-tracker.test.ts scripts/action-manager.test.ts",
     "test:e2e": "playwright test -c e2e/playwright.config.ts regression",
     "test:e2e:bootstrap": "playwright test -c e2e/playwright.config.ts setup",
     "test:e2e:install": "playwright install firefox",

--- a/public/templates/window/action_manager.hbs
+++ b/public/templates/window/action_manager.hbs
@@ -1,4 +1,7 @@
-<div class="lancer-action-manager-surface clipped card {{#unless actions}}hidden{{/unless}} {{#unless clickable}}noclick{{/unless}}">
+<div
+  class="lancer-action-manager-surface clipped card {{#unless showSurface}}hidden{{/unless}} {{#unless clickable}}noclick{{/unless}}"
+  style="width: {{positionWidth}}px"
+>
   <div class="action-label">
     <div>{{name}}</div>
     {{#if clickable}}

--- a/scripts/action-manager.test.ts
+++ b/scripts/action-manager.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildActionManagerRenderContext,
+  resolveActionManagerWidth,
+  isTokenInCombatEncounter,
+  resolveActionManagerActor,
+  shouldShowActionManagerSurface,
+} from "../src/module/action/action-manager-context.ts";
+
+function mechActor(name = "Test Mech") {
+  return {
+    name,
+    is_mech: () => true,
+    is_npc: () => false,
+    system: {
+      action_tracker: {
+        protocol: true,
+        move: 4,
+        full: true,
+        quick: true,
+        reaction: true,
+      },
+    },
+  };
+}
+
+describe("action manager context", () => {
+  it("detects combat encounter membership from combatant or inCombat", () => {
+    assert.equal(isTokenInCombatEncounter({ combatant: { id: "c1" } }), true);
+    assert.equal(isTokenInCombatEncounter({ inCombat: true }), true);
+    assert.equal(isTokenInCombatEncounter({}), false);
+  });
+
+  it("resolves mech and npc actors that are in combat", () => {
+    const actor = mechActor();
+    const resolved = resolveActionManagerActor({ actor, inCombat: true });
+    assert.equal(resolved, actor);
+    assert.equal(resolveActionManagerActor({ actor, inCombat: false }), null);
+  });
+
+  it("builds render context without invalid inline height values", () => {
+    const actor = mechActor();
+    const context = buildActionManagerRenderContext({
+      actor,
+      clickable: true,
+      showTextLabels: false,
+      position: { width: 300 },
+    });
+
+    assert.equal(context.name, "TEST MECH");
+    assert.equal(context.actions?.move, 4);
+    assert.equal(context.positionWidth, 300);
+    assert.equal(shouldShowActionManagerSurface(context), true);
+  });
+
+  it("hides the surface when no actor is selected", () => {
+    const context = buildActionManagerRenderContext({
+      actor: null,
+      clickable: true,
+      showTextLabels: false,
+      position: { width: 300 },
+    });
+    assert.equal(shouldShowActionManagerSurface(context), false);
+  });
+
+  it("resolves numeric widths for the surface style", () => {
+    assert.equal(resolveActionManagerWidth({ width: 280 }), 280);
+    assert.equal(resolveActionManagerWidth({ width: "320" }), 320);
+    assert.equal(resolveActionManagerWidth({}), 300);
+  });
+});

--- a/scripts/combat-tracker.test.ts
+++ b/scripts/combat-tracker.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  COMBAT_TRACKER_DISPOSITION_CLASSES,
+  enrichCombatTrackerTurns,
+  type CombatTrackerTurnInput,
+} from "../src/module/combat/combat-tracker-turns.ts";
+
+const appearance = { icon: "cci cci-activate", deactivate: "cci cci-deactivate" };
+
+function turn(id: string, css = "", pending = 1): CombatTrackerTurnInput {
+  return { id, css, name: id, img: "", hidden: false, isDefeated: false, canPing: false, resource: null, pending };
+}
+
+describe("combat tracker turns", () => {
+  it("enriches turns with disposition classes and activation buttons", () => {
+    const combatant = {
+      id: "c1",
+      disposition: 2,
+      activations: { max: 2, value: 1 },
+    };
+    const result = enrichCombatTrackerTurns({
+      turns: [turn("c1")],
+      getCombatant: id => (id === "c1" ? combatant : undefined),
+      activeCombatantId: "c1",
+      appearance,
+      sort: false,
+    });
+
+    assert.equal(result?.length, 1);
+    assert.match(result![0].css, /player/);
+    assert.equal(result![0].activations, 2);
+    assert.equal(result![0].pending, 1);
+    assert.equal(result![0].buttons.length, 2);
+    assert.equal(result![0].buttons[0].action, "activateCombatantTurn");
+    assert.equal(result![0].buttons[1].action, "deactivateCombatantTurn");
+  });
+
+  it("sorts active and pending turns when sort is enabled", () => {
+    const combatants = new Map([
+      ["a", { id: "a", disposition: 0, activations: { max: 1, value: 0 } }],
+      ["b", { id: "b", disposition: 0, activations: { max: 1, value: 1 } }],
+    ]);
+    const result = enrichCombatTrackerTurns({
+      turns: [turn("a", "active", 0), turn("b", "", 1)],
+      getCombatant: id => combatants.get(id),
+      appearance,
+      sort: true,
+    });
+
+    assert.deepEqual(
+      result?.map(t => t.id),
+      ["a", "b"]
+    );
+  });
+
+  it("returns undefined when turns are undefined", () => {
+    const result = enrichCombatTrackerTurns({
+      turns: undefined,
+      getCombatant: () => undefined,
+      appearance,
+      sort: false,
+    });
+    assert.equal(result, undefined);
+  });
+
+  it("exposes disposition classes for all combatant types", () => {
+    assert.equal(COMBAT_TRACKER_DISPOSITION_CLASSES[2], "player");
+    assert.equal(COMBAT_TRACKER_DISPOSITION_CLASSES[-1], "enemy");
+  });
+});

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -644,6 +644,9 @@ Hooks.on("updateCombat", (_combat, changes) => {
   if (foundry.utils.hasProperty(changes, "turn")) {
     ui.combatCarousel?.render();
   }
+  if ("round" in changes || "turn" in changes || "combatants" in changes) {
+    game.action_manager?.update();
+  }
 });
 
 // Handle dropping statuses on tokens

--- a/src/module/action/action-manager-context.ts
+++ b/src/module/action/action-manager-context.ts
@@ -1,0 +1,66 @@
+import type { ActionTrackingData } from ".";
+
+export interface ActionManagerTokenLike {
+  combatant?: unknown;
+  inCombat?: boolean;
+  actor?: ActionManagerActorLike;
+}
+
+export interface ActionManagerActorLike {
+  name: string;
+  is_mech(): boolean;
+  is_npc(): boolean;
+  system: { action_tracker: ActionTrackingData };
+}
+
+export interface ActionManagerRenderContext {
+  name?: string;
+  actions: ActionTrackingData | null;
+  clickable: boolean;
+  showTextLabels: boolean;
+  positionWidth: number;
+}
+
+export function isTokenInCombatEncounter(token: ActionManagerTokenLike): boolean {
+  return !!(token.combatant ?? token.inCombat);
+}
+
+export function resolveActionManagerActor(
+  token: ActionManagerTokenLike | null | undefined
+): ActionManagerActorLike | null {
+  if (!token?.actor) return null;
+  if (!isTokenInCombatEncounter(token)) return null;
+  if (!token.actor.is_mech() && !token.actor.is_npc()) return null;
+  return token.actor;
+}
+
+export function getActionTrackerData(actor: ActionManagerActorLike): ActionTrackingData | null {
+  if (!actor.is_mech() && !actor.is_npc()) return null;
+  return actor.system.action_tracker ?? null;
+}
+
+export function resolveActionManagerWidth(position: { width?: number | string }): number {
+  if (typeof position.width === "number") return position.width;
+  const parsed = Number.parseInt(String(position.width ?? ""), 10);
+  return Number.isFinite(parsed) ? parsed : 300;
+}
+
+export function buildActionManagerRenderContext(options: {
+  actor: ActionManagerActorLike | null;
+  clickable: boolean;
+  showTextLabels: boolean;
+  position: { width?: number | string };
+}): ActionManagerRenderContext {
+  const { actor, clickable, showTextLabels, position } = options;
+  return {
+    name: actor?.name.toLocaleUpperCase(),
+    actions: actor ? getActionTrackerData(actor) : null,
+    clickable,
+    showTextLabels,
+    positionWidth: resolveActionManagerWidth(position),
+  };
+}
+
+export function shouldShowActionManagerSurface(context: Pick<ActionManagerRenderContext, "actions">): boolean {
+  return context.actions != null;
+}

--- a/src/module/action/action-manager.ts
+++ b/src/module/action/action-manager.ts
@@ -2,6 +2,7 @@ import tippy from "tippy.js";
 import type { ActionTrackingData, ActionType } from ".";
 import type { LancerActor } from "../actor/lancer-actor";
 import { LANCER } from "../config";
+import { buildActionManagerRenderContext, resolveActionManagerActor } from "./action-manager-context";
 import { getActions, modAction, toggleAction } from "./action-tracker";
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -62,14 +63,16 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
   async _prepareContext(options: Record<string, unknown>) {
     const context = await super._prepareContext(options);
     const trackerSettings = game.settings.get(game.system.id, LANCER.setting_actionTracker);
-    const data = {
-      position: this.position,
-      name: this.target && this.target.name.toLocaleUpperCase(),
-      actions: this.getActions(),
-      clickable: game.user?.isGM || trackerSettings.allowPlayers,
+    const data = buildActionManagerRenderContext({
+      actor: this.target,
+      clickable: !!(game.user?.isGM || trackerSettings.allowPlayers),
       showTextLabels: trackerSettings.showTextLabels,
-    };
-    return foundry.utils.mergeObject(context, data);
+      position: this.position,
+    });
+    return foundry.utils.mergeObject(context, {
+      ...data,
+      showSurface: data.actions != null,
+    });
   }
 
   // DATA BINDING
@@ -110,14 +113,7 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
   private async updateControlledToken() {
     if (!canvas.ready) return;
     const token = canvas.tokens?.controlled?.[0];
-    if (token && token.inCombat && token.actor) {
-      const actor = token.actor as LancerActor;
-      if (actor.is_mech() || actor.is_npc()) {
-        this.target = token.actor;
-        return;
-      }
-    }
-    this.target = null;
+    this.target = resolveActionManagerActor(token);
   }
 
   /**

--- a/src/module/combat/combat-tracker-turns.ts
+++ b/src/module/combat/combat-tracker-turns.ts
@@ -1,0 +1,83 @@
+export const COMBAT_TRACKER_DISPOSITION_CLASSES: Record<number, string> = {
+  [-2]: "",
+  [-1]: "enemy",
+  [0]: "neutral",
+  [1]: "friendly",
+  [2]: "player",
+};
+
+export interface CombatTrackerTurnInput {
+  id: string;
+  css: string;
+  name: string;
+  img: string;
+  hidden: boolean;
+  isDefeated: boolean;
+  canPing: boolean;
+  resource: string | null;
+  pending?: number;
+}
+
+export interface CombatTrackerTurnButton {
+  icon: string;
+  action: string;
+}
+
+export interface CombatTrackerCombatantLike {
+  id: string;
+  disposition: number;
+  activations: { max?: number; value?: number };
+}
+
+export interface EnrichCombatTrackerTurnsOptions {
+  turns: CombatTrackerTurnInput[] | undefined;
+  getCombatant: (id: string) => CombatTrackerCombatantLike | undefined;
+  activeCombatantId?: string | null;
+  appearance: { icon: string; deactivate: string };
+  sort: boolean;
+}
+
+export type EnrichedCombatTrackerTurn = CombatTrackerTurnInput & {
+  buttons: CombatTrackerTurnButton[];
+  activations?: number;
+  pending?: number;
+};
+
+export function enrichCombatTrackerTurns(
+  options: EnrichCombatTrackerTurnsOptions
+): EnrichedCombatTrackerTurn[] | undefined {
+  const { turns, getCombatant, activeCombatantId, appearance, sort } = options;
+  if (turns == null) return undefined;
+
+  const enriched = turns.map(t => {
+    const combatant = getCombatant(t.id);
+    const buttons: CombatTrackerTurnButton[] = Array.from(Array(combatant?.activations.value ?? 0), () => ({
+      icon: appearance.icon,
+      action: "activateCombatantTurn",
+    }));
+    if (combatant?.id === activeCombatantId) {
+      buttons.push({ icon: appearance.deactivate, action: "deactivateCombatantTurn" });
+    }
+
+    return {
+      ...t,
+      css: `${t.css} ${COMBAT_TRACKER_DISPOSITION_CLASSES[combatant?.disposition ?? -2]}`.trim(),
+      buttons,
+      activations: combatant?.activations.max,
+      pending: combatant?.activations.value,
+    };
+  });
+
+  if (sort) {
+    enriched.sort((a, b) => {
+      const aa = a.css.indexOf("active") !== -1 ? 1 : 0;
+      const ba = b.css.indexOf("active") !== -1 ? 1 : 0;
+      if (ba - aa !== 0) return ba - aa;
+      const ad = a.pending === 0 ? 1 : 0;
+      const bd = b.pending === 0 ? 1 : 0;
+      return ad - bd;
+    });
+  }
+
+  return enriched;
+}

--- a/src/module/combat/lancer-combat-tracker.ts
+++ b/src/module/combat/lancer-combat-tracker.ts
@@ -1,5 +1,6 @@
 import { LANCER } from "../config.js";
 import type { CombatTrackerAppearance } from "../settings.js";
+import { enrichCombatTrackerTurns } from "./combat-tracker-turns.js";
 import type { LancerCombat, LancerCombatant } from "./lancer-combat.js";
 
 import ContextMenu = foundry.applications.ux.ContextMenu;
@@ -24,44 +25,38 @@ export class LancerCombatTracker extends foundry.applications.sidebar.tabs.Comba
 
   async _prepareTrackerContext(ctx: any, opts: any) {
     const appearance = game.settings.get(game.system.id, LANCER.setting_combat_appearance);
-    const disp: Record<number, string> = { [-2]: "", [-1]: "enemy", [0]: "neutral", [1]: "friendly", [2]: "player" };
-    await super._prepareTrackerContext(ctx, opts);
-    ctx.turns = ctx.turns?.map((t: any) => {
-      const combatant: LancerCombatant = this.viewed?.getEmbeddedDocument("Combatant", t.id, {}) as any;
-      const buttons = Array.from(Array(combatant?.system.activations.value ?? 0), () => ({
-        icon: appearance.icon,
-        action: "activateCombatantTurn",
-      }));
-      if (combatant === this.viewed?.combatant)
-        buttons.push({ icon: appearance.deactivate, action: "deactivateCombatantTurn" });
-      const token = combatant?.token?.object;
-      const isTargeted = !!(token && game.user?.targets.has(token));
-      const targetNames = (game.user?.targets ?? [])
-        .map(t => t.document?.name ?? t.name)
-        .filter(Boolean)
-        .join(", ");
+    const trackerCtx = (await super._prepareTrackerContext(ctx, opts)) ?? ctx;
+    const targetNames = (game.user?.targets ?? [])
+      .map(t => t.document?.name ?? t.name)
+      .filter(Boolean)
+      .join(", ");
 
+    trackerCtx.turns = enrichCombatTrackerTurns({
+      turns: trackerCtx.turns,
+      getCombatant: id => {
+        const combatant = this.viewed?.combatants.get(id) as LancerCombatant | undefined;
+        if (!combatant) return undefined;
+        return {
+          id: combatant.id,
+          disposition: combatant.disposition,
+          activations: combatant.activations,
+        };
+      },
+      activeCombatantId: this.viewed?.combatant?.id,
+      appearance,
+      sort: game.settings.get(game.system.id, LANCER.setting_combat_sort),
+    })?.map(t => {
+      const combatant = this.viewed?.combatants.get(t.id) as LancerCombatant | undefined;
+      const token = combatant?.token?.object;
       return {
         ...t,
-        css: `${t.css} ${disp[combatant.disposition]}`.trim(),
-        buttons,
-        activations: combatant?.system.activations.max,
-        pending: combatant?.system.activations.value,
-        isTargeted,
+        isTargeted: !!(token && game.user?.targets.has(token)),
         targetSummary: targetNames,
         canTarget: !!(token ?? combatant?.tokenId),
       };
     });
-    if (game.settings.get(game.system.id, LANCER.setting_combat_sort) && ctx?.turns != null) {
-      ctx.turns.sort(function (a: any, b: any) {
-        const aa = a.css.indexOf("active") !== -1 ? 1 : 0;
-        const ba = b.css.indexOf("active") !== -1 ? 1 : 0;
-        if (ba - aa !== 0) return ba - aa;
-        const ad = a.pending === 0 ? 1 : 0;
-        const bd = b.pending === 0 ? 1 : 0;
-        return ad - bd;
-      });
-    }
+
+    return trackerCtx;
   }
 
   static async #activateCombatantTurn(this: LancerCombatTracker, ev: MouseEvent, target: HTMLElement) {

--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -443,9 +443,8 @@ export function npc_tier_selector(tier_path: string, options: HelperOptions) {
 
 export function is_combatant(actor: LancerActor) {
   const combat = game.combat;
-  if (combat) {
-    return combat.combatants.find(comb => comb.actor?.uuid == actor.uuid);
-  }
+  if (!combat) return false;
+  return !!combat.combatants.find(comb => comb.actor?.uuid == actor.uuid);
 }
 
 // Create a div with flags for dropping native pilots/mechs/npcs

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.10/lancer-v3.1.10.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.11/lancer-v3.1.11.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#121](https://github.com/VacantFanatic/foundryvtt-lancer/issues/121) and restores the floating action tracker HUD during combat.

- **Combat tracker:** `LancerCombatTracker._prepareTrackerContext` now returns the tracker render context (matching Foundry v14 / dnd5e Application V2 behavior) so combatants render in the sidebar.
- **Action tracker HUD:** removes invalid `height: autopx` inline styling, refreshes when combat round/turn/combatants change, and resolves controlled tokens using `combatant` as well as `inCombat`.
- **Mech sheet combat dock:** `is_combatant` now returns an explicit boolean so action buttons show reliably when an actor is in the viewed combat.

## Testing

- `npm test` (49 passing), including new `combat-tracker` and `action-manager` unit tests
- Version bumped to **3.1.11** with CHANGELOG entry

## Manual verification

1. Add tokens to combat and start combat — combat tracker should list combatants with activation controls.
2. Select a mech/NPC token in combat — floating action tracker should appear; mech sheet combat dock should show action buttons.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fe7c1fe-e8e1-4430-83fb-bb9b02e943bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fe7c1fe-e8e1-4430-83fb-bb9b02e943bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

