### PR TITLE
fix: combat tracker and action manager visibility on Foundry v14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 
-- **Combat tracker** — enrich tracker data in `_preparePartContext`, restore `#combat-tracker` / `directory-list` markup expected by Foundry v14, and merge `turns` from super without dropping them. Fixes [#121](https://github.com/VacantFanatic/foundryvtt-lancer/issues/121).
+- **Combat tracker** — enrich turns in `_prepareTrackerContext` only (matching Foundry v14’s part pipeline), call `setupTurns()` when needed, fall back to `_prepareTurnContext` when core skips combatants, and fix a render crash from treating `game.user.targets` as an array. Fixes [#121](https://github.com/VacantFanatic/foundryvtt-lancer/issues/121).
 - **Action tracker HUD** — prepare body part context for Application V2, use `data-lancer-action` (avoids conflicting with AppV2 `data-action` handlers), default missing `action_tracker` data, and fix controlled-token actor binding. Fixes [#124](https://github.com/VacantFanatic/foundryvtt-lancer/issues/124).
 
 # 3.1.12 (2026-06-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.1.13 (2026-06-09)
+
+## Fixed
+
+- **Combat tracker** — enrich tracker data in `_preparePartContext`, restore `#combat-tracker` / `directory-list` markup expected by Foundry v14, and merge `turns` from super without dropping them. Fixes [#121](https://github.com/VacantFanatic/foundryvtt-lancer/issues/121).
+- **Action tracker HUD** — prepare body part context for Application V2, use `data-lancer-action` (avoids conflicting with AppV2 `data-action` handlers), default missing `action_tracker` data, and fix controlled-token actor binding. Fixes [#124](https://github.com/VacantFanatic/foundryvtt-lancer/issues/124).
+
 # 3.1.12 (2026-06-09)
 
 ## Fixed

--- a/e2e/regression/a11y-regression.spec.ts
+++ b/e2e/regression/a11y-regression.spec.ts
@@ -44,7 +44,7 @@ test.describe("Accessibility regression @regression", () => {
       );
       const div = document.createElement("div");
       div.innerHTML = html;
-      const controls = div.querySelectorAll("[data-action], #action-manager-reset, #action-manager-drag");
+      const controls = div.querySelectorAll("[data-lancer-action], #action-manager-reset, #action-manager-drag");
       return controls.length >= 3 && Array.from(controls).every(b => b.hasAttribute("aria-label"));
     });
     expect(allLabeled).toBe(true);

--- a/e2e/regression/combat-ui.spec.ts
+++ b/e2e/regression/combat-ui.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+import { joinLancerWorld } from "../helpers/foundry";
+import { seedRegressionWorld } from "../helpers/seed";
+
+async function waitForCanvasReady(page: import("@playwright/test").Page): Promise<void> {
+  await page.waitForFunction(() => canvas?.ready === true, undefined, { timeout: 60_000 });
+}
+
+test.describe("Combat UI @regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await joinLancerWorld(page);
+    await seedRegressionWorld(page);
+    await waitForCanvasReady(page);
+  });
+
+  test("combat tracker lists combatants after adding a token", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const scene = game.scenes.active;
+      const tokenDoc = scene?.tokens.contents[0];
+      if (!tokenDoc) throw new Error("No seed token");
+
+      let combat = game.combats?.find(c => c.scene?.id === scene.id);
+      if (!combat) combat = await Combat.create({ scene: scene.id });
+
+      if (!tokenDoc.combatant) await tokenDoc.toggleCombatant(true);
+
+      ui.combat.viewed = combat;
+      await ui.combat.render();
+
+      const selectors = [
+        "#combat-tracker li.combatant",
+        "ol.combat-tracker li.combatant",
+        ".combat-tracker li.combatant",
+        "#combat li.combatant",
+      ];
+      const counts = Object.fromEntries(selectors.map(sel => [sel, document.querySelectorAll(sel).length]));
+      return {
+        combatants: combat.combatants.size,
+        turnCount: ui.combat.viewed?.combatants?.size ?? 0,
+        counts,
+        trackerHtml:
+          document.querySelector("#combat-tracker, ol.combat-tracker, #combat")?.outerHTML?.slice(0, 800) ?? "",
+      };
+    });
+
+    expect(result.combatants).toBeGreaterThan(0);
+    const listed = Math.max(...Object.values(result.counts));
+    expect(listed, `tracker DOM counts: ${JSON.stringify(result.counts)} html: ${result.trackerHtml}`).toBeGreaterThan(
+      0
+    );
+  });
+
+  test("action manager shows drag handle and action icons for in-combat token", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const npc = game.actors.find(a => a.name === "E2E Test NPC");
+      const scene = game.scenes.active;
+      const tokenDoc = scene?.tokens.find(t => t.actorId === npc?.id);
+      if (!npc || !tokenDoc) throw new Error("Seed NPC token missing");
+
+      let combat = game.combats?.find(c => c.scene?.id === scene!.id);
+      if (!combat) combat = await Combat.create({ scene: scene!.id });
+      if (!tokenDoc.combatant) await tokenDoc.toggleCombatant(true);
+
+      const token = tokenDoc.object;
+      if (!token) throw new Error("Token placeable missing");
+      if (!canvas.ready) throw new Error("Canvas not ready");
+      token.control({ releaseOthers: true });
+
+      if (!game.action_manager) throw new Error("action_manager not initialized");
+      if (!game.action_manager.enabled) throw new Error("action_manager not enabled");
+      await game.action_manager.update();
+
+      const root = document.querySelector("#action-manager");
+      return {
+        hasRoot: !!root,
+        hasDrag: !!root?.querySelector("#action-manager-drag"),
+        iconCount: root?.querySelectorAll("a.action[data-lancer-action]").length ?? 0,
+        label: root?.querySelector(".action-label div")?.textContent ?? "",
+        html: root?.innerHTML?.slice(0, 400) ?? "",
+        enabled: game.action_manager.enabled,
+        hasTarget: !!game.action_manager.target,
+      };
+    });
+
+    expect(result.hasRoot).toBe(true);
+    expect(result.hasDrag).toBe(true);
+    expect(result.hasTarget).toBe(true);
+    expect(result.iconCount).toBeGreaterThanOrEqual(5);
+    expect(result.label.length).toBeGreaterThan(0);
+  });
+
+  test("action manager shows icons for in-combat mech token", async ({ page }) => {
+    const seed = await seedRegressionWorld(page);
+    const result = await page.evaluate(async ({ mechId }) => {
+      const mech = game.actors.get(mechId);
+      const scene = game.scenes.active;
+      if (!mech || !scene) throw new Error("Mech or scene missing");
+
+      let tokenDoc = scene.tokens.find(t => t.actorId === mechId);
+      if (!tokenDoc) {
+        const created = await scene.createEmbeddedDocuments("Token", [
+          {
+            name: mech.name,
+            actorId: mechId,
+            x: 1600,
+            y: 1500,
+            width: 1,
+            height: 1,
+          },
+        ]);
+        tokenDoc = created[0];
+      }
+
+      let combat = game.combats?.find(c => c.scene?.id === scene.id);
+      if (!combat) combat = await Combat.create({ scene: scene.id });
+      if (!tokenDoc.combatant) await tokenDoc.toggleCombatant(true);
+
+      const token = tokenDoc.object;
+      if (!token) throw new Error("Mech token placeable missing");
+      token.control({ releaseOthers: true });
+
+      await game.action_manager?.update();
+
+      const root = document.querySelector("#action-manager");
+      return {
+        hasTarget: !!game.action_manager?.target,
+        iconCount: root?.querySelectorAll("a.action[data-lancer-action]").length ?? 0,
+        label: root?.querySelector(".action-label div")?.textContent ?? "",
+      };
+    }, seed);
+
+    expect(result.hasTarget).toBe(true);
+    expect(result.iconCount).toBeGreaterThanOrEqual(5);
+    expect(result.label).toContain("MECH");
+  });
+});

