### PR TITLE
fix: remove FIRE/USE text from primary render path in mech-combat-gear.ts

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -48,6 +48,24 @@ jobs:
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "zip_name=lancer-${TAG_NAME}.zip" >> $GITHUB_OUTPUT
 
+      # Fail fast if this tag has already been published as a release.
+      - name: Check tag not already released
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.vars.outputs.tag_name }}
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/VacantFanatic/foundryvtt-lancer/releases/tags/${TAG}")
+          if [[ "$STATUS" == "200" ]]; then
+            RC_NUM="${TAG##*rc}"
+            NEXT_RC="$((RC_NUM + 1))"
+            BASE="${TAG%-rc*}"
+            echo "::error::Release tag '${TAG}' already exists. Use '${BASE}-rc${NEXT_RC}' instead."
+            exit 1
+          fi
+
       # Confirm the base version in system.json matches the tag being released.
       # For v1.0.0-rc1 the expected system.json version is 1.0.0.
       - name: Verify version matches system.json

--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -111,6 +111,14 @@ export class LancerActorSheet<T extends LancerActorType> extends HandlebarsAppli
     if ("system.core_energy" in updateData) {
       updateData["system.core_energy"] = normalizeCoreEnergyFormValue(updateData["system.core_energy"]);
     }
+    // FormDataExtended in ApplicationV2 does not coerce type="number" inputs to numbers;
+    // convert any string values that are valid numbers before hitting schema validation.
+    for (const key of Object.keys(updateData)) {
+      const val = updateData[key];
+      if (typeof val === "string" && val.trim() !== "" && !isNaN(Number(val))) {
+        updateData[key] = Number(val);
+      }
+    }
     this._propagateData(updateData);
     await this.actor.update(updateData);
   }

--- a/src/module/actor/mech-sheet.ts
+++ b/src/module/actor/mech-sheet.ts
@@ -8,6 +8,7 @@ import type { SourceData } from "../source-template";
 import { LANCER } from "../config";
 import { countActiveEffects } from "../helpers/mech-sheet-ux-core";
 import { unmount } from "svelte";
+import { mountLoadoutEditor } from "../apps/loadout/mount";
 
 import ContextMenu = foundry.applications.ux.ContextMenu;
 

--- a/src/module/helpers/mech-combat-gear-core.ts
+++ b/src/module/helpers/mech-combat-gear-core.ts
@@ -57,7 +57,7 @@ export function buildCompactWeaponCardHtml(weaponName: string, weaponPath: strin
       <img class="mech-combat-gear-thumb" src="${imgSrc}" alt="" width="32" height="32" />
       <span class="mech-combat-gear-name minor">${weaponName}</span>
       <button type="button" class="roll-attack lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Roll attack">
-        <i class="fas fa-dice-d20 i--dark" aria-hidden="true"></i>
+        <i class="cci cci-weapon" aria-hidden="true"></i>
       </button>
     </div>`;
 }
@@ -69,7 +69,7 @@ export function buildCompactSystemCardHtml(systemName: string, systemPath: strin
       <img class="mech-combat-gear-thumb" src="${imgSrc}" alt="" width="32" height="32" />
       <span class="mech-combat-gear-name minor">${systemName}</span>
       <a class="chat-flow-button lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Use system">
-        <i class="mdi mdi-message" aria-hidden="true"></i>
+        <i class="cci cci-activate" aria-hidden="true"></i>
       </a>
     </div>`;
 }

--- a/src/module/helpers/mech-combat-gear.ts
+++ b/src/module/helpers/mech-combat-gear.ts
@@ -32,8 +32,7 @@ function renderWeaponCards(mech: LancerMECH, options: HelperOptions): string {
           <img class="mech-combat-gear-thumb" src="${weapon.img || "systems/lancer/assets/icons/mech_weapon.svg"}" alt="" width="32" height="32" />
           <span class="mech-combat-gear-name minor">${weapon.name}</span>
           <button type="button" class="roll-attack lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Roll attack">
-            <i class="fas fa-dice-d20 i--4 i--dark" aria-hidden="true"></i>
-            <span>FIRE</span>
+            <i class="cci cci-weapon" aria-hidden="true"></i>
           </button>
         </div>`);
     });
@@ -52,8 +51,7 @@ function renderSystemCards(mech: LancerMECH): string {
         <img class="mech-combat-gear-thumb" src="${system.img || "systems/lancer/assets/icons/mech_system.svg"}" alt="" width="32" height="32" />
         <span class="mech-combat-gear-name minor">${system.name}</span>
         <a class="chat-flow-button lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Use system">
-          <i class="mdi mdi-message i--4" aria-hidden="true"></i>
-          <span>USE</span>
+          <i class="cci cci-activate" aria-hidden="true"></i>
         </a>
       </div>`);
   });

