### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/e2e/regression/world-load.spec.ts
+++ b/e2e/regression/world-load.spec.ts
@@ -12,13 +12,31 @@ test.describe("Lancer world load @regression", () => {
     expect(state.systemId).toBe("lancer");
     expect(state.systemVersion).toMatch(/^3\./);
 
+    const hasAllowedSocketUrl = (message: string): boolean => {
+      const urlCandidates = message.match(/\b(?:https?|wss?):\/\/[^\s)"']+/gi) ?? [];
+      for (const candidate of urlCandidates) {
+        try {
+          const parsed = new URL(candidate);
+          const host = parsed.hostname.toLowerCase();
+          if (host === "socket.io" || host.endsWith(".socket.io")) {
+            return true;
+          }
+          if (parsed.protocol === "ws:" || parsed.protocol === "wss:") {
+            return true;
+          }
+        } catch {
+          // Ignore invalid URL fragments in console messages.
+        }
+      }
+      return false;
+    };
+
     const fatal = errors.filter(
       e =>
         !e.includes("screen resolution") &&
         !e.includes("Chromium version") &&
         !e.includes("Firefox version") &&
-        !e.includes("socket.io") &&
-        !e.includes("websocket")
+        !hasAllowedSocketUrl(e)
     );
     expect(fatal, `Unexpected console errors: ${fatal.join("; ")}`).toEqual([]);
   });


### PR DESCRIPTION
Potential fix for [https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/4](https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/4)

The best fix is to stop relying on raw substring matching for `socket.io`/`websocket` and instead parse URL-like tokens from each console message, then match against URL components (hostname/protocol) with explicit rules.

In `e2e/regression/world-load.spec.ts`, inside the test callback (before `const fatal = errors.filter(...)`), add a small helper that:

- extracts URL-like substrings from a message,
- parses each with `new URL(...)`,
- checks whether hostname is exactly `socket.io` or a subdomain of it,
- or protocol is `ws:` / `wss:`.

Then replace the `e.includes("socket.io")` and `e.includes("websocket")` conditions in the filter with this helper. Keep the other text suppressions unchanged to avoid altering intended test behavior.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
