### PR TITLE
fix: dock action button labels and form coercion flatten

### DIFF
--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -107,15 +107,17 @@ export class LancerActorSheet<T extends LancerActorType> extends HandlebarsAppli
     formData: foundry.applications.ux.FormDataExtended
   ): Promise<void> {
     event.preventDefault();
-    const updateData = { ...formData.object };
+    // formData.object returns a nested object in ApplicationV2; flatten to dotted
+    // paths so the coercion pass below can reach every leaf value.
+    const updateData = foundry.utils.flattenObject(formData.object) as Record<string, unknown>;
     if ("system.core_energy" in updateData) {
       updateData["system.core_energy"] = normalizeCoreEnergyFormValue(updateData["system.core_energy"]);
     }
-    // FormDataExtended in ApplicationV2 does not coerce type="number" inputs to numbers;
-    // convert any string values that are valid numbers before hitting schema validation.
+    // ApplicationV2's FormDataExtended does not coerce type="number" inputs to
+    // numbers. Convert any string leaf that parses as a finite number.
     for (const key of Object.keys(updateData)) {
       const val = updateData[key];
-      if (typeof val === "string" && val.trim() !== "" && !isNaN(Number(val))) {
+      if (typeof val === "string" && val.trim() !== "" && isFinite(Number(val))) {
         updateData[key] = Number(val);
       }
     }

--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -266,11 +266,13 @@ export function action_button(
 ): string {
   let action_val = resolveHelperDotpath(options, data_path);
   let active: boolean;
+  let tooltip: string;
   if (action == "move") {
     active = (action_val as number) > 0;
-    title = `${title} (${action_val})`;
+    tooltip = `${title} (${action_val} remaining)`;
   } else {
     active = action_val as boolean;
+    tooltip = title;
   }
 
   let enabled = false;
@@ -285,10 +287,9 @@ export function action_button(
       class="lancer-action-button lancer-button${enabled ? " enabled" : ""}${active ? ` active lancer-${action}` : ""}"
       data-action="${action}"
       data-val="${action_val}"
-  >
-    ${icon}
-    ${title}
-  </button>`;
+      data-tooltip="${tooltip}"
+      aria-label="${tooltip}"
+    >${icon}</button>`;
 }
 
 // Suitable for any macros that take a single argument: the actor uuid


### PR DESCRIPTION
Two fixes:

**P/M/F/Q/R text labels in combat dock** — `action_button()` in `actor.ts` was rendering the title string directly inside the `<button>` element. The mech combat dock calls this with single-letter labels ("P", "M", "F", "Q", "R"), so those appeared as visible text. Moved title to `data-tooltip` and `aria-label`; for Move the tooltip includes the remaining count ("M (4 remaining)").

**Validation "must be a number" on checkbox click** — `formData.object` in ApplicationV2 returns a nested object, so the previous coercion loop only saw top-level keys and never reached `system.hp.value` etc. Added `foundry.utils.flattenObject()` before the loop so all leaf values are reachable. Tightened the number check to `isFinite()` to exclude `NaN`/`Infinity`.

https://claude.ai/code/session_01PcAoVgMtffVhf1wTD31zWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcAoVgMtffVhf1wTD31zWT)_