### PR TITLE
Add combat dock talent reminders and compact mech sheet header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Mech sheet header** — collapsed the name/pilot/frame block into a single compact left-aligned group (pilot and frame details now sit directly under the name instead of right-aligned against empty space), shrinking the header's overall height.
+
+### Added
+
+- **Combat dock talent reminders** — the persistent combat dock now shows a quick-reference strip of the pilot's talents using each talent's terse summary, so passive/triggered abilities are visible during combat without switching to the Abilities tab.
+
 ## [3.1.16-rc.1] - 2026-06-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundryvtt-lancer",
-  "version": "3.1.16-rc.1",
+  "version": "3.1.17-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundryvtt-lancer",
-      "version": "3.1.16-rc.1",
+      "version": "3.1.17-rc.1",
       "hasInstallScript": true,
       "dependencies": {
         "@massif/dustgrave-data": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "foundryvtt-lancer",
-  "version": "3.1.16-rc.5",
+  "version": "3.1.17-rc.1",
   "description": "",
   "sideEffects": [
     "src/lancer.scss",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -141,7 +141,8 @@
         "systems": "SYSTEMS"
       },
       "combat-dock": {
-        "label": "Combat quick controls"
+        "label": "Combat quick controls",
+        "talents": "Talents — quick reference"
       },
       "combat-gear": {
         "weapons": "WEAPONS",

--- a/scripts/mech-combat-dock.test.ts
+++ b/scripts/mech-combat-dock.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   buildCombatDockCoreToggleHtml,
   buildCombatDockStatChipsHtml,
+  buildCombatDockTalentsHtml,
   COMBAT_DOCK_ATTACK_FLOW_TYPES,
   normalizeCoreEnergyFormValue,
 } from "../src/module/helpers/mech-combat-dock-core.ts";
@@ -47,5 +48,35 @@ describe("mech combat dock helpers", () => {
     assert.equal(normalizeCoreEnergyFormValue(0), 0);
     assert.equal(normalizeCoreEnergyFormValue("1"), 1);
     assert.equal(normalizeCoreEnergyFormValue("0"), 0);
+  });
+
+  it("buildCombatDockTalentsHtml renders a terse reminder per talent", () => {
+    const html = buildCombatDockTalentsHtml(
+      [
+        { name: "Brawler", rank: 2, terse: "Melee attacks vs. engaged targets gain +1 ACC, +2 dmg." },
+        { name: "Walking Armory", rank: 1, terse: "Once/turn, swap an equipped weapon as a quick action." },
+      ],
+      "Talents — quick reference"
+    );
+    assert.match(html, /mech-combat-dock-talents/);
+    assert.match(html, /Brawler 2/);
+    assert.match(html, /Walking Armory 1/);
+    assert.match(html, /Melee attacks vs\. engaged targets/);
+    assert.match(html, /Talents — quick reference/);
+  });
+
+  it("buildCombatDockTalentsHtml omits talents with no terse summary", () => {
+    const html = buildCombatDockTalentsHtml([{ name: "Untagged", rank: 1, terse: "" }], "Talents");
+    assert.equal(html, "");
+  });
+
+  it("buildCombatDockTalentsHtml escapes talent name and terse text", () => {
+    const html = buildCombatDockTalentsHtml(
+      [{ name: "<b>Evil</b>", rank: 1, terse: "<script>alert(1)</script>" }],
+      "Talents"
+    );
+    assert.doesNotMatch(html, /<b>Evil<\/b>/);
+    assert.doesNotMatch(html, /<script>/);
+    assert.match(html, /&lt;b&gt;Evil&lt;\/b&gt;/);
   });
 });

--- a/scripts/mech-combat-dock.test.ts
+++ b/scripts/mech-combat-dock.test.ts
@@ -75,8 +75,8 @@ describe("mech combat dock helpers", () => {
       [{ name: "<b>Evil</b>", rank: 1, terse: "<script>alert(1)</script>" }],
       "Talents"
     );
-    assert.doesNotMatch(html, /<b>Evil<\/b>/);
-    assert.doesNotMatch(html, /<script>/);
+    assert.doesNotMatch(html, /<b>Evil<\/b>/i);
+    assert.doesNotMatch(html, /<script>/i);
     assert.match(html, /&lt;b&gt;Evil&lt;\/b&gt;/);
   });
 });

