### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-git-remote.yml
+++ b/.github/workflows/verify-git-remote.yml
@@ -5,6 +5,9 @@ on:
     branches: ["**"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   assert-safe-remote:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/2](https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege permissions unless overridden. For this workflow, the minimal required permission is `contents: read` (sufficient for `actions/checkout` and local script checks shown).

**File to edit:** `.github/workflows/verify-git-remote.yml`  
**Change location:** near the top level, after `on:` triggers and before `jobs:`.  
**Needed additions:** YAML key:
- `permissions:`
  - `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
