### PR TITLE
Auto-convert numeric strings to numbers in item sheet form updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundryvtt-lancer",
-  "version": "2.13.0",
+  "version": "3.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundryvtt-lancer",
-      "version": "2.13.0",
+      "version": "3.1.13",
       "hasInstallScript": true,
       "dependencies": {
         "@massif/dustgrave-data": "^1.4.0",

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -95,7 +95,14 @@ export class LancerItemSheet<T extends LancerItemType> extends HandlebarsApplica
     formData: foundry.applications.ux.FormDataExtended
   ): Promise<void> {
     event.preventDefault();
-    await this.item.update(formData.object);
+    const updateData = foundry.utils.flattenObject(formData.object) as Record<string, unknown>;
+    for (const key of Object.keys(updateData)) {
+      const val = updateData[key];
+      if (typeof val === "string" && val.trim() !== "" && isFinite(Number(val))) {
+        updateData[key] = Number(val);
+      }
+    }
+    await this.item.update(updateData);
   }
 
   protected override _onRender(context: object, options: Record<string, unknown>): void {


### PR DESCRIPTION
## Summary
Modified the item sheet form submission handler to automatically convert string values that represent valid numbers into actual numeric types before updating the item.

## Key Changes
- Added logic to flatten and process form data before item update
- Implemented automatic type conversion for numeric strings (e.g., "42" → 42)
- Only converts non-empty strings that parse as valid finite numbers
- Preserves non-numeric strings and other data types unchanged

## Implementation Details
The form submission handler now:
1. Flattens the form data object to handle nested properties
2. Iterates through all keys in the flattened data
3. Checks if each value is a string that, when trimmed, is non-empty and represents a finite number
4. Converts matching values to their numeric equivalents
5. Passes the processed data to the item update method

This ensures that numeric form inputs are properly typed as numbers in the item data, preventing issues that could arise from storing numeric values as strings.

https://claude.ai/code/session_01CTuUJhvSsc3xLD76Z25nPn