### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -13,6 +13,10 @@ concurrency:
   group: e2e-regression-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/1](https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (applies to all jobs unless overridden).  
For this workflow, the minimal safe baseline is:

- `contents: read` (needed by `actions/checkout`)
- `actions: read` (safe/read-only for actions metadata access; optional but explicit)

No write permissions are required for the shown steps. This preserves functionality while enforcing least privilege.

Edit `.github/workflows/e2e-regression.yml` by inserting the `permissions` block between `concurrency` and `jobs` (or anywhere at root level before/after `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
