### PR TITLE
RC tag support, static pre-release link, and icon-only action buttons

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "pre-v*"
       - "v*-rc*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, without the 'v' prefix (e.g. 3.1.13-rc1)"
+        required: true
+        type: string
 
 jobs:
   build:
@@ -17,19 +23,26 @@ jobs:
       - uses: actions/checkout@v4
 
       # Set up variables for future use.
-      # Supports both legacy "pre-v1.0.0" and "v1.0.0-rc1" tag formats.
+      # Supports manual dispatch (version input), legacy "pre-v1.0.0", and "v1.0.0-rc1" tag formats.
       # BASE_VERSION strips any -rc* suffix so it can be compared to system.json.
       - name: Set up variables
         id: vars
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          TAG_NAME=${GITHUB_REF_NAME}
-          if [[ "$TAG_NAME" == pre-v* ]]; then
-            VERSION=${TAG_NAME#pre-v}
-            BASE_VERSION=$VERSION
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            VERSION="$INPUT_VERSION"
+            TAG_NAME="v${VERSION}"
           else
-            VERSION=${TAG_NAME#v}
-            BASE_VERSION=${VERSION%-rc*}
+            TAG_NAME=${GITHUB_REF_NAME}
+            if [[ "$TAG_NAME" == pre-v* ]]; then
+              VERSION=${TAG_NAME#pre-v}
+            else
+              VERSION=${TAG_NAME#v}
+            fi
           fi
+          BASE_VERSION=${VERSION%-rc*}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT

--- a/public/templates/window/action_manager.hbs
+++ b/public/templates/window/action_manager.hbs
@@ -34,11 +34,9 @@
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.protocol"}}'
+          data-tooltip='{{localize "lancer.actionTracker.actions.protocol"}}'
         >
           <i class="cci cci-protocol theme--dark white--text" aria-hidden="true"></i>
-          {{#if showTextLabels}}<span class="action-text">{{
-                localize "lancer.actionTracker.actions.protocol"
-              }}</span>{{/if}}
         </a>
         <hr class="v-divide" role="separator" aria-orientation="vertical" />
         <a
@@ -47,9 +45,9 @@
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.move"}}'
+          data-tooltip='{{localize "lancer.actionTracker.actions.move"}}'
         >
           <i class="mdi mdi-arrow-right-bold-hexagon-outline theme--dark white--text" aria-hidden="true"></i>
-          {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.move"}}</span>{{/if}}
         </a>
         <a
           class="action {{#if actions.full}}lancer-full{{/if}}"
@@ -57,9 +55,9 @@
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.full"}}'
+          data-tooltip='{{localize "lancer.actionTracker.actions.full"}}'
         >
           <i class="mdi mdi-hexagon-slice-6 theme--dark white--text" aria-hidden="true"></i>
-          {{#if showTextLabels}}<span class="action-text">{{localize "lancer.actionTracker.actions.full"}}</span>{{/if}}
         </a>
         <a
           class="action {{#if actions.quick}}lancer-quick{{/if}}"
@@ -67,11 +65,9 @@
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.quick"}}'
+          data-tooltip='{{localize "lancer.actionTracker.actions.quick"}}'
         >
           <i class="mdi mdi-hexagon-slice-3 theme--dark white--text" aria-hidden="true"></i>
-          {{#if showTextLabels}}<span class="action-text">{{
-                localize "lancer.actionTracker.actions.quick"
-              }}</span>{{/if}}
         </a>
         <a
           class="action {{#if actions.reaction}}lancer-reaction{{/if}}"
@@ -79,11 +75,9 @@
           role="button"
           tabindex="0"
           aria-label='{{localize "lancer.actionTracker.actions.reaction"}}'
+          data-tooltip='{{localize "lancer.actionTracker.actions.reaction"}}'
         >
           <i class="cci cci-reaction theme--dark white--text" aria-hidden="true"></i>
-          {{#if showTextLabels}}<span class="action-text">{{
-                localize "lancer.actionTracker.actions.reaction"
-              }}</span>{{/if}}
         </a>
       </div>
     {{/if}}

--- a/src/module/helpers/mech-combat-gear-core.ts
+++ b/src/module/helpers/mech-combat-gear-core.ts
@@ -57,8 +57,7 @@ export function buildCompactWeaponCardHtml(weaponName: string, weaponPath: strin
       <img class="mech-combat-gear-thumb" src="${imgSrc}" alt="" width="32" height="32" />
       <span class="mech-combat-gear-name minor">${weaponName}</span>
       <button type="button" class="roll-attack lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Roll attack">
-        <i class="fas fa-dice-d20 i--4 i--dark" aria-hidden="true"></i>
-        <span>FIRE</span>
+        <i class="fas fa-dice-d20 i--dark" aria-hidden="true"></i>
       </button>
     </div>`;
 }
@@ -70,8 +69,7 @@ export function buildCompactSystemCardHtml(systemName: string, systemPath: strin
       <img class="mech-combat-gear-thumb" src="${imgSrc}" alt="" width="32" height="32" />
       <span class="mech-combat-gear-name minor">${systemName}</span>
       <a class="chat-flow-button lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Use system">
-        <i class="mdi mdi-message i--4" aria-hidden="true"></i>
-        <span>USE</span>
+        <i class="mdi mdi-message" aria-hidden="true"></i>
       </a>
     </div>`;
 }

--- a/src/styles/applications/_action-manager.scss
+++ b/src/styles/applications/_action-manager.scss
@@ -74,11 +74,6 @@
     cursor: pointer;
   }
 
-  a.action .action-text {
-    font-size: 0.45em;
-    margin-left: 0.15em;
-    vertical-align: middle;
-  }
   #action-manager.noclick a,
   #action-manager .lancer-action-manager-surface.noclick a {
     cursor: unset !important;
@@ -119,22 +114,20 @@
   }
 
   a.action {
-    font-size: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 22px;
     margin: 3px;
     border-radius: 18px;
     height: 36px;
     width: 36px;
-    background-color: #616161;
-
-    i {
-      display: inline-flex;
-      padding-top: 1px;
-    }
+    /* Used / spent — muted red */
+    background-color: #7a2e2e;
+    box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.25);
 
     &:hover {
-      -moz-box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.3);
-      -webkit-box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.3);
-      box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.3);
+      box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.2);
       text-shadow: none;
     }
   }