--- a/scripts/mech-header-layout.test.ts
+++ b/scripts/mech-header-layout.test.ts
@@ -10,12 +10,12 @@ function mechHeaderBlock(): string {
 }
 
 describe("mech sheet header layout", () => {
-  it("right-aligns pilot and frame details in the header", () => {
+  it("left-aligns pilot and frame details directly under the name", () => {
     const block = mechHeaderBlock();
     const details = block.match(/\.header-details\s*\{[\s\S]*?\}/);
     assert.ok(details, "expected .header-details override in mech header");
-    assert.match(details[0], /text-align:\s*right/);
-    assert.match(details[0], /justify-content:\s*flex-end/);
+    assert.match(details[0], /text-align:\s*left/);
+    assert.match(details[0], /justify-content:\s*flex-start/);
   });
 
   it("uses a much larger pilot portrait in the header row", () => {

--- a/src/module/helpers/mech-combat-dock-core.ts
+++ b/src/module/helpers/mech-combat-dock-core.ts
@@ -5,7 +5,21 @@ export interface CombatDockStatSnapshot {
   stress: { value: number; max: number };
 }
 
+export interface CombatDockTalentSnapshot {
+  name: string;
+  rank: number;
+  terse: string;
+}
+
 export const COMBAT_DOCK_ATTACK_FLOW_TYPES = ["BasicAttack", "Damage", "TechAttack"] as const;
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
 
 /** Coerce form values for `system.core_energy` (NumberField 0|1). */
 export function normalizeCoreEnergyFormValue(value: unknown): number {
@@ -45,4 +59,26 @@ export function buildCombatDockStatChipsHtml(stats: CombatDockStatSnapshot): str
     ${chip("STRUCT", stats.structure.value, stats.structure.max, "system.structure.value", "cci cci-structure")}
     ${chip("STRESS", stats.stress.value, stats.stress.max, "system.stress.value", "cci cci-reactor")}
   </div>`;
+}
+
+/** Quick-reference strip of pilot talent summaries (`terse`) for use during combat. */
+export function buildCombatDockTalentsHtml(talents: CombatDockTalentSnapshot[], headerLabel: string): string {
+  const rows = talents
+    .filter(talent => talent.terse)
+    .map(
+      talent => `
+      <div class="mech-combat-dock-talent" data-tooltip="${escapeHtml(talent.name)}">
+        <span class="mech-combat-dock-talent-name">${escapeHtml(talent.name)} ${talent.rank}</span>
+        <span class="mech-combat-dock-talent-terse">${escapeHtml(talent.terse)}</span>
+      </div>`
+    )
+    .join("");
+
+  if (!rows) return "";
+
+  return `
+    <div class="mech-combat-dock-talents">
+      <div class="mech-combat-dock-talents-header">${escapeHtml(headerLabel)}</div>
+      ${rows}
+    </div>`;
 }

--- a/src/module/helpers/mech-combat-dock.ts
+++ b/src/module/helpers/mech-combat-dock.ts
@@ -1,21 +1,24 @@
 import type { HelperOptions } from "handlebars";
-import type { LancerMECH } from "../actor/lancer-actor";
+import type { LancerMECH, LancerPILOT } from "../actor/lancer-actor";
 import { LancerFlowState } from "../flows/interfaces";
 import { resolveHelperDotpath } from "./commons";
 import { action_button, actor_flow_button, is_combatant } from "./actor";
 import {
   buildCombatDockCoreToggleHtml,
   buildCombatDockStatChipsHtml,
+  buildCombatDockTalentsHtml,
   COMBAT_DOCK_ATTACK_FLOW_TYPES,
+  type CombatDockTalentSnapshot,
 } from "./mech-combat-dock-core";
 
 export {
   buildCombatDockCoreToggleHtml,
   buildCombatDockStatChipsHtml,
+  buildCombatDockTalentsHtml,
   COMBAT_DOCK_ATTACK_FLOW_TYPES,
   normalizeCoreEnergyFormValue,
 } from "./mech-combat-dock-core";
-export type { CombatDockStatSnapshot } from "./mech-combat-dock-core";
+export type { CombatDockStatSnapshot, CombatDockTalentSnapshot } from "./mech-combat-dock-core";
 
 /** Attack utility buttons rendered in the persistent combat dock. */
 export function buildCombatDockAttackUtilitiesHtml(): string {
@@ -42,6 +45,20 @@ function compactOverchargeDock(actor: LancerMECH, overchargeLevel: number): stri
     </div>`;
 }
 
+function compactTalentReminders(pilot: LancerPILOT | undefined): string {
+  const talents = (pilot?.itemTypes.talent ?? []) as Array<{
+    name: string;
+    system: { curr_rank: number; terse: string };
+  }>;
+  const snapshots: CombatDockTalentSnapshot[] = talents.map(talent => ({
+    name: talent.name,
+    rank: talent.system.curr_rank,
+    terse: talent.system.terse,
+  }));
+  const headerLabel = game.i18n.localize("lancer.mech-sheet.combat-dock.talents");
+  return buildCombatDockTalentsHtml(snapshots, headerLabel);
+}
+
 function compactActionTracker(actor: LancerMECH, options: HelperOptions): string {
   if (!is_combatant(actor)) return "";
   const buttons = [
@@ -59,6 +76,7 @@ export function mechCombatDock(options: HelperOptions): string {
   const actor = (options.data?.root?.actor ?? resolveHelperDotpath(options, "actor")) as LancerMECH | undefined;
   if (!actor?.is_mech()) return "";
 
+  const pilot = options.data?.root?.pilot as LancerPILOT | undefined;
   const system = actor.system;
   const statChips = buildCombatDockStatChipsHtml({
     hp: system.hp,
@@ -70,6 +88,7 @@ export function mechCombatDock(options: HelperOptions): string {
   const core = buildCombatDockCoreToggleHtml(system.core_energy);
   const actions = compactActionTracker(actor, options);
   const attacks = buildCombatDockAttackUtilitiesHtml();
+  const talents = compactTalentReminders(pilot);
 
   return `
     <aside class="mech-combat-dock card clipped" aria-label="${game.i18n.localize("lancer.mech-sheet.combat-dock.label")}">
@@ -80,5 +99,6 @@ export function mechCombatDock(options: HelperOptions): string {
         ${actions}
         ${attacks}
       </div>
+      ${talents}
     </aside>`;
 }

--- a/src/styles/applications/_actor-sheet.scss
+++ b/src/styles/applications/_actor-sheet.scss
@@ -346,6 +346,46 @@
     }
   }
 
+  .mech-combat-dock-talents {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    border-top: 1px solid color-mix(in srgb, var(--light-text), transparent 82%);
+    padding-top: 0.3rem;
+    margin-top: 0.1rem;
+  }
+
+  .mech-combat-dock-talents-header {
+    font-size: 0.65rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--primary-color, #e67e22);
+    opacity: 0.9;
+  }
+
+  .mech-combat-dock-talent {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    gap: 0.45rem;
+    padding: 0.15rem 0.4rem;
+    border-left: 3px solid var(--primary-color, #e67e22);
+    background: color-mix(in srgb, var(--darken-1), transparent 15%);
+  }
+
+  .mech-combat-dock-talent-name {
+    font-size: 0.7rem;
+    font-weight: bold;
+    color: var(--dark-text);
+    white-space: nowrap;
+  }
+
+  .mech-combat-dock-talent-terse {
+    font-size: 0.68rem;
+    color: var(--dark-text);
+    opacity: 0.85;
+  }
+
   .mech-combat-gear-section {
     margin-bottom: 0.75rem;
   }
@@ -781,9 +821,9 @@
 
   /* Mech nameplate: name uses remaining header width; minmax(0,1fr) avoids grid min-content blowout */
   .lancer.sheet header.sheet-header.lancer-mech-sheet-header {
-    min-height: 9rem;
-    padding: 0.35em 0.5em 0.35em 0.75em;
-    grid-template-rows: minmax(3.25rem, auto) auto minmax(8rem, auto) auto;
+    min-height: 0;
+    padding: 0.3em 0.5em 0.3em 0.75em;
+    grid-template-rows: auto auto auto auto;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(160px, 240px);
     grid-template-areas:
       "name name name img"
@@ -791,20 +831,26 @@
       "pilot pilot pilot img"
       "macros macros macros img";
 
+    /* Pilot/frame subtitle sits directly under the name, left-aligned, instead
+     * of floating right against otherwise-empty header space. */
     .header-details {
       grid-area: details;
       min-width: 0;
       flex-wrap: wrap;
       display: flex;
-      justify-content: flex-end;
-      text-align: right;
+      justify-content: flex-start;
+      text-align: left;
       align-items: center;
+      font-size: 0.7rem;
+      line-height: 1.3;
+      opacity: 0.85;
+      padding-left: 0.1rem;
     }
 
     .mech-header-pilot-row {
       grid-area: pilot;
       margin: 0;
-      padding-top: 0.2rem;
+      padding-top: 0.15rem;
       width: 100%;
       min-width: 0;
       align-items: flex-start;
@@ -816,7 +862,7 @@
       flex-direction: row;
       flex-wrap: wrap;
       gap: 0.25rem;
-      padding-top: 0.35rem;
+      padding-top: 0.2rem;
       align-items: center;
 
       .lancer-flow-button {
@@ -870,12 +916,12 @@
       flex: 1 1 auto;
       box-sizing: border-box;
       align-self: stretch;
-      font-size: 46px;
-      line-height: 1.35;
+      font-size: 30px;
+      line-height: 1.2;
       letter-spacing: 0.01em;
-      height: 62px;
-      min-height: 62px;
-      padding: 0.5rem 0.45rem;
+      height: 40px;
+      min-height: 40px;
+      padding: 0.2rem 0.45rem;
       width: 100%;
       min-width: 0;
       max-width: 100%;

--- a/src/system.json
+++ b/src/system.json
@@ -2,7 +2,7 @@
   "id": "lancer",
   "title": "LANCER",
   "description": "<p>A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.</p><p>\"Lancer for FoundryVTT\" is not an official <i>Lancer</i> product; it is a third party work, and is not affiliated with Massif Press. \"Lancer for FoundryVTT\" is published via the <i>Lancer</i> Third Party License.</p><p><i>Lancer</i> is copyright Massif Press.</p>",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "compatibility": {
     "minimum": 13,
     "verified": 14,
@@ -202,7 +202,7 @@
   "secondaryTokenAttribute": "heat",
   "url": "https://github.com/VacantFanatic/foundryvtt-lancer",
   "manifest": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.16/lancer-v3.1.16.zip",
+  "download": "https://github.com/VacantFanatic/foundryvtt-lancer/releases/download/v3.1.17/lancer-v3.1.17.zip",
   "license": "GNU GPLv3",
   "readme": "https://github.com/VacantFanatic/foundryvtt-lancer/blob/master/README.md",
   "bugs": "https://github.com/VacantFanatic/foundryvtt-lancer/issues/new/choose",


### PR DESCRIPTION
## Summary

This PR adds a quick-reference talent reminder strip to the combat dock and redesigns the mech sheet header for a more compact, left-aligned layout.

## Key Changes

- **Combat dock talent reminders** — The persistent combat dock now displays a quick-reference strip showing each pilot talent's name, rank, and terse summary. This allows players to see passive/triggered abilities during combat without switching to the Abilities tab.
  - New `buildCombatDockTalentsHtml()` helper function generates the talent strip HTML with proper escaping
  - New `CombatDockTalentSnapshot` interface for talent data
  - Integrated into `mechCombatDock()` helper via `compactTalentReminders()` function
  - Added comprehensive unit tests for HTML generation, filtering, and XSS prevention

- **Mech sheet header redesign** — Collapsed the name/pilot/frame block into a single compact left-aligned group:
  - Pilot and frame details now sit directly under the name (left-aligned) instead of right-aligned against empty space
  - Reduced header height by changing grid template rows from fixed minmax values to `auto`
  - Decreased mech name font size from 46px to 30px and adjusted line height/padding
  - Adjusted spacing throughout the header (padding, margins, gaps)
  - Updated header-details styling: changed from `flex-end`/`right` to `flex-start`/`left` alignment

- **Styling additions** — New CSS classes for talent display:
  - `.mech-combat-dock-talents` — container with border-top separator
  - `.mech-combat-dock-talents-header` — uppercase label styling
  - `.mech-combat-dock-talent` — individual talent row with left border accent
  - `.mech-combat-dock-talent-name` — talent name and rank
  - `.mech-combat-dock-talent-terse` — terse summary text

- **Localization** — Added new i18n key `lancer.mech-sheet.combat-dock.talents` for the talent reminder header label

- **Version bump** — Updated to 3.1.17-rc.1

## Implementation Details

- HTML escaping is implemented via `escapeHtml()` helper to prevent XSS attacks in talent names and terse text
- Talents without terse summaries are filtered out to keep the display clean
- Talent rows include tooltips showing the full talent name on hover
- The talent reminder section is only rendered if the pilot exists and has talents with terse summaries

https://claude.ai/code/session_01D9ZZaUnkQx28vg2j3wWXQz