### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/scripts/mech-sheet-visual-polish.test.ts
+++ b/scripts/mech-sheet-visual-polish.test.ts
@@ -27,7 +27,8 @@ describe("mech sheet visual polish", () => {
   it("buildCompactSystemCardHtml renders a visible item thumbnail", () => {
     const html = buildCompactSystemCardHtml("ECM Suite", "path.system", null);
     assert.match(html, /mech-combat-gear-thumb/);
-    assert.match(html, new RegExp(`src="${COMBAT_GEAR_SYSTEM_IMG_FALLBACK.replace(/\//g, "\\/")}"`));
+    const escapedFallback = COMBAT_GEAR_SYSTEM_IMG_FALLBACK.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    assert.match(html, new RegExp(`src="${escapedFallback}"`));
     assert.match(html, /mech-combat-action-button/);
   });
 


### PR DESCRIPTION
Potential fix for [https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/5](https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/5)

The best fix is to avoid partial/manual escaping and instead properly escape **all** regex metacharacters before constructing `RegExp`.

In `scripts/mech-sheet-visual-polish.test.ts`, line 30 currently escapes only `/`. Replace that with a standard full regex-escape expression:

- `COMBAT_GEAR_SYSTEM_IMG_FALLBACK.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")`

Then interpolate that escaped value into `new RegExp(...)`. This keeps behavior identical (matching `src="...fallback..."`) while correctly handling backslashes and any other special characters.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