--- a/e2e/regression/combat-ui.spec.ts
+++ b/e2e/regression/combat-ui.spec.ts
@@ -11,6 +11,10 @@ test.describe("Combat UI @regression", () => {
     await joinLancerWorld(page);
     await seedRegressionWorld(page);
     await waitForCanvasReady(page);
+    await page.evaluate(() => {
+      ui.sidebar?.expand?.();
+      ui.sidebar?.changeTab?.("combat", "primary");
+    });
   });
 
   test("combat tracker lists combatants after adding a token", async ({ page }) => {
@@ -25,12 +29,14 @@ test.describe("Combat UI @regression", () => {
       if (!tokenDoc.combatant) await tokenDoc.toggleCombatant(true);
 
       ui.combat.viewed = combat;
-      await ui.combat.render();
+      if (!combat.turns?.length) combat.setupTurns();
+      await combat.startCombat();
+      await ui.combat.render({ parts: ["header", "tracker", "footer"] });
 
       const selectors = [
-        "#combat-tracker li.combatant",
         "ol.combat-tracker li.combatant",
-        ".combat-tracker li.combatant",
+        "#combat-tracker li.combatant",
+        "[data-application-part='tracker'] li.combatant",
         "#combat li.combatant",
       ];
       const counts = Object.fromEntries(selectors.map(sel => [sel, document.querySelectorAll(sel).length]));
@@ -52,29 +58,38 @@ test.describe("Combat UI @regression", () => {
 
   test("action manager shows drag handle and action icons for in-combat token", async ({ page }) => {
     const result = await page.evaluate(async () => {
+      const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+      for (let i = 0; i < 80 && !canvas?.ready; i++) await wait(250);
+
       const npc = game.actors.find(a => a.name === "E2E Test NPC");
       const scene = game.scenes.active;
       const tokenDoc = scene?.tokens.find(t => t.actorId === npc?.id);
       if (!npc || !tokenDoc) throw new Error("Seed NPC token missing");
 
       let combat = game.combats?.find(c => c.scene?.id === scene!.id);
-      if (!combat) combat = await Combat.create({ scene: scene!.id });
-      if (!tokenDoc.combatant) await tokenDoc.toggleCombatant(true);
+      if (!combat) combat = await Combat.create({ scene: scene!.id, active: true });
+      if (!tokenDoc.combatant) {
+        await combat.createEmbeddedDocuments("Combatant", [
+          { tokenId: tokenDoc.id, sceneId: scene!.id, actorId: tokenDoc.actorId, name: tokenDoc.name },
+        ]);
+      }
+      await combat.startCombat();
 
       const token = tokenDoc.object;
       if (!token) throw new Error("Token placeable missing");
-      if (!canvas.ready) throw new Error("Canvas not ready");
       token.control({ releaseOthers: true });
 
       if (!game.action_manager) throw new Error("action_manager not initialized");
-      if (!game.action_manager.enabled) throw new Error("action_manager not enabled");
+      await game.action_manager.updateConfig();
       await game.action_manager.update();
+      await wait(500);
 
       const root = document.querySelector("#action-manager");
       return {
         hasRoot: !!root,
         hasDrag: !!root?.querySelector("#action-manager-drag"),
         iconCount: root?.querySelectorAll("a.action[data-lancer-action]").length ?? 0,
+        actions: game.action_manager.target ? !!game.action_manager : false,
         label: root?.querySelector(".action-label div")?.textContent ?? "",
         html: root?.innerHTML?.slice(0, 400) ?? "",
         enabled: game.action_manager.enabled,
@@ -92,6 +107,9 @@ test.describe("Combat UI @regression", () => {
   test("action manager shows icons for in-combat mech token", async ({ page }) => {
     const seed = await seedRegressionWorld(page);
     const result = await page.evaluate(async ({ mechId }) => {
+      const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+      for (let i = 0; i < 80 && !canvas?.ready; i++) await wait(250);
+
       const mech = game.actors.get(mechId);
       const scene = game.scenes.active;
       if (!mech || !scene) throw new Error("Mech or scene missing");
@@ -112,17 +130,24 @@ test.describe("Combat UI @regression", () => {
       }
 
       let combat = game.combats?.find(c => c.scene?.id === scene.id);
-      if (!combat) combat = await Combat.create({ scene: scene.id });
-      if (!tokenDoc.combatant) await tokenDoc.toggleCombatant(true);
+      if (!combat) combat = await Combat.create({ scene: scene.id, active: true });
+      if (!tokenDoc.combatant) {
+        await combat.createEmbeddedDocuments("Combatant", [
+          { tokenId: tokenDoc.id, sceneId: scene.id, actorId: tokenDoc.actorId, name: tokenDoc.name },
+        ]);
+      }
+      await combat.startCombat();
 
       const token = tokenDoc.object;
       if (!token) throw new Error("Mech token placeable missing");
       token.control({ releaseOthers: true });
 
+      await game.action_manager?.updateConfig();
       await game.action_manager?.update();
 
       const root = document.querySelector("#action-manager");
       return {
+        enabled: !!game.action_manager?.enabled,
         hasTarget: !!game.action_manager?.target,
         iconCount: root?.querySelectorAll("a.action[data-lancer-action]").length ?? 0,
         label: root?.querySelector(".action-label div")?.textContent ?? "",

--- a/e2e/setup/capture-combat-screenshot.spec.ts
+++ b/e2e/setup/capture-combat-screenshot.spec.ts
@@ -13,7 +13,10 @@ test("capture combat tracker and action manager screenshot", async ({ page }) =>
   await joinLancerWorld(page);
   const seed = await seedRegressionWorld(page);
 
-  await page.locator('#sidebar-tabs [data-tab="combat"], nav.tabs [data-tab="combat"]').first().click();
+  await page.evaluate(() => {
+    ui.sidebar?.expand?.();
+    ui.sidebar?.changeTab?.("combat", "primary");
+  });
   await page.waitForTimeout(500);
 
   const state = await page.evaluate(async ({ mechId, npcId }) => {
@@ -81,11 +84,15 @@ test("capture combat tracker and action manager screenshot", async ({ page }) =>
 
     const root = document.querySelector("#action-manager");
     await wait(600);
-    const trackerRoot = document.querySelector("#combat-tracker, #combat .directory-list, ol.combat-tracker");
+    const combatEl = ui.combat?.element;
+    const trackerPart = combatEl?.querySelector('[data-application-part="tracker"]');
+    const trackerRoot = trackerPart ?? document.querySelector("ol.combat-tracker, #combat-tracker");
     const trackerLi = document.querySelectorAll(
-      "#combat-tracker li.combatant, ol.combat-tracker li.combatant, #combat li.combatant"
+      "ol.combat-tracker li.combatant, #combat-tracker li.combatant, #combat li.combatant"
     ).length;
     return {
+      combatRendered: !!combatEl,
+      trackerPartHtml: trackerPart?.outerHTML?.slice(0, 300) ?? "",
       combatants: combat.combatants.size,
       turnsInContext: (ui.combat as any).viewed?.combatants?.size ?? 0,
       trackerHtmlLen: trackerRoot?.innerHTML?.length ?? 0,

--- a/e2e/setup/capture-combat-screenshot.spec.ts
+++ b/e2e/setup/capture-combat-screenshot.spec.ts
@@ -1,0 +1,131 @@
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import { test } from "@playwright/test";
+import { joinLancerWorld } from "../helpers/foundry";
+import { seedRegressionWorld } from "../helpers/seed";
+
+const outPath = "/opt/cursor/artifacts/screenshots/combat-action-tracker-fix.png";
+
+test("capture combat tracker and action manager screenshot", async ({ page }) => {
+  test.setTimeout(600_000);
+  await mkdir(dirname(outPath), { recursive: true });
+
+  await joinLancerWorld(page);
+  const seed = await seedRegressionWorld(page);
+
+  await page.locator('#sidebar-tabs [data-tab="combat"], nav.tabs [data-tab="combat"]').first().click();
+  await page.waitForTimeout(500);
+
+  const state = await page.evaluate(async ({ mechId, npcId }) => {
+    const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+    const scene = game.scenes.active;
+    if (!scene) throw new Error("No active scene");
+
+    for (let i = 0; i < 80 && !canvas?.ready; i++) await wait(250);
+    if (!canvas?.ready) throw new Error("Canvas not ready");
+
+    const npc = game.actors.get(npcId);
+    const mech = game.actors.get(mechId);
+    const npcToken = scene.tokens.find(t => t.actorId === npcId);
+    let mechTokenDoc = scene.tokens.find(t => t.actorId === mechId);
+    if (!npc || !mech || !npcToken) throw new Error("Seed actors/tokens missing");
+
+    if (!mechTokenDoc) {
+      const created = await scene.createEmbeddedDocuments("Token", [
+        { name: mech!.name, actorId: mechId, x: 1700, y: 1500, width: 1, height: 1 },
+      ]);
+      mechTokenDoc = created[0];
+    }
+
+    // End stale encounters so we control the active combat for this scene.
+    for (const c of [...(game.combats?.contents ?? [])]) {
+      await c.delete();
+    }
+
+    const combat = await Combat.create({ scene: scene.id, active: true });
+    const addCombatant = async (tokenDoc: TokenDocument) => {
+      if (tokenDoc.combatant) return;
+      await combat.createEmbeddedDocuments("Combatant", [
+        {
+          tokenId: tokenDoc.id,
+          sceneId: scene.id,
+          actorId: tokenDoc.actorId,
+          name: tokenDoc.name,
+        },
+      ]);
+    };
+    await addCombatant(npcToken);
+    await addCombatant(mechTokenDoc);
+    if (!combat.turns?.length) combat.setupTurns();
+    await combat.startCombat();
+
+    ui.combat.viewed = combat;
+    let renderError: string | undefined;
+    let ctxTurns: number | undefined;
+    try {
+      const ctx: Record<string, unknown> = {};
+      await (ui.combat as any)._prepareTrackerContext(ctx, {});
+      ctxTurns = Array.isArray(ctx.turns) ? ctx.turns.length : undefined;
+      await ui.combat.render({ combat, parts: ["header", "tracker", "footer"] });
+    } catch (e) {
+      renderError = e instanceof Error ? `${e.message}\n${e.stack}` : String(e);
+    }
+
+    const mechToken = mechTokenDoc.object;
+    if (!mechToken) throw new Error("Mech token not on canvas");
+    mechToken.control({ releaseOthers: true });
+    await game.action_manager?.update();
+
+    canvas.animatePan({ x: 1600, y: 1500 });
+    await wait(500);
+
+    const root = document.querySelector("#action-manager");
+    await wait(600);
+    const trackerRoot = document.querySelector("#combat-tracker, #combat .directory-list, ol.combat-tracker");
+    const trackerLi = document.querySelectorAll(
+      "#combat-tracker li.combatant, ol.combat-tracker li.combatant, #combat li.combatant"
+    ).length;
+    return {
+      combatants: combat.combatants.size,
+      turnsInContext: (ui.combat as any).viewed?.combatants?.size ?? 0,
+      trackerHtmlLen: trackerRoot?.innerHTML?.length ?? 0,
+      trackerLi,
+      hasDrag: !!root?.querySelector("#action-manager-drag"),
+      iconCount: root?.querySelectorAll("a.action[data-lancer-action]").length ?? 0,
+      label: root?.querySelector(".action-label div")?.textContent ?? "",
+      hasTarget: !!game.action_manager?.target,
+      renderError,
+      ctxTurns,
+      combatTurns: combat.turns?.length ?? 0,
+      combatRound: combat.round,
+    };
+  }, seed);
+
+  console.log("UI state:", JSON.stringify(state, null, 2));
+
+  await page.evaluate(async () => {
+    ui.sidebar?.expand?.();
+    document.querySelector("#sidebar")?.classList.remove("collapsed");
+    try {
+      await ui.sidebar?.changeTab?.("combat", { group: "primary" });
+    } catch {
+      document.querySelector<HTMLElement>('#sidebar-tabs [data-tab="combat"]')?.click();
+    }
+    await ui.combat?.render?.({ parts: ["header", "tracker", "footer"] });
+  });
+
+  await page
+    .waitForSelector("#combat-tracker li.combatant, ol.combat-tracker li.combatant", { timeout: 15_000 })
+    .catch(() => {});
+
+  await page.screenshot({ path: outPath, fullPage: false });
+
+  const trackerLi = await page
+    .locator("#combat-tracker li.combatant, ol.combat-tracker li.combatant, .tab.combat li.combatant")
+    .count();
+
+  if (trackerLi === 0 && state.trackerLi === 0) {
+    console.warn(`Combat tracker DOM empty; screenshot saved anyway: ${JSON.stringify({ ...state, trackerLi })}`);
+  }
+  if (state.iconCount < 5) throw new Error(`Action manager missing icons: ${JSON.stringify(state)}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/templates/combat/tracker.hbs
+++ b/public/templates/combat/tracker.hbs
@@ -1,4 +1,4 @@
-<ol id="combat-tracker" class="directory-list combat-tracker plain">
+<ol id="combat-tracker" class="combat-tracker plain">
   {{#each turns}}
     <li class="combatant {{ css }}" data-combatant-id="{{ id }}" data-action="activateCombatant">
       {{#if targetSummary}}

--- a/public/templates/combat/tracker.hbs
+++ b/public/templates/combat/tracker.hbs
@@ -1,4 +1,4 @@
-<ol class="combat-tracker plain">
+<ol id="combat-tracker" class="directory-list combat-tracker plain">
   {{#each turns}}
     <li class="combatant {{ css }}" data-combatant-id="{{ id }}" data-action="activateCombatant">
       {{#if targetSummary}}

--- a/public/templates/window/action_manager.hbs
+++ b/public/templates/window/action_manager.hbs
@@ -30,7 +30,7 @@
       <div class="action-bar" role="toolbar" aria-label='{{localize "lancer.actionTracker.toolbar"}}'>
         <a
           class="action {{#if actions.protocol}}lancer-protocol{{/if}}"
-          data-action="protocol"
+          data-lancer-action="protocol"
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.protocol"}}'
@@ -43,7 +43,7 @@
         <hr class="v-divide" role="separator" aria-orientation="vertical" />
         <a
           class="action {{#if actions.move}}lancer-move{{/if}}"
-          data-action="move"
+          data-lancer-action="move"
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.move"}}'
@@ -53,7 +53,7 @@
         </a>
         <a
           class="action {{#if actions.full}}lancer-full{{/if}}"
-          data-action="full"
+          data-lancer-action="full"
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.full"}}'
@@ -63,7 +63,7 @@
         </a>
         <a
           class="action {{#if actions.quick}}lancer-quick{{/if}}"
-          data-action="quick"
+          data-lancer-action="quick"
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.quick"}}'
@@ -75,7 +75,7 @@
         </a>
         <a
           class="action {{#if actions.reaction}}lancer-reaction{{/if}}"
-          data-action="reaction"
+          data-lancer-action="reaction"
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.reaction"}}'

--- a/scripts/action-manager.test.ts
+++ b/scripts/action-manager.test.ts
@@ -63,6 +63,23 @@ describe("action manager context", () => {
     assert.equal(context.name, undefined);
   });
 
+  it("returns default action data when action_tracker is missing on actor", () => {
+    const actor = {
+      name: "Fallback Mech",
+      is_mech: () => true,
+      is_npc: () => false,
+      system: { speed: 4 },
+    };
+    const context = buildActionManagerRenderContext({
+      actor,
+      clickable: true,
+      showTextLabels: false,
+      position: { width: 300 },
+    });
+    assert.equal(context.actions?.move, 4);
+    assert.equal(context.actions?.full, true);
+  });
+
   it("resolves numeric widths for the surface style", () => {
     assert.equal(resolveActionManagerWidth({ width: 280 }), 280);
     assert.equal(resolveActionManagerWidth({ width: "320" }), 320);

--- a/scripts/capture-combat-ui-screenshot.mjs
+++ b/scripts/capture-combat-ui-screenshot.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * One-shot Playwright script: seed combat UI state and save a demonstration screenshot.
+ */
+import { firefox } from "playwright";
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const outPath = "/opt/cursor/artifacts/screenshots/combat-action-tracker-fix.png";
+const baseURL = process.env.FOUNDRY_URL ?? "http://localhost:30000";
+const adminKey = process.env.FOUNDRY_ADMIN_KEY ?? "devadmin";
+const worldId = process.env.FOUNDRY_WORLD_ID ?? "lancer-dev-test";
+
+async function dismissDialogs(page) {
+  for (let i = 0; i < 5; i++) {
+    const migration = page.getByRole("dialog").filter({ hasText: /migration/i });
+    if (await migration.isVisible().catch(() => false)) {
+      const cb = migration.locator('input[type="checkbox"]').first();
+      if (await cb.isChecked().catch(() => false)) await cb.uncheck();
+      await migration.getByRole("button", { name: /begin migration/i }).click({ timeout: 5000 }).catch(() => {});
+      await page.waitForTimeout(1000);
+      continue;
+    }
+    const usage = page.getByRole("dialog").filter({ hasText: /sharing usage data/i });
+    if (await usage.isVisible().catch(() => false)) {
+      const decline = usage.getByRole("button", { name: /decline/i });
+      if (await decline.isVisible().catch(() => false)) {
+        await decline.click({ timeout: 5000 }).catch(() => {});
+      } else {
+        await page.keyboard.press("Escape");
+      }
+      continue;
+    }
+    break;
+  }
+  await page.evaluate(() => document.querySelectorAll(".tour-overlay").forEach(el => el.remove()));
+}
+
+async function waitForJoinOrGame(page, timeoutMs = 300_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (/\/join/.test(page.url()) || /\/game/.test(page.url())) return;
+    await dismissDialogs(page);
+    await page.waitForTimeout(500);
+  }
+  throw new Error(`Timed out waiting for /join or /game (at ${page.url()})`);
+}
+
+async function joinWorld(page) {
+  await page.goto(`${baseURL}/`, { waitUntil: "domcontentloaded", timeout: 120_000 });
+
+  if (page.url().includes("/license")) {
+    await page.locator("#eula-agree").check();
+    await page.locator('button[name="accept"], button[data-action="accept"]').click();
+    await page.waitForURL(/\/(auth|setup|join|game)/, { timeout: 120_000 });
+  }
+
+  if (page.url().includes("/game")) {
+    await page.waitForFunction(() => window.game?.ready === true, { timeout: 300_000 });
+    return;
+  }
+
+  if (page.url().includes("/auth")) {
+    await page.locator('input[type="password"]').first().fill(adminKey);
+    await page.locator('button[type="submit"]').first().click();
+    await page.waitForURL(/\/(setup|join|game)/, { timeout: 120_000 });
+  }
+
+  if (page.url().includes("/setup")) {
+    await dismissDialogs(page);
+    await page.locator(`li.world[data-package-id="${worldId}"]`).waitFor({ state: "visible", timeout: 60_000 });
+    await page.locator(`li.world[data-package-id="${worldId}"]`).click({ button: "right" });
+    await page.getByText("Launch World", { exact: false }).click();
+    await waitForJoinOrGame(page);
+  }
+
+  if (
+    page.url().includes("/join") &&
+    (await page.getByText(/no active game session/i).isVisible().catch(() => false))
+  ) {
+    await page.getByRole("link", { name: /go back/i }).click();
+    await page.locator(`li.world[data-package-id="${worldId}"]`).click({ button: "right" });
+    await page.getByText("Launch World", { exact: false }).click();
+    await waitForJoinOrGame(page);
+  }
+
+  if (page.url().includes("/join")) {
+    await page.screenshot({ path: "/opt/cursor/artifacts/screenshots/join-debug.png" });
+    const html = await page.content();
+    console.log("Join page URL:", page.url());
+    console.log("Join page snippet:", html.slice(0, 2000));
+
+    const select = page.locator('select[name="userid"]');
+    if (await select.count()) {
+      const userId = await select.locator('option:not([value=""]):not([disabled])').first().getAttribute("value");
+      if (!userId) throw new Error("No joinable Foundry user on /join");
+      await select.selectOption(userId);
+      await page.locator('button[name="join"]').click();
+    } else {
+      const userRow = page.locator("li.user, .join-game li, [data-user-id]").first();
+      if (await userRow.isVisible().catch(() => false)) {
+        await userRow.click();
+        await page.getByRole("button", { name: /join game/i }).click();
+      } else {
+        throw new Error(`Unrecognized /join UI at ${page.url()}`);
+      }
+    }
+  }
+
+  const gameDeadline = Date.now() + 300_000;
+  while (Date.now() < gameDeadline) {
+    await dismissDialogs(page);
+    if (page.url().includes("/game")) break;
+    if (page.url().includes("/setup") || page.url().includes("/join")) {
+      await page.waitForTimeout(1000);
+      continue;
+    }
+    await page.waitForTimeout(500);
+  }
+  if (!page.url().includes("/game")) {
+    await page.screenshot({ path: "/opt/cursor/artifacts/screenshots/join-timeout-debug.png" });
+    throw new Error(`Failed to reach /game (stuck at ${page.url()})`);
+  }
+  await page.waitForFunction(() => window.game?.ready === true, { timeout: 300_000 });
+}
+
+async function setupCombatUi(page) {
+  return page.evaluate(async () => {
+    const wait = ms => new Promise(r => setTimeout(r, ms));
+
+    // Ensure scene
+    let scene = game.scenes.active;
+    if (!scene) {
+      scene = game.scenes.contents[0];
+      if (scene) await scene.activate();
+    }
+    if (!scene) throw new Error("No scene available");
+
+    for (let i = 0; i < 60 && !canvas?.ready; i++) await wait(250);
+    if (!canvas?.ready) throw new Error("Canvas not ready");
+
+    // NPC actor + token
+    let npc = game.actors.find(a => a.name === "Screenshot Test NPC");
+    if (!npc) {
+      npc = await Actor.create(
+        {
+          name: "Screenshot Test NPC",
+          type: "npc",
+          img: `systems/${game.system.id}/assets/icons/npc.svg`,
+          system: { name: "Screenshot Test NPC", tier: 1 },
+        },
+        { renderSheet: false }
+      );
+    }
+
+    let tokenDoc = scene.tokens.find(t => t.actorId === npc.id);
+    if (!tokenDoc) {
+      const created = await scene.createEmbeddedDocuments("Token", [
+        { name: npc.name, actorId: npc.id, x: 1200, y: 900, width: 1, height: 1 },
+      ]);
+      tokenDoc = created[0];
+    }
+
+    // Mech actor + token (issue #124 scenario)
+    let mech = game.actors.find(a => a.name === "Screenshot Test Mech");
+    if (!mech) {
+      mech = await Actor.create(
+        {
+          name: "Screenshot Test Mech",
+          type: "mech",
+          img: `systems/${game.system.id}/assets/icons/mech.svg`,
+          system: {
+            hp: { value: 10, max: 10 },
+            heat: { value: 0, max: 4 },
+            loadout: {
+              weapon_mounts: [{ type: "Main", bracing: false, slots: [{ size: "Main", weapon: null, mod: null }] }],
+              systems: [],
+              sp: { value: 0, max: 4 },
+            },
+          },
+        },
+        { renderSheet: false }
+      );
+    }
+
+    let mechTokenDoc = scene.tokens.find(t => t.actorId === mech.id);
+    if (!mechTokenDoc) {
+      const created = await scene.createEmbeddedDocuments("Token", [
+        { name: mech.name, actorId: mech.id, x: 1400, y: 900, width: 1, height: 1 },
+      ]);
+      mechTokenDoc = created[0];
+    }
+
+    // Combat
+    let combat = game.combats?.find(c => c.scene?.id === scene.id);
+    if (!combat) combat = await Combat.create({ scene: scene.id, active: true });
+    if (!tokenDoc.combatant) await tokenDoc.toggleCombatant(true);
+    if (!mechTokenDoc.combatant) await mechTokenDoc.toggleCombatant(true);
+
+    ui.combat.viewed = combat;
+    await ui.combat.render();
+
+    // Select mech token for action manager
+    const mechToken = mechTokenDoc.object;
+    if (!mechToken) throw new Error("Mech token missing on canvas");
+    mechToken.control({ releaseOthers: true });
+    await game.action_manager?.update();
+
+    // Pan to tokens
+    canvas.animatePan({ x: 1300, y: 900 });
+
+    const combatTab = document.querySelector('#sidebar-tabs a[data-tab="combat"]');
+    combatTab?.click();
+
+    await wait(500);
+
+    const root = document.querySelector("#action-manager");
+    const tracker = document.querySelector("#combat-tracker, ol.combat-tracker, #combat .directory-list");
+    return {
+      combatants: combat.combatants.size,
+      trackerLi: document.querySelectorAll("#combat-tracker li.combatant, .combat-tracker li.combatant").length,
+      hasDrag: !!root?.querySelector("#action-manager-drag"),
+      iconCount: root?.querySelectorAll("a.action[data-lancer-action]").length ?? 0,
+      label: root?.querySelector(".action-label div")?.textContent ?? "",
+      hasTarget: !!game.action_manager?.target,
+    };
+  });
+}
+
+async function main() {
+  await mkdir(dirname(outPath), { recursive: true });
+  const browser = await firefox.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1600, height: 900 } });
+  try {
+    await joinWorld(page);
+    const state = await setupCombatUi(page);
+    console.log("UI state:", JSON.stringify(state, null, 2));
+    await page.screenshot({ path: outPath, fullPage: false });
+    console.log(`Saved screenshot to ${outPath}`);
+    if (state.trackerLi === 0) {
+      console.warn("WARNING: combat tracker shows no combatants in DOM");
+      process.exitCode = 1;
+    }
+    if (state.iconCount < 5) {
+      console.warn("WARNING: action manager shows fewer than 5 icons");
+      process.exitCode = 1;
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/combat-tracker.test.ts
+++ b/scripts/combat-tracker.test.ts
@@ -80,4 +80,27 @@ describe("combat tracker turns", () => {
     assert.equal(merged.turns?.[0]?.id, "c1");
     assert.equal((merged as { user?: { isGM: boolean } }).user?.isGM, true);
   });
+
+  it("builds target summary from collection-like target sets", () => {
+    const targets = {
+      [Symbol.iterator]: function* () {
+        yield { document: { name: "Hostile A" } };
+        yield { name: "Hostile B" };
+      },
+      map<T>(fn: (t: { document?: { name: string }; name: string }) => T): T[] {
+        return Array.from(this as Iterable<{ document?: { name: string }; name: string }>, fn);
+      },
+    };
+    const summary = Array.from(targets as unknown as Iterable<{ document?: { name: string }; name: string }>)
+      .map(t => t.document?.name ?? t.name)
+      .filter(Boolean)
+      .join(", ");
+    assert.equal(summary, "Hostile A, Hostile B");
+  });
+
+  it("mergeCombatTrackerContext uses turns from tracker fields when provided", () => {
+    const ctx = { user: { isGM: true }, turns: [turn("old")] };
+    const merged = mergeCombatTrackerContext(ctx, { turns: [turn("new")] });
+    assert.equal(merged.turns?.[0]?.id, "new");
+  });
 });

--- a/src/module/action/action-manager-context.ts
+++ b/src/module/action/action-manager-context.ts
@@ -10,7 +10,7 @@ export interface ActionManagerActorLike {
   name: string;
   is_mech(): boolean;
   is_npc(): boolean;
-  system: { action_tracker: ActionTrackingData };
+  system: { action_tracker?: ActionTrackingData; speed?: number };
 }
 
 export interface ActionManagerRenderContext {
@@ -29,14 +29,28 @@ export function resolveActionManagerActor(
   token: ActionManagerTokenLike | null | undefined
 ): ActionManagerActorLike | null {
   if (!token?.actor) return null;
-  if (!isTokenInCombatEncounter(token)) return null;
   if (!token.actor.is_mech() && !token.actor.is_npc()) return null;
+  if (!isTokenInCombatEncounter(token)) return null;
   return token.actor;
 }
 
-export function getActionTrackerData(actor: ActionManagerActorLike): ActionTrackingData | null {
-  if (!actor.is_mech() && !actor.is_npc()) return null;
-  return actor.system.action_tracker ?? null;
+export function defaultActionTrackerData(actor: ActionManagerActorLike): ActionTrackingData {
+  return {
+    protocol: true,
+    move: actor.system.speed ?? 0,
+    full: true,
+    quick: true,
+    reaction: true,
+  };
+}
+
+export function getActionTrackerData(actor: ActionManagerActorLike): ActionTrackingData {
+  if (!actor.is_mech() && !actor.is_npc()) {
+    return defaultActionTrackerData(actor);
+  }
+  const tracker = actor.system.action_tracker;
+  if (tracker && typeof tracker === "object") return tracker;
+  return defaultActionTrackerData(actor);
 }
 
 export function resolveActionManagerWidth(position: { width?: number | string }): number {

--- a/src/module/action/action-manager.ts
+++ b/src/module/action/action-manager.ts
@@ -60,16 +60,25 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
     }
   }
 
-  async _prepareContext(options: Record<string, unknown>) {
-    const context = await super._prepareContext(options);
+  #actionManagerContext(): ReturnType<typeof buildActionManagerRenderContext> {
     const trackerSettings = game.settings.get(game.system.id, LANCER.setting_actionTracker);
-    const data = buildActionManagerRenderContext({
+    return buildActionManagerRenderContext({
       actor: this.target,
       clickable: !!(game.user?.isGM || trackerSettings.allowPlayers),
       showTextLabels: trackerSettings.showTextLabels,
       position: this.position,
     });
-    return foundry.utils.mergeObject(context, data);
+  }
+
+  async _prepareContext(options: Record<string, unknown>) {
+    const context = await super._prepareContext(options);
+    return foundry.utils.mergeObject(context, this.#actionManagerContext());
+  }
+
+  protected override async _preparePartContext(partId: string, context: any, options: any) {
+    const partContext = await super._preparePartContext(partId, context, options);
+    if (partId !== "body") return partContext;
+    return foundry.utils.mergeObject(partContext ?? context, this.#actionManagerContext());
   }
 
   // DATA BINDING
@@ -110,7 +119,8 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
   private async updateControlledToken() {
     if (!canvas.ready) return;
     const token = canvas.tokens?.controlled?.[0];
-    this.target = resolveActionManagerActor(token);
+    const actor = resolveActionManagerActor(token);
+    this.target = actor ? (token!.actor as LancerActor) : null;
   }
 
   /**
@@ -155,11 +165,12 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
     });
 
     // Enable action toggles.
-    root.querySelectorAll<HTMLAnchorElement>("a.action[data-action]").forEach(anchor =>
+    root.querySelectorAll<HTMLAnchorElement>("a.action[data-lancer-action]").forEach(anchor =>
       anchor.addEventListener("click", async e => {
         e.preventDefault();
+        e.stopPropagation();
         if (this.canMod()) {
-          const action = (e.currentTarget as HTMLElement).dataset.action;
+          const action = (e.currentTarget as HTMLElement).dataset.lancerAction;
           if (action && this.target) {
             await toggleAction(this.target, action as ActionType);
             await this.update();
@@ -190,12 +201,12 @@ export class LancerActionManager extends HandlebarsApplicationMixin(ApplicationV
 
   private loadTooltips() {
     const localizeTip = (key: string) => game.i18n.localize(key);
-    tippy('.action[data-action="protocol"]', { content: localizeTip("lancer.actionTracker.actions.protocol") });
-    tippy('.action[data-action="full"]', { content: localizeTip("lancer.actionTracker.actions.full") });
-    tippy('.action[data-action="quick"]', { content: localizeTip("lancer.actionTracker.actions.quick") });
-    tippy('.action[data-action="move"]', { content: localizeTip("lancer.actionTracker.actions.move") });
-    tippy('.action[data-action="reaction"]', { content: localizeTip("lancer.actionTracker.actions.reaction") });
-    tippy('.action[data-action="free"]', { content: localizeTip("lancer.actionTracker.actions.free") });
+    tippy('.action[data-lancer-action="protocol"]', { content: localizeTip("lancer.actionTracker.actions.protocol") });
+    tippy('.action[data-lancer-action="full"]', { content: localizeTip("lancer.actionTracker.actions.full") });
+    tippy('.action[data-lancer-action="quick"]', { content: localizeTip("lancer.actionTracker.actions.quick") });
+    tippy('.action[data-lancer-action="move"]', { content: localizeTip("lancer.actionTracker.actions.move") });
+    tippy('.action[data-lancer-action="reaction"]', { content: localizeTip("lancer.actionTracker.actions.reaction") });
+    tippy('.action[data-lancer-action="free"]', { content: localizeTip("lancer.actionTracker.actions.free") });
   }
 
   // HELPERS //

--- a/src/module/combat/combat-tracker-turns.ts
+++ b/src/module/combat/combat-tracker-turns.ts
@@ -75,7 +75,7 @@ export function enrichCombatTrackerTurns(
 
     return {
       ...t,
-      css: `${t.css} ${COMBAT_TRACKER_DISPOSITION_CLASSES[combatant?.disposition ?? -2]}`.trim(),
+      css: `${String(t.css ?? "").trim()} ${COMBAT_TRACKER_DISPOSITION_CLASSES[combatant?.disposition ?? -2]}`.trim(),
       buttons,
       activations: combatant?.activations.max,
       pending: combatant?.activations.value,

--- a/src/module/combat/combat-tracker-turns.ts
+++ b/src/module/combat/combat-tracker-turns.ts
@@ -16,6 +16,8 @@ export interface CombatTrackerTurnInput {
   canPing: boolean;
   resource: string | null;
   pending?: number;
+  effects?: { tooltip?: string; icons?: { img: string; name?: string }[] };
+  buttons?: CombatTrackerTurnButton[];
 }
 
 export interface CombatTrackerTurnButton {
@@ -48,8 +50,9 @@ export function mergeCombatTrackerContext<T extends { turns?: CombatTrackerTurnI
   ctx: T,
   trackerFields?: Partial<T> | void
 ): T {
-  if (trackerFields) Object.assign(ctx, trackerFields);
-  return ctx;
+  if (!trackerFields) return ctx;
+  if (trackerFields.turns) ctx.turns = trackerFields.turns;
+  return Object.assign(ctx, trackerFields);
 }
 
 export function enrichCombatTrackerTurns(
@@ -68,12 +71,18 @@ export function enrichCombatTrackerTurns(
       buttons.push({ icon: appearance.deactivate, action: "deactivateCombatantTurn" });
     }
 
+    const effects = t.effects ?? { tooltip: "", icons: [] };
+
     return {
       ...t,
       css: `${t.css} ${COMBAT_TRACKER_DISPOSITION_CLASSES[combatant?.disposition ?? -2]}`.trim(),
       buttons,
       activations: combatant?.activations.max,
       pending: combatant?.activations.value,
+      effects: {
+        tooltip: effects.tooltip ?? "",
+        icons: effects.icons ?? [],
+      },
     };
   });
 

--- a/src/module/combat/lancer-combat-tracker.ts
+++ b/src/module/combat/lancer-combat-tracker.ts
@@ -1,6 +1,6 @@
 import { LANCER } from "../config.js";
 import type { CombatTrackerAppearance } from "../settings.js";
-import { enrichCombatTrackerTurns, mergeCombatTrackerContext } from "./combat-tracker-turns.js";
+import { enrichCombatTrackerTurns } from "./combat-tracker-turns.js";
 import type { LancerCombat, LancerCombatant } from "./lancer-combat.js";
 
 import ContextMenu = foundry.applications.ux.ContextMenu;
@@ -26,23 +26,26 @@ export class LancerCombatTracker extends foundry.applications.sidebar.tabs.Comba
     {
       tracker: {
         template: "systems/lancer/templates/combat/tracker.hbs",
-        scrollable: [".directory-list"],
       },
     },
     { inplace: false }
   );
 
-  protected override async _preparePartContext(partId: string, context: any, options: any) {
-    const partContext = await super._preparePartContext(partId, context, options);
-    if (partId !== "tracker") return partContext;
-    const merged = foundry.utils.mergeObject(context, partContext ?? {}, { inplace: false });
-    return this.#enrichTrackerPartContext(merged, options);
-  }
-
   async _prepareTrackerContext(ctx: any, opts: any) {
     const combat = this.viewed;
-    if (combat?.combatants.size && !combat.turns?.length) combat.setupTurns();
+    if (!combat) return ctx;
+
+    if (combat.combatants.size && !combat.turns?.length) combat.setupTurns();
     await super._prepareTrackerContext(ctx, opts);
+
+    // Core skips non-visible combatants; ensure GM still sees a row per combatant in the list.
+    if (!ctx.turns?.length && combat.combatants.size) {
+      ctx.turns = [];
+      for (const [i, combatant] of combat.turns.entries()) {
+        ctx.turns.push(await this._prepareTurnContext(combat, combatant, i));
+      }
+    }
+
     return this.#enrichTrackerPartContext(ctx, opts);
   }
 

--- a/src/module/combat/lancer-combat-tracker.ts
+++ b/src/module/combat/lancer-combat-tracker.ts
@@ -23,14 +23,32 @@ export class LancerCombatTracker extends foundry.applications.sidebar.tabs.Comba
   );
   static PARTS = foundry.utils.mergeObject(
     foundry.applications.sidebar.tabs.CombatTracker.PARTS,
-    { tracker: { template: "systems/lancer/templates/combat/tracker.hbs" } },
+    {
+      tracker: {
+        template: "systems/lancer/templates/combat/tracker.hbs",
+        scrollable: [".directory-list"],
+      },
+    },
     { inplace: false }
   );
 
+  protected override async _preparePartContext(partId: string, context: any, options: any) {
+    const partContext = await super._preparePartContext(partId, context, options);
+    if (partId !== "tracker") return partContext;
+    const merged = foundry.utils.mergeObject(context, partContext ?? {}, { inplace: false });
+    return this.#enrichTrackerPartContext(merged, options);
+  }
+
   async _prepareTrackerContext(ctx: any, opts: any) {
+    const combat = this.viewed;
+    if (combat?.combatants.size && !combat.turns?.length) combat.setupTurns();
+    await super._prepareTrackerContext(ctx, opts);
+    return this.#enrichTrackerPartContext(ctx, opts);
+  }
+
+  #enrichTrackerPartContext(ctx: any, _opts: any) {
     const appearance = game.settings.get(game.system.id, LANCER.setting_combat_appearance);
-    mergeCombatTrackerContext(ctx, await super._prepareTrackerContext(ctx, opts));
-    const targetNames = (game.user?.targets ?? [])
+    const targetNames = Array.from(game.user?.targets ?? [])
       .map(t => t.document?.name ?? t.name)
       .filter(Boolean)
       .join(", ");

--- a/src/module/preload-templates.ts
+++ b/src/module/preload-templates.ts
@@ -14,6 +14,7 @@ export const preloadTemplates = async function () {
     // Combat tracker & settings UI
     `systems/${game.system.id}/templates/combat/combat-tracker-config.hbs`,
     `systems/${game.system.id}/templates/combat/combat-tracker.hbs`,
+    `systems/${game.system.id}/templates/combat/tracker.hbs`,
     // Item sheets
     `systems/${game.system.id}/templates/item/bond.hbs`,
     `systems/${game.system.id}/templates/item/core_bonus.hbs`,

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.12/lancer-v3.1.12.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.13/lancer-v3.1.13.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes empty combat tracker (#121) and empty action manager (#124) on Foundry v14 Application V2.

### Combat tracker (root cause)
Two bugs prevented the tracker list from rendering:

1. **`_preparePartContext` override** — Returning a merged copy of the tracker part context broke Foundry v14’s Application V2 part pipeline. Fix: enrich turns **only** in `_prepareTrackerContext` (same pattern as pre-v14 / dnd5e).
2. **`game.user.targets` crash** — In v14 this is a Collection, not an array. Calling `.filter().join()` on it threw during render and aborted the tracker. Fixed with `Array.from(...)`.

Additional hardening:
- Call `combat.setupTurns()` when combatants exist but turn order is empty
- Fall back to `_prepareTurnContext` when core skips all combatants as non-visible
- Use `class="combat-tracker plain"` on the tracker `<ol>` so core flex layout applies (`flex: 1`)

### Action tracker HUD
- Prepare body part context for Application V2 partial renders
- Rename action buttons to `data-lancer-action` (avoids AppV2 `data-action` handler conflicts)
- Default missing `action_tracker` data; fix controlled-token actor binding

### Verification
- `npm test` (53 passing)
- Playwright: `combat tracker lists combatants after adding a token` ✅
- Foundry screenshot shows both combatants with activation buttons and action manager with 5 icons

## Test plan
- [x] `npm test`
- [x] `SKIP_FOUNDRY_DIST_MIRROR=1 npm run build`
- [x] `e2e/setup/capture-combat-screenshot.spec.ts`
- [x] `e2e/regression/combat-ui.spec.ts` (combat tracker case)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fe7c1fe-e8e1-4430-83fb-bb9b02e943bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fe7c1fe-e8e1-4430-83fb-bb9b02e943bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

