### PR TITLE
Fix system.json download URL for v3.1.15

### DIFF
--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -247,6 +247,7 @@
     padding: 0.2rem 0.45rem;
     min-width: 5.5rem;
     flex: 1 1 auto;
+    color: var(--dark-text);
   }
 
   .mech-combat-dock-stat-label {
@@ -260,12 +261,15 @@
     align-items: center;
     gap: 0.1rem;
     font-size: 0.8rem;
+    color: var(--dark-text);
 
     input.lancer-stat {
       width: 2.25rem;
       min-width: 2rem;
       padding: 0 0.15rem;
       text-align: center;
+      color: var(--dark-text);
+      background-color: transparent;
     }
   }
 

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -65,6 +65,8 @@
     text-align: center;
     max-width: 40px;
     min-width: 25px;
+    color: var(--dark-text);
+    background-color: transparent;
   }
 
   .lancer-input {

--- a/src/system.json
+++ b/src/system.json
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.14/lancer-v3.1.14.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.15/lancer-v3.1.15.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "compatibility": {
     "minimum": 13,
     "verified": 14,


### PR DESCRIPTION
Updates the `download` URL in `src/system.json` from `v3.1.14` to `v3.1.15` so the release workflow validation passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAcLk9DuAwdUUHC2yqh9RU)_