### PR TITLE
Fix text color and background styling for stat inputs

### DIFF
--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -247,6 +247,7 @@
     padding: 0.2rem 0.45rem;
     min-width: 5.5rem;
     flex: 1 1 auto;
+    color: var(--dark-text);
   }
 
   .mech-combat-dock-stat-label {
@@ -260,12 +261,15 @@
     align-items: center;
     gap: 0.1rem;
     font-size: 0.8rem;
+    color: var(--dark-text);
 
     input.lancer-stat {
       width: 2.25rem;
       min-width: 2rem;
       padding: 0 0.15rem;
       text-align: center;
+      color: var(--dark-text);
+      background-color: transparent;
     }
   }
 

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -65,6 +65,8 @@
     text-align: center;
     max-width: 40px;
     min-width: 25px;
+    color: var(--dark-text);
+    background-color: transparent;
   }
 
   .lancer-input {


### PR DESCRIPTION
## Summary
This PR improves the visual consistency and readability of stat input fields across the actor sheet and general input components by explicitly setting text color and background styling.

## Key Changes
- Added `color: var(--dark-text)` to mech combat dock stat values and labels for consistent text color
- Added `color: var(--dark-text)` and `background-color: transparent` to the `lancer-stat` input class in the actor sheet
- Added `color: var(--dark-text)` and `background-color: transparent` to the general `lancer-input` class for consistency

## Implementation Details
These changes ensure that stat input fields use the application's dark text color variable and maintain a transparent background, preventing potential contrast issues and ensuring visual consistency across different UI themes. The changes are applied to both the actor sheet combat dock and the general input component styles.

https://claude.ai/code/session_01UAcLk9DuAwdUUHC2yqh9RU