--- a/src/styles/applications/_action-manager.scss
+++ b/src/styles/applications/_action-manager.scss
@@ -44,10 +44,12 @@
     min-height: 0;
     margin-top: 0;
     margin-bottom: 0;
-    background-color: #eaeaea;
-    border: 1px solid #5d5d5d;
+    /* Dark panel — floats above the scene without clashing with light backgrounds */
+    background-color: #1c1c22;
+    border: 1px solid #3a3a4a;
+    border-radius: 4px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
     box-sizing: border-box;
-    /* .clipped dogears cut off the circular action row; keep the card look without clip-path */
     clip-path: none;
     -webkit-clip-path: none;
   }
@@ -55,28 +57,70 @@
   #action-manager-drag,
   .action-manager-drag {
     cursor: move;
-    font-size: 1.35em;
-    padding: 8px 2px 0 6px;
+    font-size: 1.1em;
+    padding: 0 2px 0 4px;
     border: none;
     background: transparent;
-    color: inherit;
+    color: #666;
     line-height: 1;
     flex: 0 0 auto;
+    align-self: center;
+
+    &:hover {
+      color: #999;
+    }
   }
+
   .action-manager-reset-wrap {
     position: absolute;
-    right: 0;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   #action-manager-reset {
     display: inline-flex;
     padding: 2px;
     cursor: pointer;
+    color: rgba(255, 255, 255, 0.45);
+    font-size: 0.9em;
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.8);
+    }
   }
 
   #action-manager.noclick a,
   #action-manager .lancer-action-manager-surface.noclick a {
     cursor: unset !important;
+  }
+
+  .action-label {
+    position: relative;
+    display: flex;
+    flex: 0 0 auto;
+    flex-shrink: 0;
+    align-items: center;
+    min-height: 1.4rem;
+    padding: 2px 28px 2px 8px; /* right pad leaves room for reset button */
+    border-bottom: 1px solid #2e2e3a;
+    background-color: color-mix(in srgb, var(--primary-color), #000 55%);
+    color: rgba(255, 255, 255, 0.7);
+    font-style: italic;
+    font-size: 0.75em;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  #action-manager .action-manager-controls {
+    display: flex;
+    flex-direction: row;
+    flex: 0 0 auto;
+    flex-shrink: 0;
+    align-items: center;
+    min-height: 0;
+    padding: 3px 4px;
+    gap: 2px;
   }
 
   .action-bar {
@@ -86,59 +130,45 @@
     align-items: center;
     justify-content: flex-start;
     min-width: 0;
+    gap: 2px;
     overflow-x: auto;
-    /* overflow-x: auto + overflow-y: visible often resolves to auto-y in UAs → bogus vertical scrollbar */
     overflow-y: hidden;
-  }
-  .action-label {
-    display: flex;
-    flex: 0 0 auto;
-    flex-shrink: 0;
-    align-items: center;
-    min-height: 1.75rem;
-    padding-left: 8px;
-    border-bottom: 1px solid black;
-    background-color: var(--primary-color);
-    color: var(--light-text);
-    font-style: italic;
-    font-size: 0.95em;
-  }
-
-  #action-manager .action-manager-controls {
-    display: flex;
-    flex-direction: row;
-    flex: 0 0 auto;
-    flex-shrink: 0;
-    align-items: stretch;
-    min-height: 0;
   }
 
   a.action {
     display: inline-flex;
+    flex: 0 0 auto;
     align-items: center;
     justify-content: center;
-    font-size: 22px;
-    margin: 3px;
-    border-radius: 18px;
-    height: 36px;
-    width: 36px;
-    /* Used / spent — muted red */
-    background-color: #7a2e2e;
-    box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.25);
+    font-size: 16px;
+    border-radius: 50%;
+    height: 30px;
+    width: 30px;
+    transition: opacity 0.15s ease, box-shadow 0.15s ease;
+
+    /* Used / spent: present but clearly inactive */
+    background-color: rgba(255, 255, 255, 0.07);
+    opacity: 0.35;
 
     &:hover {
-      box-shadow: inset 0 0 100px 100px rgba(255, 255, 255, 0.2);
-      text-shadow: none;
+      opacity: 0.6;
     }
   }
