### PR TITLE
Refactor HUD callbacks and fix UI/form data issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.16-rc.1] - 2026-06-14
+
+### Fixed
+
+- **Actor sheet form validation** (#141) — `_propagateData` now guards with `!= null` before writing `img`/`name` to the prototype token, preventing a schema-validation error on every keystroke because actor sheet templates include no `img` input.
+- **Damage HUD / sliding HUD** (#146) — Svelte 5 stable removed the `events` option from `mount()`, causing the Promise returned by `openSlidingHud` to never resolve. Fixed by exporting `setCallback()` from `SlidingHUDZone.svelte` and calling it directly instead of relying on the removed events option.
+- **Combat tab weapon cards** (#147) — Mech weapon cards on the combat tab now display range and damage stats (icons + values) below the weapon name, giving players the critical info they need without opening the item sheet.
+- **Stabilize flow** (#148) — The submit button callback in `renderStabilizePrompt` was returning `true`, causing `DialogV2.wait()` to resolve with `true` instead of the `"submit"` action string. Removed the return value so the button action string is used as intended.
+
 ## [3.1.13] - 2026-06-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.13",
+  "version": "3.1.16-rc.1",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/templates/chat/attack-card.hbs
+++ b/public/templates/chat/attack-card.hbs
@@ -65,26 +65,26 @@
   {{/if}}
   {{#if on_attack}}
     <div class="card clipped">
-      <div class="lancer-mini-header collapse-trigger" data-collapse-id="{{_uuid}}-effect">
+      <div class="lancer-mini-header collapse-trigger" data-collapse-id="{{_uuid}}-on-attack">
         {{localize "lancer.chat-card.title.on-attack"}}
       </div>
-      <span class="effect-text collapse" data-collapse-id="{{_uuid}}-effect">{{{on_attack}}}</span>
+      <span class="effect-text collapse" data-collapse-id="{{_uuid}}-on-attack">{{{on_attack}}}</span>
     </div>
   {{/if}}
   {{#if on_hit}}
     <div class="card clipped">
-      <div class="lancer-mini-header collapse-trigger" data-collapse-id="{{_uuid}}-effect">
+      <div class="lancer-mini-header collapse-trigger" data-collapse-id="{{_uuid}}-on-hit">
         {{localize "lancer.chat-card.title.on-hit"}}
       </div>
-      <span class="effect-text collapse" data-collapse-id="{{_uuid}}-effect">{{{on_hit}}}</span>
+      <span class="effect-text collapse" data-collapse-id="{{_uuid}}-on-hit">{{{on_hit}}}</span>
     </div>
   {{/if}}
   {{#if on_crit}}
     <div class="card clipped">
-      <div class="lancer-mini-header collapse-trigger" data-collapse-id="{{_uuid}}-effect">
+      <div class="lancer-mini-header collapse-trigger" data-collapse-id="{{_uuid}}-on-crit">
         {{localize "lancer.chat-card.title.on-crit"}}
       </div>
-      <span class="effect-text collapse" data-collapse-id="{{_uuid}}-effect">{{{on_crit}}}</span>
+      <span class="effect-text collapse" data-collapse-id="{{_uuid}}-on-crit">{{{on_crit}}}</span>
     </div>
   {{/if}}
   {{{tag-list "tags"}}}

--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -724,20 +724,23 @@ export class LancerActorSheet<T extends LancerActorType> extends HandlebarsAppli
 
   _propagateData(formData: any): any {
     // Pushes relevant field data from the form to other appropriate locations,
-    // e.x. to synchronize name between token and actor
+    // e.x. to synchronize name between token and actor.
+    // Guard: only propagate a field if it is actually present in the submitted form data
+    // (i.e. not undefined). Actor sheet templates omit the img input, so formData["img"]
+    // would be undefined and passing it to actor.update() causes a schema validation error.
     let token = this.actor.prototypeToken;
 
     if (!token) {
-      // Set the prototype token image if the prototype token isn't initialized
-      formData["prototypeToken.texture.src"] = formData["img"];
-      formData["prototypeToken.name"] = formData["name"];
+      // Set the prototype token image/name if the prototype token isn't initialized
+      if (formData["img"] != null) formData["prototypeToken.texture.src"] = formData["img"];
+      if (formData["name"] != null) formData["prototypeToken.name"] = formData["name"];
     } else {
       // Update token image if it matches the old actor image - keep in sync
-      if (this.actor.img === token.texture.src && this.actor.img !== formData["img"]) {
+      if (formData["img"] != null && this.actor.img === token.texture.src && this.actor.img !== formData["img"]) {
         formData["prototypeToken.texture.src"] = formData["img"];
       }
       // Ditto for name
-      if (this.actor.name === token["name"] && this.actor.name !== formData["name"]) {
+      if (formData["name"] != null && this.actor.name === token["name"] && this.actor.name !== formData["name"]) {
         formData["prototypeToken.name"] = formData["name"];
       }
     }

--- a/src/module/apps/slidinghud/SlidingHUDZone.svelte
+++ b/src/module/apps/slidinghud/SlidingHUDZone.svelte
@@ -5,7 +5,6 @@
 
   import { flip } from "svelte/animate";
   import { slide } from "svelte/transition";
-  import { createEventDispatcher } from "svelte";
 
   import { sidebarWidth } from "./sidebar-width";
   import { isDragging } from "./is-dragging";
@@ -14,7 +13,19 @@
   import DamageHud from "../damage/DamageHUD.svelte";
   import StructStressHud from "../struct_stress/StructStressHUD.svelte";
 
-  let dispatch = createEventDispatcher();
+  // Callbacks registered by index.ts to receive submit/cancel results for each HUD key.
+  // Stored as a plain object (no Svelte reactivity needed).
+  const callbacks: Record<string, [(value: any) => any, () => any] | null> = {
+    hase: null,
+    attack: null,
+    damage: null,
+    struct: null,
+    stress: null,
+  };
+
+  export function setCallback(key: string, resolve: (value: any) => any, reject: () => any) {
+    callbacks[key] = [resolve, reject];
+  }
 
   let dialogs: { [key: string]: typeof SvelteComponent } = {
     hase: AccDiffHud,
@@ -60,13 +71,16 @@
   }
 
   export function open(key: string, data: any) {
-    dispatch(`${key}.cancel`); // Re-opening closes the previous instance of this hud
+    // Cancel any pending promise for this key before re-opening
+    callbacks[key]?.[1]();
+    callbacks[key] = null;
     huds[key].open = new Date().getTime();
     huds[key].data = data;
   }
 
   export function close(key: string) {
-    dispatch(`${key}.cancel`);
+    callbacks[key]?.[1]();
+    callbacks[key] = null;
     huds[key].open = null;
     huds[key].data = null;
   }
@@ -93,7 +107,13 @@
   export let components: { [key: string]: SvelteComponent } = {};
 
   function forward(key: string, event: string, data?: any | undefined) {
-    dispatch(`${key}.${event}`, data ? data : undefined);
+    // Call the registered callback directly (replaces the removed `events` option of mount()).
+    if (event === "submit") {
+      callbacks[key]?.[0](data ?? undefined);
+    } else {
+      callbacks[key]?.[1]();
+    }
+    callbacks[key] = null;
     // no matter why we get an event from a child, we should close it, it's _done_
     huds[key].open = null;
     huds[key].data = null;

--- a/src/module/apps/slidinghud/index.ts
+++ b/src/module/apps/slidinghud/index.ts
@@ -6,33 +6,12 @@ import { mount } from "svelte";
 
 // TODO: Find a better type for this
 let hud: ReturnType<typeof mount>;
-// Look - I don't really know enough typescript to get it right,
-// but these will hold the success/reject of any
-let activeCallbacks: Record<keyof HUDData, null | [(value: any) => any, () => any]> = {
-  hase: null,
-  attack: null,
-  damage: null,
-  struct: null,
-  stress: null,
-};
 
 export async function attach() {
   if (!hud) {
     let HUDZone = (await import("./SlidingHUDZone.svelte")).default;
-    const events: Record<string, (e: any) => any> = {};
-    for (const key of ["attack", "damage", "hase", "struct", "stress"] as Array<keyof HUDData>) {
-      events[`${key}.submit`] = (ev: any) => {
-        activeCallbacks[key]?.[0](ev.detail);
-        activeCallbacks[key] = null;
-      };
-      events[`${key}.cancel`] = () => {
-        activeCallbacks[key]?.[1]();
-        activeCallbacks[key] = null;
-      };
-    }
     hud = mount(HUDZone, {
       target: document.body,
-      events,
     });
   }
   return hud;
@@ -41,11 +20,13 @@ export async function attach() {
 export async function openSlidingHud<T extends keyof HUDData>(key: T, data: HUDData[T]): Promise<HUDData[T]> {
   let hud = await attach();
 
-  // open the hud, cancelling existing listeners
+  // open the hud; SlidingHUDZone.open() cancels any existing pending callback for this key
   hud.open(key, data);
 
   return new Promise((resolve, reject) => {
-    activeCallbacks[key] = [resolve, reject];
+    // Register callbacks directly on the component — avoids the removed `events`
+    // option of Svelte 5's mount(), which silently dropped in Svelte 5 stable.
+    (hud as any).setCallback(key, resolve, reject);
   });
 }
 

--- a/src/module/flows/stabilize.ts
+++ b/src/module/flows/stabilize.ts
@@ -56,11 +56,10 @@ async function renderStabilizePrompt(state: FlowState<LancerFlowState.StabilizeD
         label: game.i18n.localize("lancer.flow.common.submit"),
         default: true,
         callback: (_event, _button, dialog) => {
-          if (!state.data) return false;
+          if (!state.data) return;
           const root = dialog.element as HTMLElement;
           state.data.option1 = <StabOptions1>$(root).find(".stabilize-options-1:checked").first().val();
           state.data.option2 = <StabOptions2>$(root).find(".stabilize-options-2:checked").first().val();
-          return true;
         },
       },
       {

--- a/src/module/helpers/mech-combat-gear.ts
+++ b/src/module/helpers/mech-combat-gear.ts
@@ -1,5 +1,6 @@
 import type { HelperOptions } from "handlebars";
 import type { LancerMECH } from "../actor/lancer-actor";
+import type { LancerMECH_WEAPON } from "../item/lancer-item";
 import { resolveHelperDotpath } from "./commons";
 import {
   buildCompactSystemCardHtml,
@@ -19,6 +20,25 @@ export {
 } from "./mech-combat-gear-core";
 export type { CombatGearCounts } from "./mech-combat-gear-core";
 
+function weaponProfileStats(weapon: LancerMECH_WEAPON): string {
+  const profile = weapon.currentProfile();
+  const ranges = profile.range
+    .map(
+      r =>
+        `<span data-tooltip="${r.type}"><i class="cci cci-${r.type.toLowerCase()}" aria-hidden="true"></i>${r.val}</span>`
+    )
+    .join("");
+  const damages = (profile.damage ?? [])
+    .map(
+      d =>
+        `<span data-tooltip="${d.type}"><i class="cci cci-${d.type.toLowerCase()} damage--${d.type.toLowerCase()}" aria-hidden="true"></i>${d.val}</span>`
+    )
+    .join("");
+  if (!ranges && !damages) return "";
+  const sep = ranges && damages ? `<span class="mech-combat-gear-sep">//</span>` : "";
+  return `<div class="mech-combat-gear-stats">${ranges}${sep}${damages}</div>`;
+}
+
 function renderWeaponCards(mech: LancerMECH, options: HelperOptions): string {
   const cards: string[] = [];
   const loadout = mech.system.loadout;
@@ -27,10 +47,14 @@ function renderWeaponCards(mech: LancerMECH, options: HelperOptions): string {
       const weapon = slot.weapon?.value;
       if (!weapon) return;
       const weaponPath = `system.loadout.weapon_mounts.${mountIndex}.slots.${slotIndex}.weapon.value`;
+      const stats = weaponProfileStats(weapon);
       cards.push(`
         <div class="mech-combat-gear-card card clipped ref set" ${ref_params(weapon, weaponPath)}>
           <img class="mech-combat-gear-thumb" src="${weapon.img || "systems/lancer/assets/icons/mech_weapon.svg"}" alt="" width="32" height="32" />
-          <span class="mech-combat-gear-name minor">${weapon.name}</span>
+          <div class="mech-combat-gear-label">
+            <span class="mech-combat-gear-name minor">${weapon.name}</span>
+            ${stats}
+          </div>
           <button type="button" class="roll-attack lancer-button lancer-secondary mech-combat-action-button" data-tooltip="Roll attack">
             <i class="cci cci-weapon" aria-hidden="true"></i>
           </button>

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -424,11 +424,37 @@
     }
   }
 
-  .mech-combat-gear-name {
+  .mech-combat-gear-label {
     flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  .mech-combat-gear-name {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .mech-combat-gear-stats {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.78em;
+    opacity: 0.85;
+
+    span {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.15rem;
+    }
+
+    .mech-combat-gear-sep {
+      opacity: 0.5;
+    }
   }
 
   .mech-combat-gear-empty {

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.15",
+  "version": "3.1.16-rc.1",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.15/lancer-v3.1.15.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.16-rc.1/lancer-v3.1.16-rc.1.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
## Summary
This PR refactors the sliding HUD callback system to work with Svelte 5's removal of the `events` mount option, fixes collapsible section IDs in attack cards, and adds guards against undefined form data in actor sheet updates.

## Key Changes

- **HUD Callback Refactoring**: Replaced Svelte event dispatcher with direct callback registration
  - Moved callback storage from `index.ts` to `SlidingHUDZone.svelte` component
  - Implemented `setCallback()` export function for direct callback registration
  - Updated `open()`, `close()`, and `forward()` methods to call callbacks directly instead of dispatching events
  - Removed the `events` option from `mount()` call in `index.ts` (incompatible with Svelte 5 stable)

- **Attack Card Template Fixes**: Fixed collapsible section IDs to be unique per effect type
  - Changed all `data-collapse-id="{{_uuid}}-effect"` to type-specific IDs (`on-attack`, `on-hit`, `on-crit`)
  - Prevents multiple sections from collapsing together when they should be independent

- **Actor Sheet Form Data Guards**: Added null checks before propagating form data
  - Only propagate `img` and `name` fields if they exist in formData (prevents schema validation errors)
  - Fixes issue where omitted form fields would cause actor.update() to fail
  - Applied guards to both prototype token initialization and sync logic

- **Stabilize Flow Cleanup**: Removed unnecessary return statements from dialog callback
  - Changed `return false` to `return` (no-op)
  - Removed `return true` statement (callback doesn't use return value)

## Implementation Details

The HUD callback system now uses a plain object to store resolve/reject function pairs, keyed by HUD type. When a HUD is opened, any pending callback for that key is rejected before the new one is registered. This maintains the same promise-based API while avoiding Svelte's deprecated event system.

https://claude.ai/code/session_011e1r6mSgtSzBSgNwy6aCyM