### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/src/module/helpers/commons.ts
+++ b/src/module/helpers/commons.ts
@@ -862,14 +862,21 @@ export function handlePopoutTextEditor(html: JQuery, root_doc: LancerActor | Lan
 
 // A handlebars helper that makes the provided html safe by closing tags and eliminating all on<eventname> attributes
 export function safe_html_helper(orig: string) {
-  // Do simple html correction
+  // Parse and normalize HTML first
   let doc = document.createElement("div");
   doc.innerHTML = orig;
-  orig = doc.innerHTML; // Will have had all tags etc closed
 
-  // then kill all on<event>. Technically this will hit attrs, we don't really care
-  let bad = /on[a-zA-Z\-]+=".*?"/g;
-  orig = orig.replace(bad, "");
+  // Remove all inline event handler attributes (on*)
+  const elements = doc.querySelectorAll("*");
+  elements.forEach(el => {
+    for (const attr of Array.from(el.attributes)) {
+      if (attr.name.toLowerCase().startsWith("on")) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  });
+
+  orig = doc.innerHTML;
   return orig || defaultPlaceholder;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/3](https://github.com/VacantFanatic/foundryvtt-lancer/security/code-scanning/3)

Best fix: stop using regex to sanitize HTML attributes and instead sanitize via DOM parsing and explicit attribute removal.  
In `src/module/helpers/commons.ts`, update `safe_html_helper` to:

1. Parse `orig` into a detached container (`div`).
2. Iterate all descendant elements.
3. Remove every attribute whose name starts with `on` (case-insensitive).
4. Return sanitized `innerHTML` (or `defaultPlaceholder`).

This preserves existing functionality (returning cleaned HTML string) while making sanitization complete and not dependent on fragile multi-character regex matching. No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