+
   a.action.lancer-protocol,
   a.action.lancer-move,
   a.action.lancer-full,
   a.action.lancer-quick,
   a.action.lancer-reaction {
-    /* Available — tactical green */
-    background-color: #3c7a4e;
-    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.15), 0 0 5px rgba(80, 200, 120, 0.3);
+    /* Available: full opacity, green accent */
+    background-color: #2e6e42;
+    opacity: 1;
+    box-shadow: 0 0 6px rgba(60, 180, 100, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+
+    &:hover {
+      background-color: #38885a;
+      box-shadow: 0 0 10px rgba(60, 200, 110, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+    }
   }
 
   .white--text {
@@ -148,17 +178,13 @@
 
   .v-divide {
     align-self: stretch;
-    border: solid;
-    border-width: 0 thin 0 0;
+    border: none;
+    border-left: 1px solid #3a3a4a;
     display: inline-flex;
-    height: inherit;
-    min-height: 100%;
-    max-height: 100%;
-    max-width: 0;
-    width: 0;
-    vertical-align: text-bottom;
-    margin: 0 4px;
-    padding: 4px;
-    color: #888888;
+    height: 20px;
+    align-self: center;
+    margin: 0 2px;
+    padding: 0;
+    flex: 0 0 auto;
   }
 }

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -383,28 +383,40 @@
       align-items: center;
       justify-content: center;
       flex: 0 0 auto;
-      width: 2.25rem;
-      height: 2.25rem;
+      width: 2rem;
+      height: 2rem;
       min-width: unset;
       margin: 0;
       padding: 0;
-      font-size: 1.1rem;
-      background: color-mix(in srgb, var(--darken-2), transparent 20%);
-      border: 1px solid color-mix(in srgb, var(--light-text), transparent 78%);
+      font-size: 1.15rem;
+      /* Nearly transparent — blends into the card, accent border carries the color */
+      background: rgba(0, 0, 0, 0.18);
+      border: 1px solid transparent;
       box-shadow: none;
 
       &:hover {
-        background: color-mix(in srgb, var(--darken-2), #fff 12%);
-        box-shadow: var(--hover-bright);
+        background: rgba(255, 255, 255, 0.1);
       }
     }
 
     .roll-attack.mech-combat-action-button {
-      border-left: 3px solid var(--primary-color);
+      border-color: color-mix(in srgb, var(--primary-color), transparent 30%);
+      color: color-mix(in srgb, var(--primary-color), #fff 40%);
+
+      &:hover {
+        border-color: var(--primary-color);
+        background: color-mix(in srgb, var(--primary-color), transparent 82%);
+      }
     }
 
     .chat-flow-button.mech-combat-action-button {
-      border-left: 3px solid var(--system-color);
+      border-color: color-mix(in srgb, var(--system-color), transparent 30%);
+      color: color-mix(in srgb, var(--system-color), #fff 40%);
+
+      &:hover {
+        border-color: var(--system-color);
+        background: color-mix(in srgb, var(--system-color), transparent 82%);
+      }
     }
   }
 


### PR DESCRIPTION
The previous fix only updated `mech-combat-gear-core.ts`. The mech sheet actually uses the local `renderWeaponCards`/`renderSystemCards` functions in `mech-combat-gear.ts`, which still had the old `fa-dice-d20` icon + `<span>FIRE</span>` / `mdi-message` + `<span>USE</span>` markup. Fixed both to use `cci-weapon` / `cci-activate` with no text label.

https://claude.ai/code/session_01PcAoVgMtffVhf1wTD31zWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcAoVgMtffVhf1wTD31zWT)_