### PR TITLE
fix: combat tracker turns and action tracker drag handle (v3.1.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.1.12 (2026-06-09)
+
+## Fixed
+
+- **Combat tracker** — merge tracker fields onto the shared render context so `turns` are not dropped when Foundry returns tracker-only data from `_prepareTrackerContext`. Preserve core `CombatTracker` click actions by merging `DEFAULT_OPTIONS`.
+- **Action tracker HUD** — always show the drag handle (even without a selected combatant), restore flex layout on the control row, move the HUD via `setPosition`, and use `pointer-events` so the transparent host does not block canvas token selection.
+
 # 3.1.11 (2026-06-09)
 
 ## Fixed

--- a/e2e/regression/a11y-regression.spec.ts
+++ b/e2e/regression/a11y-regression.spec.ts
@@ -37,7 +37,6 @@ test.describe("Accessibility regression @regression", () => {
         {
           showTextLabels: false,
           clickable: true,
-          showSurface: true,
           positionWidth: 300,
           name: "E2E",
           actions: { protocol: true, move: true, full: false, quick: false },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -583,6 +583,7 @@
       "showTextLabels": "Show text labels",
       "showTextLabels-desc": "Show text labels beside action icons on the floating action tracker.",
       "toolbar": "Combat actions",
+      "select-token": "Select a mech or NPC in combat",
       "drag": "Drag action tracker",
       "reset": "Reset actions",
       "actions": {

--- a/public/templates/window/action_manager.hbs
+++ b/public/templates/window/action_manager.hbs
@@ -1,84 +1,91 @@
 <div
-  class="lancer-action-manager-surface clipped card {{#unless showSurface}}hidden{{/unless}} {{#unless clickable}}noclick{{/unless}}"
+  class="lancer-action-manager-surface clipped card {{#unless clickable}}noclick{{/unless}}"
   style="width: {{positionWidth}}px"
 >
   <div class="action-label">
-    <div>{{name}}</div>
+    <div>{{#if name}}{{name}}{{else}}{{localize "lancer.actionTracker.select-token"}}{{/if}}</div>
     {{#if clickable}}
-      <div class="action-manager-reset-wrap">
-        <a
-          id="action-manager-reset"
-          class="mdi mdi-restore"
-          role="button"
-          tabindex="0"
-          aria-label='{{localize "lancer.actionTracker.reset"}}'
-        ></a>
-      </div>
+      {{#if actions}}
+        <div class="action-manager-reset-wrap">
+          <a
+            id="action-manager-reset"
+            class="mdi mdi-restore"
+            role="button"
+            tabindex="0"
+            aria-label='{{localize "lancer.actionTracker.reset"}}'
+          ></a>
+        </div>
+      {{/if}}
     {{/if}}
   </div>
   <div class="action-manager-controls">
-    <i
+    <button
+      type="button"
       id="action-manager-drag"
-      class="mdi mdi-drag"
-      role="img"
+      class="action-manager-drag mdi mdi-drag"
       aria-label='{{localize "lancer.actionTracker.drag"}}'
-    ></i>
-    <div class="action-bar" role="toolbar" aria-label='{{localize "lancer.actionTracker.toolbar"}}'>
-      <a
-        class="action {{#if actions.protocol}}lancer-protocol{{/if}}"
-        data-action="protocol"
-        role="button"
-        tabindex="0"
-        aria-label='{{localize "lancer.actionTracker.actions.protocol"}}'
-      >
-        <i class="cci cci-protocol theme--dark white--text" aria-hidden="true"></i>
-        {{#if showTextLabels}}<span class="action-text">{{
-              localize "lancer.actionTracker.actions.protocol"
-            }}</span>{{/if}}
-      </a>
-      <hr class="v-divide" role="separator" aria-orientation="vertical" />
-      <a
-        class="action {{#if actions.move}}lancer-move{{/if}}"
-        data-action="move"
-        role="button"
-        tabindex="0"
-        aria-label='{{localize "lancer.actionTracker.actions.move"}}'
-      >
-        <i class="mdi mdi-arrow-right-bold-hexagon-outline theme--dark white--text" aria-hidden="true"></i>
-        {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.move"}}</span>{{/if}}
-      </a>
-      <a
-        class="action {{#if actions.full}}lancer-full{{/if}}"
-        data-action="full"
-        role="button"
-        tabindex="0"
-        aria-label='{{localize "lancer.actionTracker.actions.full"}}'
-      >
-        <i class="mdi mdi-hexagon-slice-6 theme--dark white--text" aria-hidden="true"></i>
-        {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.full"}}</span>{{/if}}
-      </a>
-      <a
-        class="action {{#if actions.quick}}lancer-quick{{/if}}"
-        data-action="quick"
-        role="button"
-        tabindex="0"
-        aria-label='{{localize "lancer.actionTracker.actions.quick"}}'
-      >
-        <i class="mdi mdi-hexagon-slice-3 theme--dark white--text" aria-hidden="true"></i>
-        {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.quick"}}</span>{{/if}}
-      </a>
-      <a
-        class="action {{#if actions.reaction}}lancer-reaction{{/if}}"
-        data-action="reaction"
-        role="button"
-        tabindex="0"
-        aria-label='{{localize "lancer.actionTracker.actions.reaction"}}'
-      >
-        <i class="cci cci-reaction theme--dark white--text" aria-hidden="true"></i>
-        {{#if showTextLabels}}<span class="action-text">{{
-              localize "lancer.actionTracker.actions.reaction"
-            }}</span>{{/if}}
-      </a>
-    </div>
+    >
+    </button>
+    {{#if actions}}
+      <div class="action-bar" role="toolbar" aria-label='{{localize "lancer.actionTracker.toolbar"}}'>
+        <a
+          class="action {{#if actions.protocol}}lancer-protocol{{/if}}"
+          data-action="protocol"
+          role="button"
+          tabindex="0"
+          aria-label='{{localize "lancer.actionTracker.actions.protocol"}}'
+        >
+          <i class="cci cci-protocol theme--dark white--text" aria-hidden="true"></i>
+          {{#if showTextLabels}}<span class="action-text">{{
+                localize "lancer.actionTracker.actions.protocol"
+              }}</span>{{/if}}
+        </a>
+        <hr class="v-divide" role="separator" aria-orientation="vertical" />
+        <a
+          class="action {{#if actions.move}}lancer-move{{/if}}"
+          data-action="move"
+          role="button"
+          tabindex="0"
+          aria-label='{{localize "lancer.actionTracker.actions.move"}}'
+        >
+          <i class="mdi mdi-arrow-right-bold-hexagon-outline theme--dark white--text" aria-hidden="true"></i>
+          {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.move"}}</span>{{/if}}
+        </a>
+        <a
+          class="action {{#if actions.full}}lancer-full{{/if}}"
+          data-action="full"
+          role="button"
+          tabindex="0"
+          aria-label='{{localize "lancer.actionTracker.actions.full"}}'
+        >
+          <i class="mdi mdi-hexagon-slice-6 theme--dark white--text" aria-hidden="true"></i>
+          {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.full"}}</span>{{/if}}
+        </a>
+        <a
+          class="action {{#if actions.quick}}lancer-quick{{/if}}"
+          data-action="quick"
+          role="button"
+          tabindex="0"
+          aria-label='{{localize "lancer.actionTracker.actions.quick"}}'
+        >
+          <i class="mdi mdi-hexagon-slice-3 theme--dark white--text" aria-hidden="true"></i>
+          {{#if showTextLabels}}<span class="action-text">{{
+                localize "lancer.actionTracker.actions.quick"
+              }}</span>{{/if}}
+        </a>
+        <a
+          class="action {{#if actions.reaction}}lancer-reaction{{/if}}"
+          data-action="reaction"
+          role="button"
+          tabindex="0"
+          aria-label='{{localize "lancer.actionTracker.actions.reaction"}}'
+        >
+          <i class="cci cci-reaction theme--dark white--text" aria-hidden="true"></i>
+          {{#if showTextLabels}}<span class="action-text">{{
+                localize "lancer.actionTracker.actions.reaction"
+              }}</span>{{/if}}
+        </a>
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/scripts/action-manager.test.ts
+++ b/scripts/action-manager.test.ts
@@ -5,7 +5,6 @@ import {
   resolveActionManagerWidth,
   isTokenInCombatEncounter,
   resolveActionManagerActor,
-  shouldShowActionManagerSurface,
 } from "../src/module/action/action-manager-context.ts";
 
 function mechActor(name = "Test Mech") {
@@ -51,17 +50,17 @@ describe("action manager context", () => {
     assert.equal(context.name, "TEST MECH");
     assert.equal(context.actions?.move, 4);
     assert.equal(context.positionWidth, 300);
-    assert.equal(shouldShowActionManagerSurface(context), true);
   });
 
-  it("hides the surface when no actor is selected", () => {
+  it("returns null actions when no actor is selected", () => {
     const context = buildActionManagerRenderContext({
       actor: null,
       clickable: true,
       showTextLabels: false,
       position: { width: 300 },
     });
-    assert.equal(shouldShowActionManagerSurface(context), false);
+    assert.equal(context.actions, null);
+    assert.equal(context.name, undefined);
   });
 
   it("resolves numeric widths for the surface style", () => {

--- a/scripts/combat-tracker.test.ts
+++ b/scripts/combat-tracker.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   COMBAT_TRACKER_DISPOSITION_CLASSES,
   enrichCombatTrackerTurns,
+  mergeCombatTrackerContext,
   type CombatTrackerTurnInput,
 } from "../src/module/combat/combat-tracker-turns.ts";
 
@@ -67,5 +68,16 @@ describe("combat tracker turns", () => {
   it("exposes disposition classes for all combatant types", () => {
     assert.equal(COMBAT_TRACKER_DISPOSITION_CLASSES[2], "player");
     assert.equal(COMBAT_TRACKER_DISPOSITION_CLASSES[-1], "enemy");
+  });
+
+  it("mergeCombatTrackerContext keeps turns when super returns tracker-only fields", () => {
+    const ctx = {
+      user: { isGM: true },
+      turns: [turn("c1")],
+    };
+    const merged = mergeCombatTrackerContext(ctx, { hasDecimals: false });
+    assert.equal(merged.turns?.length, 1);
+    assert.equal(merged.turns?.[0]?.id, "c1");
+    assert.equal((merged as { user?: { isGM: boolean } }).user?.isGM, true);
   });
 });

--- a/src/module/action/action-manager-context.ts
+++ b/src/module/action/action-manager-context.ts
@@ -60,7 +60,3 @@ export function buildActionManagerRenderContext(options: {
     positionWidth: resolveActionManagerWidth(position),
   };
 }
-
-export function shouldShowActionManagerSurface(context: Pick<ActionManagerRenderContext, "actions">): boolean {
-  return context.actions != null;
-}

--- a/src/module/action/action-manager.ts
+++ b/src/module/action/action-manager.ts
@@ -69,10 +69,7 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
       showTextLabels: trackerSettings.showTextLabels,
       position: this.position,
     });
-    return foundry.utils.mergeObject(context, {
-      ...data,
-      showSurface: data.actions != null,
-    });
+    return foundry.utils.mergeObject(context, data);
   }
 
   // DATA BINDING
@@ -145,8 +142,7 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
     const root = this.element;
     if (!root) return;
 
-    // Enable dragging.
-    this.dragElement(root);
+    this.bindDragHandle();
 
     // Enable reset.
     root.querySelector("#action-manager-reset")?.addEventListener("click", async e => {
@@ -204,69 +200,38 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
 
   // HELPERS //
 
-  private dragElement(root: HTMLElement) {
-    const appPos = this.position;
-    const dragHandle = root.querySelector<HTMLElement>("#action-manager-drag");
-    if (!dragHandle) return;
-    dragHandle.onmousedown = ev => {
+  private bindDragHandle() {
+    const handle = this.element?.querySelector<HTMLElement>("#action-manager-drag");
+    if (!handle) return;
+
+    handle.onmousedown = (ev: MouseEvent) => {
       ev.preventDefault();
-      ev = ev || window.event;
+      const startX = ev.clientX;
+      const startY = ev.clientY;
+      const startLeft = this.position.left ?? LancerActionManager.DEF_LEFT;
+      const startTop = this.position.top ?? LancerActionManager.DEF_TOP;
 
-      const hud = this.element;
-      const marginLeft = parseInt(window.getComputedStyle(hud ?? root).marginLeft.replace("px", ""));
-      const marginTop = parseInt(window.getComputedStyle(hud ?? root).marginTop.replace("px", ""));
+      const onMove = (e: MouseEvent) => {
+        e.preventDefault();
+        void this.setPosition({
+          left: startLeft + (e.clientX - startX),
+          top: startTop + (e.clientY - startY),
+        });
+      };
 
-      dragElement(root);
-      let pos1 = 0,
-        pos2 = 0,
-        pos3 = 0,
-        pos4 = 0;
+      const onUp = (e: MouseEvent) => {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+        const left = Math.max(0, startLeft + (e.clientX - startX));
+        const top = Math.max(0, startTop + (e.clientY - startY));
+        this.position.left = left;
+        this.position.top = top;
+        void this.setPosition({ left, top });
+        void game.user?.update({ flags: { lancer: { "action-manager": { pos: { top, left } } } } });
+      };
 
-      function dragElement(elmnt: HTMLElement) {
-        elmnt.onmousedown = dragMouseDown;
-
-        function dragMouseDown(e: MouseEvent) {
-          e = e || window.event;
-          e.preventDefault();
-          pos3 = e.clientX;
-          pos4 = e.clientY;
-
-          document.onmouseup = closeDragElement;
-          document.onmousemove = elementDrag;
-        }
-
-        function elementDrag(e: MouseEvent) {
-          e = e || window.event;
-          e.preventDefault();
-          // calculate the new cursor position:
-          pos1 = pos3 - e.clientX;
-          pos2 = pos4 - e.clientY;
-          pos3 = e.clientX;
-          pos4 = e.clientY;
-          // set the element's new position:
-          elmnt.style.top = elmnt.offsetTop - pos2 - marginTop + "px";
-          elmnt.style.left = elmnt.offsetLeft - pos1 - marginLeft + "px";
-        }
-
-        function closeDragElement() {
-          // stop moving when mouse button is released:
-          elmnt.onmousedown = null;
-          document.onmouseup = null;
-          document.onmousemove = null;
-          let xPos = elmnt.offsetLeft - pos1 > window.innerWidth ? window.innerWidth : elmnt.offsetLeft - pos1;
-          let yPos =
-            elmnt.offsetTop - pos2 > window.innerHeight - 20 ? window.innerHeight - 100 : elmnt.offsetTop - pos2;
-          xPos = xPos < 8 ? 0 : xPos - 10;
-          yPos = yPos < 8 ? 0 : yPos - 3;
-          if (xPos != elmnt.offsetLeft - pos1 || yPos != elmnt.offsetTop - pos2) {
-            elmnt.style.top = yPos + "px";
-            elmnt.style.left = xPos + "px";
-          }
-          game.user?.update({ flags: { lancer: { "action-manager": { pos: { top: yPos, left: xPos } } } } });
-          appPos.top = yPos;
-          appPos.left = xPos;
-        }
-      }
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
     };
   }
 

--- a/src/module/combat/combat-tracker-turns.ts
+++ b/src/module/combat/combat-tracker-turns.ts
@@ -43,6 +43,15 @@ export type EnrichedCombatTrackerTurn = CombatTrackerTurnInput & {
   pending?: number;
 };
 
+/** Merge tracker-only fields from super._prepareTrackerContext onto the shared render context. */
+export function mergeCombatTrackerContext<T extends { turns?: CombatTrackerTurnInput[] }>(
+  ctx: T,
+  trackerFields?: Partial<T> | void
+): T {
+  if (trackerFields) Object.assign(ctx, trackerFields);
+  return ctx;
+}
+
 export function enrichCombatTrackerTurns(
   options: EnrichCombatTrackerTurnsOptions
 ): EnrichedCombatTrackerTurn[] | undefined {

--- a/src/module/combat/lancer-combat-tracker.ts
+++ b/src/module/combat/lancer-combat-tracker.ts
@@ -1,6 +1,6 @@
 import { LANCER } from "../config.js";
 import type { CombatTrackerAppearance } from "../settings.js";
-import { enrichCombatTrackerTurns } from "./combat-tracker-turns.js";
+import { enrichCombatTrackerTurns, mergeCombatTrackerContext } from "./combat-tracker-turns.js";
 import type { LancerCombat, LancerCombatant } from "./lancer-combat.js";
 
 import ContextMenu = foundry.applications.ux.ContextMenu;
@@ -10,13 +10,17 @@ import ContextMenu = foundry.applications.ux.ContextMenu;
  * buttons and either move or remove the initiative button
  */
 export class LancerCombatTracker extends foundry.applications.sidebar.tabs.CombatTracker {
-  static DEFAULT_OPTIONS = {
-    actions: {
-      activateCombatantTurn: LancerCombatTracker.#activateCombatantTurn,
-      deactivateCombatantTurn: LancerCombatTracker.#deactivateCombatantTurn,
-      toggleCombatantTarget: LancerCombatTracker.#toggleCombatantTarget,
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    foundry.applications.sidebar.tabs.CombatTracker.DEFAULT_OPTIONS,
+    {
+      actions: {
+        activateCombatantTurn: LancerCombatTracker.#activateCombatantTurn,
+        deactivateCombatantTurn: LancerCombatTracker.#deactivateCombatantTurn,
+        toggleCombatantTarget: LancerCombatTracker.#toggleCombatantTarget,
+      },
     },
-  };
+    { inplace: false }
+  );
   static PARTS = foundry.utils.mergeObject(
     foundry.applications.sidebar.tabs.CombatTracker.PARTS,
     { tracker: { template: "systems/lancer/templates/combat/tracker.hbs" } },
@@ -25,14 +29,14 @@ export class LancerCombatTracker extends foundry.applications.sidebar.tabs.Comba
 
   async _prepareTrackerContext(ctx: any, opts: any) {
     const appearance = game.settings.get(game.system.id, LANCER.setting_combat_appearance);
-    const trackerCtx = (await super._prepareTrackerContext(ctx, opts)) ?? ctx;
+    mergeCombatTrackerContext(ctx, await super._prepareTrackerContext(ctx, opts));
     const targetNames = (game.user?.targets ?? [])
       .map(t => t.document?.name ?? t.name)
       .filter(Boolean)
       .join(", ");
 
-    trackerCtx.turns = enrichCombatTrackerTurns({
-      turns: trackerCtx.turns,
+    ctx.turns = enrichCombatTrackerTurns({
+      turns: ctx.turns,
       getCombatant: id => {
         const combatant = this.viewed?.combatants.get(id) as LancerCombatant | undefined;
         if (!combatant) return undefined;
@@ -56,7 +60,7 @@ export class LancerCombatTracker extends foundry.applications.sidebar.tabs.Comba
       };
     });
 
-    return trackerCtx;
+    return ctx;
   }
 
   static async #activateCombatantTurn(this: LancerCombatTracker, ev: MouseEvent, target: HTMLElement) {

--- a/src/styles/applications/_action-manager.scss
+++ b/src/styles/applications/_action-manager.scss
@@ -15,6 +15,12 @@
     height: fit-content;
     max-height: none;
     overflow: visible;
+    pointer-events: none;
+  }
+
+  #action-manager .lancer-action-manager-surface,
+  #action-manager .window-content {
+    pointer-events: auto;
   }
 
   #action-manager .window-content {
@@ -46,14 +52,16 @@
     -webkit-clip-path: none;
   }
 
-  #action-manager.hidden,
-  #action-manager .lancer-action-manager-surface.hidden {
-    display: none !important; // Because apparently you need to do this.
-  }
-  #action-manager-drag {
+  #action-manager-drag,
+  .action-manager-drag {
     cursor: move;
     font-size: 1.35em;
     padding: 8px 2px 0 6px;
+    border: none;
+    background: transparent;
+    color: inherit;
+    line-height: 1;
+    flex: 0 0 auto;
   }
   .action-manager-reset-wrap {
     position: absolute;
@@ -102,6 +110,8 @@
   }
 
   #action-manager .action-manager-controls {
+    display: flex;
+    flex-direction: row;
     flex: 0 0 auto;
     flex-shrink: 0;
     align-items: stretch;

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.11/lancer-v3.1.11.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.12/lancer-v3.1.12.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up fix for [#121](https://github.com/VacantFanatic/foundryvtt-lancer/issues/121) after v3.1.11 still left the combat tracker empty and broke action tracker UX.

### Combat tracker
- Merge tracker fields onto the **shared** render context (`ctx`) instead of using only the return value from `super._prepareTrackerContext`, which dropped `turns`.
- Merge parent `CombatTracker.DEFAULT_OPTIONS` so core combatant actions (`activateCombatant`, `toggleHidden`, etc.) remain registered.

### Action tracker HUD
- Always show the drag handle bar (even when no combatant is selected).
- Restore `display: flex` on the control row so the drag icon is visible.
- Drag via Application V2 `setPosition` instead of mutating inline styles on the wrong element.
- Set `pointer-events: none` on the transparent host so it no longer blocks canvas token selection.

## Testing
- `npm test` (50 passing)
- Version **3.1.12**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fe7c1fe-e8e1-4430-83fb-bb9b02e943bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fe7c1fe-e8e1-4430-83fb-bb9b02e943bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