@@ -143,8 +136,9 @@
   a.action.lancer-full,
   a.action.lancer-quick,
   a.action.lancer-reaction {
-    background-color: var(--primary-color);
-    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.2);
+    /* Available — tactical green */
+    background-color: #3c7a4e;
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.15), 0 0 5px rgba(80, 200, 120, 0.3);
   }
 
   .white--text {

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -381,25 +381,21 @@
     .mech-combat-action-button.lancer-button {
       display: inline-flex;
       align-items: center;
-      gap: 0.2rem;
-      min-width: 3.25rem;
+      justify-content: center;
+      flex: 0 0 auto;
+      width: 2.25rem;
       height: 2.25rem;
+      min-width: unset;
       margin: 0;
-      padding: 0.15rem 0.45rem;
-      background: linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--light-gray-color), #fff 10%),
-        var(--light-gray-color)
-      );
-      box-shadow:
-        var(--button-shadow),
-        inset 0 1px 0 color-mix(in srgb, #fff, transparent 88%);
+      padding: 0;
+      font-size: 1.1rem;
+      background: color-mix(in srgb, var(--darken-2), transparent 20%);
+      border: 1px solid color-mix(in srgb, var(--light-text), transparent 78%);
+      box-shadow: none;
 
       &:hover {
-        box-shadow:
-          var(--button-shadow),
-          var(--hover-bright),
-          0 0 6px color-mix(in srgb, var(--primary-highlight), transparent 55%);
+        background: color-mix(in srgb, var(--darken-2), #fff 12%);
+        box-shadow: var(--hover-bright);
       }
     }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **CI: RC tag support** — pre-release workflow now triggers on `v*-rc*` tags in addition to `pre-v*`; base version (e.g. `1.0.0`) is compared to `system.json` while the full RC version (e.g. `1.0.0-rc1`) is stamped into the built artifact so testers see the exact RC inside Foundry
- **CI: Static pre-release manifest link** — each pre-release run updates a persistent `pre-release-latest` GitHub release; testers install once and get subsequent RCs as normal Foundry updates
- **CI: `workflow_dispatch` trigger** — pre-release can now be kicked off directly from the GitHub Actions UI (or via API) by entering a version string, no local tag push required
- **UI: Icon-only action economy buttons** — text labels removed, action name moves to tooltip; available actions are tactical green, spent actions are muted crimson; consistent 36px sizing with proper centering
- **UI: Compact FIRE/USE combat gear buttons** — text removed, icon-only square buttons that blend into the card; colored left border retained as visual identifier

## Test plan

- [ ] Push a `v3.1.13-rc1` tag (or use Actions → Run workflow) and confirm both the versioned pre-release and `pre-release-latest` releases are created
- [ ] Install via static URL and confirm Foundry shows version `3.1.13-rc1`
- [ ] Push a second RC (`rc2`) and confirm Foundry sees it as an update via the static link
- [ ] In-game: verify action economy buttons show green (available) / red (used) with tooltips on hover
- [ ] In-game: verify FIRE/USE buttons are compact icon squares with tooltips

https://claude.ai/code/session_01PcAoVgMtffVhf1wTD31zWT
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcAoVgMtffVhf1wTD31zWT)_